### PR TITLE
fix: use offset topic replication instead of transaction one

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class KafkaHealthIndicator implements HealthIndicator {
 
     private static final String ID = "kafka";
-    private static final String REPLICATION_PROPERTY = "transaction.state.log.replication.factor";
+    private static final String REPLICATION_PROPERTY = "offsets.topic.replication.factor";
     private final AdminClient adminClient;
     private final KafkaDefaultConfiguration defaultConfiguration;
 


### PR DESCRIPTION
Use the property 'offsets.topic.replication.factor' instead of  'transaction.state.log.replication.factory' because this is the only one that are needed to be set to one in case of a one node cluster.
This allow health check with a one node cluster to works.

This fixes #11 