### PR TITLE
Break out of poll() loop on exception. Fixes #39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ subprojects { Project subproject ->
 
     
     repositories {
+        // mavenLocal()
         maven { url "https://repo.grails.org/grails/core" }
     }
     

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
 }
 
 repositories {
-    // mavenLocal()
     mavenCentral()
     maven { url "https://repo.grails.org/grails/core" }
 }
@@ -47,7 +46,6 @@ subprojects { Project subproject ->
 
     
     repositories {
-        // mavenLocal()
         maven { url "https://repo.grails.org/grails/core" }
     }
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=1.1.0.BUILD-SNAPSHOT
 kafkaVersion=2.1.1
 micronautDocsVersion=1.0.0.RC1
-micronautVersion=1.1.0.RC1
+micronautVersion=1.1.0
 micronautTestVersion=1.0.2
 protocVersion=3.5.1
 groovyVersion=2.5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.1.0.RC3
+projectVersion=1.1.0.BUILD-SNAPSHOT
 kafkaVersion=2.1.1
 micronautDocsVersion=1.0.0.RC1
 micronautVersion=1.1.0.RC1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.1.0.BUILD-SNAPSHOT
+projectVersion=1.1.0
 kafkaVersion=2.1.1
 micronautDocsVersion=1.0.0.RC1
 micronautVersion=1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ developers=Graeme Rocher
 grailsVersion=3.2.9
 testskafka=kafka/src/test/groovy/io/micronaut/configuration/kafka/docs
 testskafkastreams=kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams
+kafkastreams=kafka-streams/src/main/groovy/io/micronaut/configuration/kafka/streams

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=1.1.0.BUILD-SNAPSHOT
 kafkaVersion=2.1.1
-micronautDocsVersion=1.0.0.M5
-micronautVersion=1.1.0.M2
+micronautDocsVersion=1.0.0.RC1
+micronautVersion=1.1.0.RC1
 micronautTestVersion=1.0.2
 protocVersion=3.5.1
 groovyVersion=2.5.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.1.0.BUILD-SNAPSHOT
+projectVersion=1.1.0.RC3
 kafkaVersion=2.1.1
 micronautDocsVersion=1.0.0.RC1
 micronautVersion=1.1.0.RC1

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
@@ -35,6 +35,7 @@ public class InteractiveQueryService {
 
     /**
      * Constructor for interactive query service.
+     *
      * @param streams the collection os streams
      */
     InteractiveQueryService(Collection<KafkaStreams> streams) {
@@ -42,12 +43,13 @@ public class InteractiveQueryService {
     }
 
     // tag::getQueryableStore[]
+
     /**
      * Retrieve and return a queryable store by name created in the application.
      *
      * @param storeName name of the queryable store
      * @param storeType type of the queryable store
-     * @param <T> generic queryable store
+     * @param <T>       generic queryable store
      * @return queryable store.
      */
     public <T> T getQueryableStore(String storeName, QueryableStoreType<T> storeType) {
@@ -57,8 +59,7 @@ public class InteractiveQueryService {
                 if (store != null) {
                     return store;
                 }
-            }
-            catch (InvalidStateStoreException ignored) {
+            } catch (InvalidStateStoreException ignored) {
                 //pass through
             }
         }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
@@ -20,6 +20,7 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Services to facilitate the interactive query capabilities of Kafka Streams. This class provides
@@ -45,25 +46,26 @@ public class InteractiveQueryService {
     // tag::getQueryableStore[]
 
     /**
-     * Retrieve and return a queryable store by name created in the application.
+     * Retrieve and return a queryable store by name created in the application.  If state store is not
+     * present an Optional.empty() will be returned.
      *
      * @param storeName name of the queryable store
      * @param storeType type of the queryable store
      * @param <T>       generic queryable store
      * @return queryable store.
      */
-    public <T> T getQueryableStore(String storeName, QueryableStoreType<T> storeType) {
+    public <T> Optional<T> getQueryableStore(String storeName, QueryableStoreType<T> storeType) {
         for (KafkaStreams kafkaStream : this.streams) {
             try {
                 T store = kafkaStream.store(storeName, storeType);
                 if (store != null) {
-                    return store;
+                    return Optional.of(store);
                 }
             } catch (InvalidStateStoreException ignored) {
                 //pass through
             }
         }
-        return null;
+        return Optional.empty();
     }
     // end::getQueryableStore[]
 }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.streams;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.state.QueryableStoreType;
+
+import java.util.Collection;
+
+/**
+ * Services to facilitate the interactive query capabilities of Kafka Streams. This class provides
+ * services such as querying for a particular store. This is part of the public API of the kafka streams
+ * binder and the users can inject this service in their applications to make use of it.
+ *
+ * @author Christian Oestreich
+ * @since 1.1.1
+ */
+public class InteractiveQueryService {
+
+    private final Collection<KafkaStreams> streams;
+
+    /**
+     * Constructor for interactive query service.
+     * @param streams the collection os streams
+     */
+    InteractiveQueryService(Collection<KafkaStreams> streams) {
+        this.streams = streams;
+    }
+
+    // tag::getQueryableStore[]
+    /**
+     * Retrieve and return a queryable store by name created in the application.
+     *
+     * @param storeName name of the queryable store
+     * @param storeType type of the queryable store
+     * @param <T> generic queryable store
+     * @return queryable store.
+     */
+    public <T> T getQueryableStore(String storeName, QueryableStoreType<T> storeType) {
+        for (KafkaStreams kafkaStream : this.streams) {
+            try {
+                T store = kafkaStream.store(storeName, storeType);
+                if (store != null) {
+                    return store;
+                }
+            }
+            catch (InvalidStateStoreException ignored) {
+                //pass through
+            }
+        }
+        return null;
+    }
+    // end::getQueryableStore[]
+}

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -73,6 +73,11 @@ public class KafkaStreamsFactory implements Closeable {
         return kafkaStreams;
     }
 
+    /**
+     * Create the interactive query service bean.
+     *
+     * @return Rhe {@link InteractiveQueryService} bean
+     */
     @Singleton
     InteractiveQueryService interactiveQueryService() {
         return new InteractiveQueryService(streams);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -15,16 +15,18 @@
  */
 package io.micronaut.configuration.kafka.streams;
 
-import io.micronaut.context.annotation.*;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.kstream.KStream;
 
 import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -52,7 +54,7 @@ public class KafkaStreamsFactory implements Closeable {
     /**
      * Builds the default {@link KafkaStreams} bean from the configuration and the supplied {@link ConfiguredStreamBuilder}.
      *
-     * @param builder The builder
+     * @param builder  The builder
      * @param kStreams The KStream definitions
      * @return The {@link KafkaStreams} bean
      */
@@ -69,6 +71,11 @@ public class KafkaStreamsFactory implements Closeable {
         streams.add(kafkaStreams);
         kafkaStreams.start();
         return kafkaStreams;
+    }
+
+    @Singleton
+    InteractiveQueryService interactiveQueryService() {
+        return new InteractiveQueryService(streams);
     }
 
     @Override

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/InteractiveQueryServiceExample.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/InteractiveQueryServiceExample.java
@@ -1,8 +1,10 @@
 package io.micronaut.configuration.kafka.streams;
 
 import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 
 import javax.inject.Singleton;
+import java.util.Optional;
 
 /**
  * Example service that uses the InteractiveQueryService in a reusable way.  This is only intended as an example.
@@ -20,32 +22,35 @@ public class InteractiveQueryServiceExample {
      * Method to get the word state store and word count from the store using the interactive query service.
      *
      * @param stateStore the name of the state store ie "foo-store"
-     * @param word the key to get, in this case the word as the stream and ktable have been grouped by word
+     * @param word       the key to get, in this case the word as the stream and ktable have been grouped by word
      * @return the Long count of the word in the store
      */
     public Long getWordCount(String stateStore, String word) {
-        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<String, Long>keyValueStore()).get(word);
+        Optional<ReadOnlyKeyValueStore<String, Long>> queryableStore = interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.keyValueStore());
+        return queryableStore.map(kvReadOnlyKeyValueStore -> kvReadOnlyKeyValueStore.get(word)).orElse(0L);
     }
 
     /**
      * Method to get byte array from a state store using the interactive query service.
      *
      * @param stateStore the name of the state store ie "bar-store"
-     * @param blobName the key to get, in this case the name of the blob
+     * @param blobName   the key to get, in this case the name of the blob
      * @return the byte[] stored in the state store
      */
     public byte[] getBytes(String stateStore, String blobName) {
-        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<String, byte[]>keyValueStore()).get(blobName);
+        Optional<ReadOnlyKeyValueStore<String, byte[]>> queryableStore = interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.keyValueStore());
+        return queryableStore.map(stringReadOnlyKeyValueStore -> stringReadOnlyKeyValueStore.get(blobName)).orElse(null);
     }
 
     /**
      * Method to get value V by key K.
      *
      * @param stateStore the name of the state store ie "baz-store"
-     * @param name the key to get
+     * @param name       the key to get
      * @return the value of type V stored in the state store
      */
-    public <K,V> V getGenericKeyValue(String stateStore, K name) {
-        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<K, V>keyValueStore()).get(name);
+    public <K, V> V getGenericKeyValue(String stateStore, K name) {
+        Optional<ReadOnlyKeyValueStore<K, V>> queryableStore = interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<K, V>keyValueStore());
+        return queryableStore.map(kvReadOnlyKeyValueStore -> kvReadOnlyKeyValueStore.get(name)).orElse(null);
     }
 }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/InteractiveQueryServiceExample.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/InteractiveQueryServiceExample.java
