### PR TITLE
Issue #41 use num.partitions property to create multiple partition to…

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
@@ -88,7 +88,7 @@ public class KafkaDefaultConfiguration extends AbstractKafkaConfiguration {
             Object value = entry.getValue();
             if (ConversionService.SHARED.canConvert(entry.getValue().getClass(), String.class)) {
                 Optional<?> converted = ConversionService.SHARED.convert(entry.getValue(), String.class);
-                if (converted.isPresent()){
+                if (converted.isPresent()) {
                     value = converted.get();
                 }
             }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/embedded/KafkaEmbedded.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/embedded/KafkaEmbedded.java
@@ -142,7 +142,7 @@ public class KafkaEmbedded implements BeanCreatedEventListener<AbstractKafkaConf
                     Properties properties = new Properties();
                     properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ("127.0.0.1:" + kafkaPort));
                     AdminClient adminClient = AdminClient.create(properties);
-                    adminClient.createTopics(topics.stream().map(s -> new NewTopic(s, 1, (short) 1)).collect(Collectors.toList()))
+                    adminClient.createTopics(topics.stream().map(s -> new NewTopic(s, kafkaConfig.numPartitions(), (short) 1)).collect(Collectors.toList()))
                                .all().get();
                 }
             } catch (Throwable e) {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
@@ -18,10 +18,12 @@ package io.micronaut.configuration.kafka.embedded
 import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
 import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration
 import io.micronaut.context.ApplicationContext
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import spock.lang.Specification
 
-class KafkaEmbeddedSpec extends Specification{
+class KafkaEmbeddedSpec extends Specification {
 
     void "test run kafka embedded server"() {
         given:
@@ -48,5 +50,47 @@ class KafkaEmbeddedSpec extends Specification{
 
         cleanup:
         applicationContext.close()
+    }
+
+    void "test run kafka embedded server with multiple partitions topic"() {
+        given:
+        int partitionNumber = 10
+        String topicName = "my-topic"
+
+        ApplicationContext applicationContext = ApplicationContext.run(
+                new HashMap() {
+                    {
+                        put(AbstractKafkaConfiguration.EMBEDDED, true)
+                        put(AbstractKafkaConfiguration.EMBEDDED_TOPICS, topicName)
+                        put("kafka.embedded.properties.num.partitions", partitionNumber)
+                    }
+                }
+        )
+
+        AdminClient adminClient = createAdminClient()
+
+        when:
+        KafkaEmbedded kafkaEmbedded = applicationContext.getBean(KafkaEmbedded)
+
+        then:
+        kafkaEmbedded.kafkaServer.isPresent()
+        kafkaEmbedded.zkPort.isPresent()
+
+        and:
+        adminClient
+                .describeTopics([topicName]).values()
+                .get(topicName).get()
+                .partitions().size() == partitionNumber
+
+        cleanup:
+        adminClient.close()
+        applicationContext.close()
+    }
+
+    private static AdminClient createAdminClient() {
+        Properties properties = new Properties()
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, AbstractKafkaConfiguration.DEFAULT_BOOTSTRAP_SERVERS)
+        AdminClient adminClient = AdminClient.create(properties)
+        adminClient
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
@@ -58,13 +58,11 @@ class KafkaEmbeddedSpec extends Specification {
         String topicName = "multi-partition-topic"
 
         ApplicationContext applicationContext = ApplicationContext.run(
-                new HashMap() {
-                    {
-                        put(AbstractKafkaConfiguration.EMBEDDED, true)
-                        put(AbstractKafkaConfiguration.EMBEDDED_TOPICS, topicName)
-                        put("kafka.embedded.properties.num.partitions", partitionNumber)
-                    }
-                }
+                [
+                        (AbstractKafkaConfiguration.EMBEDDED)       : true,
+                        (AbstractKafkaConfiguration.EMBEDDED_TOPICS): topicName,
+                        "kafka.embedded.properties.num.partitions"  : partitionNumber
+                ]
         )
 
         AdminClient adminClient = createAdminClient()
@@ -92,12 +90,10 @@ class KafkaEmbeddedSpec extends Specification {
         String topicName = "single-partition-topic"
 
         ApplicationContext applicationContext = ApplicationContext.run(
-                new HashMap() {
-                    {
-                        put(AbstractKafkaConfiguration.EMBEDDED, true)
-                        put(AbstractKafkaConfiguration.EMBEDDED_TOPICS, topicName)
-                    }
-                }
+                [
+                        (AbstractKafkaConfiguration.EMBEDDED)       : true,
+                        (AbstractKafkaConfiguration.EMBEDDED_TOPICS): topicName
+                ]
         )
 
         AdminClient adminClient = createAdminClient()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
@@ -52,10 +52,10 @@ class KafkaEmbeddedSpec extends Specification {
         applicationContext.close()
     }
 
-    void "test run kafka embedded server with multiple partitions topic"() {
+    void "test run kafka embedded server with multi partition topic"() {
         given:
         int partitionNumber = 10
-        String topicName = "my-topic"
+        String topicName = "multi-partition-topic"
 
         ApplicationContext applicationContext = ApplicationContext.run(
                 new HashMap() {
@@ -81,6 +81,40 @@ class KafkaEmbeddedSpec extends Specification {
                 .describeTopics([topicName]).values()
                 .get(topicName).get()
                 .partitions().size() == partitionNumber
+
+        cleanup:
+        adminClient.close()
+        applicationContext.close()
+    }
+
+    void "test run kafka embedded server with single partition topic"() {
+        given:
+        String topicName = "single-partition-topic"
+
+        ApplicationContext applicationContext = ApplicationContext.run(
+                new HashMap() {
+                    {
+                        put(AbstractKafkaConfiguration.EMBEDDED, true)
+                        put(AbstractKafkaConfiguration.EMBEDDED_TOPICS, topicName)
+                    }
+                }
+        )
+
+        AdminClient adminClient = createAdminClient()
+
+        when:
+        KafkaEmbedded kafkaEmbedded = applicationContext.getBean(KafkaEmbedded)
+
+        then:
+        kafkaEmbedded.kafkaServer.isPresent()
+        kafkaEmbedded.zkPort.isPresent()
+
+        and:
+        adminClient
+                .describeTopics([topicName]).values()
+                .get(topicName).get()
+                .partitions().size() == 1
+
 
         cleanup:
         adminClient.close()


### PR DESCRIPTION
…pic in embedded kafka

Tiny change in KafkaEmbedded.java to add option of creating topic with more than 1 partition.
Change should not affect existing clients of micronaut-kafka as default value for num.partitions in kafkaConfig remains 1.

Topic with specific number of partition should be created only when `kafka.embedded.properties.num.partitions` property provided in micronaut application properties.

Unit test implemented to assert number of partitions in created topic