@@ -1,0 +1,51 @@
+package io.micronaut.configuration.kafka.streams;
+
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+
+import javax.inject.Singleton;
+
+/**
+ * Example service that uses the InteractiveQueryService in a reusable way.  This is only intended as an example.
+ */
+@Singleton
+public class InteractiveQueryServiceExample {
+
+    private final InteractiveQueryService interactiveQueryService;
+
+    public InteractiveQueryServiceExample(InteractiveQueryService interactiveQueryService) {
+        this.interactiveQueryService = interactiveQueryService;
+    }
+
+    /**
+     * Method to get the word state store and word count from the store using the interactive query service.
+     *
+     * @param stateStore the name of the state store ie "foo-store"
+     * @param word the key to get, in this case the word as the stream and ktable have been grouped by word
+     * @return the Long count of the word in the store
+     */
+    public Long getWordCount(String stateStore, String word) {
+        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<String, Long>keyValueStore()).get(word);
+    }
+
+    /**
+     * Method to get byte array from a state store using the interactive query service.
+     *
+     * @param stateStore the name of the state store ie "bar-store"
+     * @param blobName the key to get, in this case the name of the blob
+     * @return the byte[] stored in the state store
+     */
+    public byte[] getBytes(String stateStore, String blobName) {
+        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<String, byte[]>keyValueStore()).get(blobName);
+    }
+
+    /**
+     * Method to get value V by key K.
+     *
+     * @param stateStore the name of the state store ie "baz-store"
+     * @param name the key to get
+     * @return the value of type V stored in the state store
+     */
+    public <K,V> V getGenericKeyValue(String stateStore, K name) {
+        return interactiveQueryService.getQueryableStore(stateStore, QueryableStoreTypes.<K, V>keyValueStore()).get(name);
+    }
+}

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
@@ -33,8 +33,7 @@ class KafkaStreamsSpec extends Specification {
                     "kafka.bootstrap.servers", 'localhost:${random.port}',
                     AbstractKafkaConfiguration.EMBEDDED, true,
                     AbstractKafkaConfiguration.EMBEDDED_TOPICS, [WordCountStream.INPUT, WordCountStream.OUTPUT],
-                    'kafka.streams.my-stream.num.stream.threads', 10,
-                    'kafka.streams.count-stream.num.stream.threads', 10,
+                    'kafka.streams.my-stream.num.stream.threads', 10
             )
     )
 

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
@@ -58,14 +58,14 @@ class KafkaStreamsSpec extends Specification {
         conditions.eventually {
             countListener.getCount("fox") > 0
             countListener.getCount("jumps") > 0
-            interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_MEMORY_STORE, "fox") > 0
-            interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_MEMORY_STORE, "jumps") > 0
-            interactiveQueryService.<String, Long>getGenericKeyValue(WordCountStream.WORD_COUNT_MEMORY_STORE, "the") > 0
+            interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_STORE, "fox") > 0
+            interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_STORE, "jumps") > 0
+            interactiveQueryService.<String, Long>getGenericKeyValue(WordCountStream.WORD_COUNT_STORE, "the") > 0
 
             println countListener.wordCounts
-            println interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_MEMORY_STORE, "fox")
-            println interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_MEMORY_STORE, "jumps")
-            println interactiveQueryService.<String, Long>getGenericKeyValue(WordCountStream.WORD_COUNT_MEMORY_STORE, "the")
+            println interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_STORE, "fox")
+            println interactiveQueryService.getWordCount(WordCountStream.WORD_COUNT_STORE, "jumps")
+            println interactiveQueryService.<String, Long>getGenericKeyValue(WordCountStream.WORD_COUNT_STORE, "the")
         }
 
     }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/WordCountStream.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/WordCountStream.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Grouped;
-import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
@@ -41,7 +40,7 @@ public class WordCountStream {
 
     public static final String INPUT = "streams-plaintext-input"; // <1>
     public static final String OUTPUT = "streams-wordcount-output"; // <2>
-    public static final String WORD_COUNT_MEMORY_STORE = "word-count-memory-store";
+    public static final String WORD_COUNT_STORE = "word-count-store";
 
 // end::clazz[]
 
@@ -62,7 +61,7 @@ public class WordCountStream {
                 .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
                 .groupBy((key, word) -> word, Grouped.with(Serdes.String(), Serdes.String()))
                 //Store the result in a store for lookup later
-                .count(Materialized.as(WORD_COUNT_MEMORY_STORE)); // <4>
+                .count(Materialized.as(WORD_COUNT_STORE)); // <4>
 
         groupedByWord
                 //convert to stream

--- a/kafka-streams/src/test/resources/logback.xml
+++ b/kafka-streams/src/test/resources/logback.xml
@@ -12,6 +12,4 @@
         <appender-ref ref="STDOUT" />
     </root>
     <logger name="io.micronaut.context" level="TRACE"/>
-    <!--<logger name="io.micronaut.configuration.kafka" level="TRACE"/>-->
-    <!--<logger name="org.apache.kafka" level="TRACE"/>-->
 </configuration>

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -8,6 +8,7 @@ dependencyManagement {
 
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
+    annotationProcessor "io.micronaut:micronaut-graal"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
     compileOnly "io.micronaut:micronaut-inject-java"
     compileOnly 'io.opentracing.contrib:opentracing-kafka-client:0.0.16'

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaConsumerFactory.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaConsumerFactory.java
@@ -16,12 +16,18 @@
 package io.micronaut.configuration.kafka;
 
 import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration;
+import io.micronaut.configuration.kafka.serde.JsonSerde;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.TypeHint;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.clients.consumer.RangeAssignor;
+import org.apache.kafka.clients.consumer.RoundRobinAssignor;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.common.serialization.*;
 
 import java.util.Optional;
 import java.util.Properties;
@@ -33,6 +39,37 @@ import java.util.Properties;
  * @since 1.0
  */
 @Factory
+@TypeHint({
+        // serializers
+        ShortSerializer.class,
+        DoubleSerializer.class,
+        LongSerializer.class,
+        BytesSerializer.class,
+        ByteArraySerializer.class,
+        IntegerSerializer.class,
+        ByteBufferSerializer.class,
+        StringSerializer.class,
+        FloatSerializer.class,
+        // serdes
+        JsonSerde.class,
+        // deserializers
+        ShortDeserializer.class,
+        DoubleDeserializer.class,
+        LongDeserializer.class,
+        BytesDeserializer.class,
+        ByteArraySerializer.class,
+        IntegerDeserializer.class,
+        ByteBufferDeserializer.class,
+        StringDeserializer.class,
+        FloatDeserializer.class,
+
+        // partitioners
+        DefaultPartitioner.class,
+        // assigners
+        RangeAssignor.class,
+        RoundRobinAssignor.class,
+        StickyAssignor.class
+})
 public class KafkaConsumerFactory {
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.DefaultConversionService;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import java.time.Duration;
@@ -44,7 +43,6 @@ public class KafkaDefaultConfiguration extends AbstractKafkaConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final int DEFAULT_HEALTHTIMEOUT = 10;
 
-    private static final ConversionService CONVERSION_SERVICE = new DefaultConversionService();
     private Duration healthTimeout = Duration.ofSeconds(DEFAULT_HEALTHTIMEOUT);
 
     /**
@@ -88,8 +86,8 @@ public class KafkaDefaultConfiguration extends AbstractKafkaConfiguration {
             return !Stream.of("embedded", "consumers", "producers", "streams").anyMatch(key::startsWith);
         }).forEach(entry -> {
             Object value = entry.getValue();
-            if (CONVERSION_SERVICE.canConvert(entry.getValue().getClass(), String.class)) {
-                Optional<Object> converted = CONVERSION_SERVICE.convert(entry.getValue(), String.class);
+            if (ConversionService.SHARED.canConvert(entry.getValue().getClass(), String.class)) {
+                Optional<?> converted = ConversionService.SHARED.convert(entry.getValue(), String.class);
                 if (converted.isPresent()){
                     value = converted.get();
                 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
@@ -88,7 +88,7 @@ public class KafkaDefaultConfiguration extends AbstractKafkaConfiguration {
             Object value = entry.getValue();
             if (ConversionService.SHARED.canConvert(entry.getValue().getClass(), String.class)) {
                 Optional<?> converted = ConversionService.SHARED.convert(entry.getValue(), String.class);
-                if (converted.isPresent()){
+                if (converted.isPresent()) {
                     value = converted.get();
                 }
             }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/embedded/KafkaEmbedded.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/embedded/KafkaEmbedded.java
@@ -142,7 +142,7 @@ public class KafkaEmbedded implements BeanCreatedEventListener<AbstractKafkaConf
                     Properties properties = new Properties();
                     properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ("127.0.0.1:" + kafkaPort));
                     AdminClient adminClient = AdminClient.create(properties);
-                    adminClient.createTopics(topics.stream().map(s -> new NewTopic(s, 1, (short) 1)).collect(Collectors.toList()))
+                    adminClient.createTopics(topics.stream().map(s -> new NewTopic(s, kafkaConfig.numPartitions(), (short) 1)).collect(Collectors.toList()))
                                .all().get();
                 }
             } catch (Throwable e) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
@@ -23,7 +23,12 @@ import io.micronaut.health.HealthStatus;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import io.reactivex.Flowable;
-import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeClusterOptions;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
 
@@ -98,7 +103,7 @@ public class KafkaHealthIndicator implements HealthIndicator {
             });
         }).onErrorReturn(throwable ->
                 HealthResult.builder(ID, HealthStatus.DOWN)
-                            .exception(throwable).build()
+                        .exception(throwable).build()
         );
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -44,7 +44,7 @@ abstract class AbstractKafkaMetricsReporter implements MetricsReporter, MeterBin
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        if(!METER_REGISTRIES.contains(registry)) {
+        if (!METER_REGISTRIES.contains(registry)) {
             METER_REGISTRIES.add(registry);
         }
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.kafka.metrics;
 import io.micronaut.configuration.kafka.config.AbstractKafkaProducerConfiguration;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
@@ -31,6 +32,8 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".kafka.enabled", value = "true", defaultValue = "true")
 @Context
+// Producer metrics are primary since Grails/Boot only support a single metric provider
+@Primary
 public class KafkaProducerMetrics extends AbstractKafkaMetrics<AbstractKafkaProducerConfiguration> implements BeanCreatedEventListener<AbstractKafkaProducerConfiguration> {
 
     @Override

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -38,6 +38,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
@@ -187,14 +188,14 @@ public class KafkaConsumerProcessor
     @Override
     public void process(BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
 
-        Topic[] topicAnnotations = method.synthesizeDeclaredAnnotationsByType(Topic.class);
+        List<AnnotationValue<Topic>> topicAnnotations = method.getDeclaredAnnotationValuesByType(Topic.class);
         AnnotationValue<KafkaListener> consumerAnnotation = method.getAnnotation(KafkaListener.class);
 
-        if (ArrayUtils.isEmpty(topicAnnotations)) {
-            topicAnnotations = beanDefinition.synthesizeAnnotationsByType(Topic.class);
+        if (CollectionUtils.isEmpty(topicAnnotations)) {
+            topicAnnotations = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
         }
 
-        if (consumerAnnotation != null && ArrayUtils.isNotEmpty(topicAnnotations)) {
+        if (consumerAnnotation != null && !CollectionUtils.isEmpty(topicAnnotations)) {
 
             Duration pollTimeout = method.getValue(KafkaListener.class, "pollTimeout", Duration.class)
                     .orElse(Duration.ofMillis(100));
@@ -333,9 +334,10 @@ public class KafkaConsumerProcessor
 
 
 
-                for (Topic topicAnnotation : topicAnnotations) {
-                    String[] topicNames = topicAnnotation.value();
-                    String[] patterns = topicAnnotation.patterns();
+                for (AnnotationValue<Topic> topicAnnotation : topicAnnotations) {
+
+                    String[] topicNames = topicAnnotation.getValue(String[].class).orElse(StringUtils.EMPTY_STRING_ARRAY);
+                    String[] patterns = topicAnnotation.get("patterns", String[].class).orElse(StringUtils.EMPTY_STRING_ARRAY);
                     boolean hasTopics = ArrayUtils.isNotEmpty(topicNames);
                     boolean hasPatterns = ArrayUtils.isNotEmpty(patterns);
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -536,18 +536,16 @@ public class KafkaConsumerProcessor
                                                 break;
                                             }
 
-                                            if (!failed) {
-                                                if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
-                                                    try {
-                                                        kafkaConsumer.commitSync(
-                                                                currentOffsets
-                                                        );
-                                                    } catch (CommitFailedException e) {
-                                                        handleException(kafkaConsumer, consumerBean, consumerRecord, e);
-                                                    }
-                                                } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-                                                    kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
+                                            if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
+                                                try {
+                                                    kafkaConsumer.commitSync(
+                                                            currentOffsets
+                                                    );
+                                                } catch (CommitFailedException e) {
+                                                    handleException(kafkaConsumer, consumerBean, consumerRecord, e);
                                                 }
+                                            } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
+                                                kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                             }
                                         }
                                     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -402,7 +402,7 @@ public class KafkaConsumerProcessor
                                 }
 
                                 ConsumerRecords<?, ?> consumerRecords = kafkaConsumer.poll(pollTimeout);
-
+                                boolean failed = false;
                                 if (consumerPaused && !paused.contains(finalClientId)) {
                                     if (LOG.isDebugEnabled()) {
                                         LOG.debug("Resuming Kafka consumption for Consumer [{}] from topic partition: {}", finalClientId, kafkaConsumer.paused());
@@ -531,34 +531,40 @@ public class KafkaConsumerProcessor
                                                 }
                                             } catch (Throwable e) {
                                                 handleException(kafkaConsumer, consumerBean, consumerRecord, e);
-                                                continue;
+                                                // break out of the poll loop so that re-delivery can be attempted
+                                                failed = true;
+                                                break;
                                             }
 
-                                            if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
-                                                try {
-                                                    kafkaConsumer.commitSync(
-                                                            currentOffsets
-                                                    );
-                                                } catch (CommitFailedException e) {
-                                                    handleException(kafkaConsumer, consumerBean, consumerRecord, e);
+                                            if (!failed) {
+                                                if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
+                                                    try {
+                                                        kafkaConsumer.commitSync(
+                                                                currentOffsets
+                                                        );
+                                                    } catch (CommitFailedException e) {
+                                                        handleException(kafkaConsumer, consumerBean, consumerRecord, e);
+                                                    }
+                                                } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
+                                                    kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                                 }
-                                            } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-                                                kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                             }
                                         }
                                     }
 
+                                    if (!failed) {
+                                        if (offsetStrategy == OffsetStrategy.SYNC) {
+                                            try {
+                                                kafkaConsumer.commitSync();
+                                            } catch (CommitFailedException e) {
+                                                handleException(kafkaConsumer, consumerBean, null, e);
+                                            }
+                                        } else if (offsetStrategy == OffsetStrategy.ASYNC) {
+                                            kafkaConsumer.commitAsync(resolveCommitCallback(consumerBean));
+                                        }
+                                    }
                                 }
 
-                                if (offsetStrategy == OffsetStrategy.SYNC) {
-                                    try {
-                                        kafkaConsumer.commitSync();
-                                    } catch (CommitFailedException e) {
-                                        handleException(kafkaConsumer, consumerBean, null, e);
-                                    }
-                                } else if (offsetStrategy == OffsetStrategy.ASYNC) {
-                                    kafkaConsumer.commitAsync(resolveCommitCallback(consumerBean));
-                                }
                             } catch (WakeupException e) {
                                 throw e;
                             } catch (Throwable e) {

--- a/kafka/src/main/resources/META-INF/native-image/io.micronaut/micronaut-kafka/native-image.properties
+++ b/kafka/src/main/resources/META-INF/native-image/io.micronaut/micronaut-kafka/native-image.properties
@@ -1,0 +1,2 @@
+Args = --initialize-at-build-time=org.apache.kafka,net.jpountz \
+       --initialize-at-runtime=io.micronaut.configuration.kafka.embedded.KafkaEmbedded

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -118,4 +118,34 @@ class KafkaConfigurationSpec extends Specification {
         consumer.close()
         applicationContext.close()
     }
+
+    void "test configure list fields default properties"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                ("kafka.${ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG}".toString()):Arrays.asList("localhost:1111","localhost:1112"),
+                ("kafka.${ConsumerConfig.GROUP_ID_CONFIG}".toString()):"mygroup",
+                ("kafka.consumers.default." + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+                ("kafka.consumers.default." + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name
+        )
+
+        when:
+        AbstractKafkaConsumerConfiguration config = applicationContext.getBean(AbstractKafkaConsumerConfiguration)
+        Properties props = config.getConfig()
+
+        then:
+        props[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] == "localhost:1111,localhost:1112"
+        props[ConsumerConfig.GROUP_ID_CONFIG] == "mygroup"
+
+        when:
+        Consumer consumer = applicationContext.createBean(Consumer, config)
+
+        then:
+        consumer != null
+
+        cleanup:
+        consumer.close()
+        applicationContext.close()
+
+
+    }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
@@ -93,7 +93,7 @@ class KafkaListenerSpec extends Specification {
             Map result = response.body()
 
             result.names.contains("kafka.producer.count")
-            result.names.contains("kafka.consumer.count")
+            //result.names.contains("kafka.consumer.count")
             !result.names.contains("kafka.count")
         }
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
@@ -72,22 +72,20 @@ class KafkaListenerSpec extends Specification {
         MyClient myClient = context.getBean(MyClient)
         MyConsumer myConsumer = context.getBean(MyConsumer)
 
+        expect:
+        context.containsBean(KafkaConsumerMetrics)
+        context.containsBean(KafkaProducerMetrics)
+        context.containsBean(MeterRegistry)
+        context.containsBean(MetricsEndpoint)
+
         when:
         myClient.sendSentence("key", "hello world", "words")
 
         then:
-        context.containsBean(KafkaConsumerMetrics)
-        context.containsBean(KafkaProducerMetrics)
-
-        and:
         conditions.eventually {
             myConsumer.wordCount == 2
             myConsumer.lastTopic == 'words'
         }
-
-        and:
-        context.containsBean(MeterRegistry)
-        context.containsBean(MetricsEndpoint)
 
         and:
         conditions.eventually {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
@@ -69,7 +69,7 @@ class KafkaListenerSpec extends Specification {
 
     void "test simple consumer"() {
         given:
-        PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
         MyClient myClient = context.getBean(MyClient)
         MyConsumer myConsumer = context.getBean(MyConsumer)
         context.containsBean(KafkaHealthIndicator)
@@ -95,7 +95,6 @@ class KafkaListenerSpec extends Specification {
             Map result = response.body()
 
             result.names.contains("kafka.producer.count")
-            result.names.contains("kafka.consumer.count")
             !result.names.contains("kafka.count")
         }
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaListenerSpec.groovy
@@ -19,6 +19,7 @@ import groovy.transform.EqualsAndHashCode
 import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
 import io.micronaut.configuration.kafka.config.AbstractKafkaProducerConfiguration
+import io.micronaut.configuration.kafka.health.KafkaHealthIndicator
 import io.micronaut.configuration.kafka.metrics.KafkaConsumerMetrics
 import io.micronaut.configuration.kafka.metrics.KafkaProducerMetrics
 import io.micronaut.configuration.kafka.serde.JsonSerde
@@ -71,6 +72,7 @@ class KafkaListenerSpec extends Specification {
         PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
         MyClient myClient = context.getBean(MyClient)
         MyConsumer myConsumer = context.getBean(MyConsumer)
+        context.containsBean(KafkaHealthIndicator)
 
         expect:
         context.containsBean(KafkaConsumerMetrics)
@@ -93,7 +95,7 @@ class KafkaListenerSpec extends Specification {
             Map result = response.body()
 
             result.names.contains("kafka.producer.count")
-            //result.names.contains("kafka.consumer.count")
+            result.names.contains("kafka.consumer.count")
             !result.names.contains("kafka.count")
         }
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/embedded/KafkaEmbeddedSpec.groovy
@@ -18,10 +18,12 @@ package io.micronaut.configuration.kafka.embedded
 import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
 import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration
 import io.micronaut.context.ApplicationContext
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import spock.lang.Specification
 
-class KafkaEmbeddedSpec extends Specification{
+class KafkaEmbeddedSpec extends Specification {
 
     void "test run kafka embedded server"() {
         given:
@@ -48,5 +50,77 @@ class KafkaEmbeddedSpec extends Specification{
 
         cleanup:
         applicationContext.close()
+    }
+
+    void "test run kafka embedded server with multi partition topic"() {
+        given:
+        int partitionNumber = 10
+        String topicName = "multi-partition-topic"
+
+        ApplicationContext applicationContext = ApplicationContext.run(
+                [
+                        (AbstractKafkaConfiguration.EMBEDDED)       : true,
+                        (AbstractKafkaConfiguration.EMBEDDED_TOPICS): topicName,
+                        "kafka.embedded.properties.num.partitions"  : partitionNumber
+                ]
+        )
+
+        AdminClient adminClient = createAdminClient()
+
+        when:
+        KafkaEmbedded kafkaEmbedded = applicationContext.getBean(KafkaEmbedded)
+
+        then:
+        kafkaEmbedded.kafkaServer.isPresent()
+        kafkaEmbedded.zkPort.isPresent()
+
+        and:
+        adminClient
+                .describeTopics([topicName]).values()
+                .get(topicName).get()
+                .partitions().size() == partitionNumber
+
+        cleanup:
+        adminClient.close()
+        applicationContext.close()
+    }
+
+    void "test run kafka embedded server with single partition topic"() {
+        given:
+        String topicName = "single-partition-topic"
+
+        ApplicationContext applicationContext = ApplicationContext.run(
+                [
+                        (AbstractKafkaConfiguration.EMBEDDED)       : true,
+                        (AbstractKafkaConfiguration.EMBEDDED_TOPICS): topicName
+                ]
+        )
+
+        AdminClient adminClient = createAdminClient()
+
+        when:
+        KafkaEmbedded kafkaEmbedded = applicationContext.getBean(KafkaEmbedded)
+
+        then:
+        kafkaEmbedded.kafkaServer.isPresent()
+        kafkaEmbedded.zkPort.isPresent()
+
+        and:
+        adminClient
+                .describeTopics([topicName]).values()
+                .get(topicName).get()
+                .partitions().size() == 1
+
+
+        cleanup:
+        adminClient.close()
+        applicationContext.close()
+    }
+
+    private static AdminClient createAdminClient() {
+        Properties properties = new Properties()
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, AbstractKafkaConfiguration.DEFAULT_BOOTSTRAP_SERVERS)
+        AdminClient adminClient = AdminClient.create(properties)
+        adminClient
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
@@ -60,7 +60,6 @@ class KafkaErrorHandlingSpec extends Specification {
 
         @Topic("errors")
         void handleMessage(String message) {
-            println "RECEIVED $message"
             if (count.getAndIncrement() == 1) {
                 throw new RuntimeException("Won't handle first")
             }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
@@ -1,0 +1,86 @@
+package io.micronaut.configuration.kafka.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.messaging.MessageHeaders
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class KafkaErrorHandlingSpec extends Specification {
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+            CollectionUtils.mapOf(
+                    "kafka.bootstrap.servers", 'localhost:${random.port}',
+                    AbstractKafkaConfiguration.EMBEDDED, true,
+                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, ["errors"]
+            )
+    )
+
+    void "test an exception that is thrown is not committed"() {
+        when:"A consumer throws an exception"
+        def context = embeddedServer.getApplicationContext()
+        ErrorClient myClient = context.getBean(ErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+
+        ErrorCausingConsumer myConsumer = context.getBean(ErrorCausingConsumer)
+
+        then:"The message is re-delivered and eventually handled"
+        conditions.eventually {
+            myConsumer.received.size() == 2
+            myConsumer.count.get() == 3
+        }
+
+
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, offsetStrategy = OffsetStrategy.SYNC)
+    static class ErrorCausingConsumer implements KafkaListenerExceptionHandler {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("errors")
+        void handleMessage(String message) {
+            println "RECEIVED $message"
+            if (count.getAndIncrement() == 1) {
+                throw new RuntimeException("Won't handle first")
+            }
+            received.add(message)
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            def record = exception.consumerRecord.orElse(null)
+            def consumer = exception.kafkaConsumer
+            consumer.seek(
+                    new TopicPartition("errors", record.partition()),
+                    record.offset()
+            )
+        }
+    }
+
+    @KafkaClient
+    static interface ErrorClient {
+        @Topic("errors")
+        void sendMessage(String message)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
@@ -56,7 +56,7 @@ class KafkaConsumerMetricsSpec extends Specification {
 
     void "test simple consumer"() {
         given:
-        PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyConsumerMetrics)
@@ -66,7 +66,6 @@ class KafkaConsumerMetricsSpec extends Specification {
         conditions.eventually {
             def response = httpClient.exchange("/metrics", Map).blockingFirst()
             Map result = response.body()
-            result.names.contains("kafka.consumer.count")
             result.names.contains("kafka.consumer.bytes-consumed-total")
             !result.names.contains("kafka.consumer.record-error-rate")
             !result.names.contains("kafka.producer.count")

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
@@ -30,6 +30,7 @@ import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 class KafkaConsumerMetricsSpec extends Specification {
 
@@ -54,31 +55,24 @@ class KafkaConsumerMetricsSpec extends Specification {
     RxHttpClient httpClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL(), new DefaultHttpClientConfiguration(followRedirects: false))
 
     void "test simple consumer"() {
-        expect:
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyConsumerMetrics)
 
-        when:
-        def response = httpClient.exchange("/metrics", Map).blockingFirst()
-        Map result = response.body()
-
-        then: 'kafka.consumer only metrics will be present'
-        result.names.contains("kafka.consumer.count")
-        result.names.contains("kafka.consumer.bytes-consumed-total")
-
-        and: 'producer only metric not bleed to consumer'
-        !result.names.contains("kafka.consumer.record-error-rate")
-
-        and: 'producer metrics will not be present'
-        !result.names.contains("kafka.producer.count")
-        !result.names.contains("kafka.producer.record-error-rate")
-
-        and: 'consumer only metric not bleed to producer'
-        !result.names.contains("kafka.producer.bytes-consumed-total")
-
-        and: 'generic count will not exist'
-        !result.names.contains("kafka.count")
+        expect:
+        conditions.eventually {
+            def response = httpClient.exchange("/metrics", Map).blockingFirst()
+            Map result = response.body()
+//            result.names.contains("kafka.consumer.count")
+            result.names.contains("kafka.consumer.bytes-consumed-total")
+            !result.names.contains("kafka.consumer.record-error-rate")
+            !result.names.contains("kafka.producer.count")
+            !result.names.contains("kafka.producer.record-error-rate")
+            !result.names.contains("kafka.producer.bytes-consumed-total")
+            !result.names.contains("kafka.count")
+        }
     }
 
     @KafkaListener(offsetReset = OffsetReset.EARLIEST)

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
@@ -42,7 +42,7 @@ class KafkaConsumerMetricsSpec extends Specification {
                     "micrometer.metrics.enabled", true,
                     'endpoints.metrics.sensitive', false,
                     AbstractKafkaConfiguration.EMBEDDED, true,
-                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, ["words", "books", "words-records", "books-records"]
+                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, ["words-metrics", "words", "books", "words-records", "books-records"]
             )
     )
 
@@ -60,12 +60,13 @@ class KafkaConsumerMetricsSpec extends Specification {
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyConsumerMetrics)
+        context.containsBean(KafkaHealthIndicator)
 
         expect:
         conditions.eventually {
             def response = httpClient.exchange("/metrics", Map).blockingFirst()
             Map result = response.body()
-//            result.names.contains("kafka.consumer.count")
+            result.names.contains("kafka.consumer.count")
             result.names.contains("kafka.consumer.bytes-consumed-total")
             !result.names.contains("kafka.consumer.record-error-rate")
             !result.names.contains("kafka.producer.count")

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
@@ -59,7 +59,7 @@ class KafkaProducerMetricsSpec extends Specification {
 
     void "test simple producer"() {
         given:
-        PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyClientMetrics)
@@ -72,7 +72,6 @@ class KafkaProducerMetricsSpec extends Specification {
         conditions.eventually {
             def response = httpClient.exchange("/metrics", Map).blockingFirst()
             Map result = response.body()
-            result.names.contains("kafka.consumer.count")
             !result.names.contains("kafka.consumer.record-error-rate")
             result.names.contains("kafka.producer.count")
             result.names.contains("kafka.producer.record-error-rate")

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.RecordMetadata
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 class KafkaProducerMetricsSpec extends Specification {
 
@@ -57,7 +58,8 @@ class KafkaProducerMetricsSpec extends Specification {
     RxHttpClient httpClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL(), new DefaultHttpClientConfiguration(followRedirects: false))
 
     void "test simple producer"() {
-        expect:
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 40, delay: 1)
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyClientMetrics)
@@ -65,25 +67,17 @@ class KafkaProducerMetricsSpec extends Specification {
         when:
         context.getBean(MyClientMetrics).sendGetRecordMetadata("key", "value")
 
-        and:
-        def response = httpClient.exchange("/metrics", Map).blockingFirst()
-        Map result = response.body()
-
-        then: 'kafka.consumer.count will be there due to default consumer'
-        result.names.contains("kafka.consumer.count")
-
-        and: 'producer only metric not bleed to consumer'
-        !result.names.contains("kafka.consumer.record-error-rate")
-
-        and: 'producer count will be there because we fired up consumer bean via send'
-        result.names.contains("kafka.producer.count")
-        result.names.contains("kafka.producer.record-error-rate")
-
-        and: 'consumer only metric not bleed to producer'
-        !result.names.contains("kafka.producer.bytes-consumed-total")
-
-        and: 'generic count will not exist'
-        !result.names.contains("kafka.count")
+        then:
+        conditions.eventually {
+            def response = httpClient.exchange("/metrics", Map).blockingFirst()
+            Map result = response.body()
+//            result.names.contains("kafka.consumer.count")
+            !result.names.contains("kafka.consumer.record-error-rate")
+            result.names.contains("kafka.producer.count")
+            result.names.contains("kafka.producer.record-error-rate")
+            !result.names.contains("kafka.producer.bytes-consumed-total")
+            !result.names.contains("kafka.count")
+        }
     }
 
     @KafkaClient

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
@@ -63,6 +63,7 @@ class KafkaProducerMetricsSpec extends Specification {
         context.containsBean(MeterRegistry)
         context.containsBean(MetricsEndpoint)
         context.containsBean(MyClientMetrics)
+        context.containsBean(KafkaHealthIndicator)
 
         when:
         context.getBean(MyClientMetrics).sendGetRecordMetadata("key", "value")
@@ -71,7 +72,7 @@ class KafkaProducerMetricsSpec extends Specification {
         conditions.eventually {
             def response = httpClient.exchange("/metrics", Map).blockingFirst()
             Map result = response.body()
-//            result.names.contains("kafka.consumer.count")
+            result.names.contains("kafka.consumer.count")
             !result.names.contains("kafka.consumer.record-error-rate")
             result.names.contains("kafka.producer.count")
             result.names.contains("kafka.producer.record-error-rate")
@@ -85,7 +86,7 @@ class KafkaProducerMetricsSpec extends Specification {
         @Topic("words-metrics")
         void sendSentence(@KafkaKey String key, String sentence, @Header String topic)
 
-        @Topic("words-metrics")
+        @Topic("words-metrics-two")
         RecordMetadata sendGetRecordMetadata(@KafkaKey String key, String sentence)
 
         @Topic("books-metrics")

--- a/src/main/docs/guide/kafkaQuickStart.adoc
+++ b/src/main/docs/guide/kafkaQuickStart.adoc
@@ -28,6 +28,26 @@ kafka:
 
 TIP: You can also set the environment variable `KAFKA_BOOTSTRAP_SERVERS` to a comma separated list of values to externalize configuration.
 
+If your broker needs to setup SSL, it can be configured this way:
+
+.Configuring Kafka
+[source,yaml]
+----
+kafka:
+  bootstrap:
+    servers: localhost:9092
+  ssl:
+    keystore:
+      location: /path/to/client.keystore.p12
+      password: secret
+    truststore:
+      location: /path/to/client.truststore.jks
+      password: secret
+      type: PKCS12
+  security:
+    protocol: ssl
+----
+
 === Creating a Kafka Producer with @KafkaClient
 
 To create a Kafka `Producer` that sends messages you can simply define an interface that is annotated with ann:configuration.kafka.annotation.KafkaClient[].

--- a/src/main/docs/guide/kafkaStream.adoc
+++ b/src/main/docs/guide/kafkaStream.adoc
@@ -48,6 +48,7 @@ include::{testskafkastreams}/WordCountStream.java[tags=wordCountStream, indent=4
 <1> The input topic
 <2> The output topic
 <3> An instance of api:configuration.kafka.streams.ConfiguredStreamBuilder[] is injected that allows mutating the configuration
+<4> Materialize the count stream and save to a state store
 
 NOTE: With Kafka streams the key and value `Serdes` (serializer/deserializer) must be classes with a zero argument constructor. If you wish to use JSON (de)serialization you can subclass api:configuration.kafka.serde.JsonSerde[] to define your `Serdes`
 
@@ -93,3 +94,25 @@ You can then inject a api:configuration.kafka.streams.ConfiguredStreamBuilder[] 
 include::{testskafkastreams}/WordCountStream.java[tags=namedStream, indent=0]
 }
 ----
+
+=== Interactive Query Service
+
+When using streams you can set a state store for your stream using a store builder and telling the stream to store its data.  In the above example for the Kafka Streams Word Count, the output is materialized to a named store that can later be retrieved via the Interactive Query Service.  Apache Kafka docs https://kafka.apache.org/10/documentation/streams/developer-guide/interactive-queries.html#querying-local-key-value-stores[available here].
+
+You can inject the `InteractiveQueryService` and use the method `getQueryableStore` to get values from a state store.
+
+[source,java]
+----
+include::{kafkastreams}/InteractiveQueryService.java[tags=getQueryableStore, indent=0]
+----
+
+An example service that wraps the `InteractiveQueryService` is included below.  This is here to illustrate that when calling the `getQueryableStore` method you must provide the store name and preferably the type of key and value you are trying to retrieve.
+
+[source,java]
+----
+include::{testkafkastreams}/InteractiveQueryServiceExample.java[]
+----
+
+
+
+


### PR DESCRIPTION
This change breaks out of the poll loop and prevents committing offset on exception, that allows a custom exception handler to then seek back and resume the original message consumption avoiding message loss.