### PR TITLE
 Break out of poll() loop on exception. Fixes #39

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -534,18 +534,16 @@ public class KafkaConsumerProcessor
                                                 break;
                                             }
 
-                                            if (!failed) {
-                                                if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
-                                                    try {
-                                                        kafkaConsumer.commitSync(
-                                                                currentOffsets
-                                                        );
-                                                    } catch (CommitFailedException e) {
-                                                        handleException(kafkaConsumer, consumerBean, consumerRecord, e);
-                                                    }
-                                                } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-                                                    kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
+                                            if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
+                                                try {
+                                                    kafkaConsumer.commitSync(
+                                                            currentOffsets
+                                                    );
+                                                } catch (CommitFailedException e) {
+                                                    handleException(kafkaConsumer, consumerBean, consumerRecord, e);
                                                 }
+                                            } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
+                                                kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                             }
                                         }
                                     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -400,7 +400,7 @@ public class KafkaConsumerProcessor
                                 }
 
                                 ConsumerRecords<?, ?> consumerRecords = kafkaConsumer.poll(pollTimeout);
-
+                                boolean failed = false;
                                 if (consumerPaused && !paused.contains(finalClientId)) {
                                     if (LOG.isDebugEnabled()) {
                                         LOG.debug("Resuming Kafka consumption for Consumer [{}] from topic partition: {}", finalClientId, kafkaConsumer.paused());
@@ -529,34 +529,40 @@ public class KafkaConsumerProcessor
                                                 }
                                             } catch (Throwable e) {
                                                 handleException(kafkaConsumer, consumerBean, consumerRecord, e);
-                                                continue;
+                                                // break out of the poll loop so that re-delivery can be attempted
+                                                failed = true;
+                                                break;
                                             }
 
-                                            if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
-                                                try {
-                                                    kafkaConsumer.commitSync(
-                                                            currentOffsets
-                                                    );
-                                                } catch (CommitFailedException e) {
-                                                    handleException(kafkaConsumer, consumerBean, consumerRecord, e);
+                                            if (!failed) {
+                                                if (offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
+                                                    try {
+                                                        kafkaConsumer.commitSync(
+                                                                currentOffsets
+                                                        );
+                                                    } catch (CommitFailedException e) {
+                                                        handleException(kafkaConsumer, consumerBean, consumerRecord, e);
+                                                    }
+                                                } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
+                                                    kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                                 }
-                                            } else if (offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-                                                kafkaConsumer.commitAsync(currentOffsets, resolveCommitCallback(consumerBean));
                                             }
                                         }
                                     }
 
+                                    if (!failed) {
+                                        if (offsetStrategy == OffsetStrategy.SYNC) {
+                                            try {
+                                                kafkaConsumer.commitSync();
+                                            } catch (CommitFailedException e) {
+                                                handleException(kafkaConsumer, consumerBean, null, e);
+                                            }
+                                        } else if (offsetStrategy == OffsetStrategy.ASYNC) {
+                                            kafkaConsumer.commitAsync(resolveCommitCallback(consumerBean));
+                                        }
+                                    }
                                 }
 
-                                if (offsetStrategy == OffsetStrategy.SYNC) {
-                                    try {
-                                        kafkaConsumer.commitSync();
-                                    } catch (CommitFailedException e) {
-                                        handleException(kafkaConsumer, consumerBean, null, e);
-                                    }
-                                } else if (offsetStrategy == OffsetStrategy.ASYNC) {
-                                    kafkaConsumer.commitAsync(resolveCommitCallback(consumerBean));
-                                }
                             } catch (WakeupException e) {
                                 throw e;
                             } catch (Throwable e) {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
@@ -60,7 +60,6 @@ class KafkaErrorHandlingSpec extends Specification {
 
         @Topic("errors")
         void handleMessage(String message) {
-            println "RECEIVED $message"
             if (count.getAndIncrement() == 1) {
                 throw new RuntimeException("Won't handle first")
             }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
@@ -1,0 +1,86 @@
+package io.micronaut.configuration.kafka.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.messaging.MessageHeaders
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class KafkaErrorHandlingSpec extends Specification {
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+            CollectionUtils.mapOf(
+                    "kafka.bootstrap.servers", 'localhost:${random.port}',
+                    AbstractKafkaConfiguration.EMBEDDED, true,
+                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, ["errors"]
+            )
+    )
+
+    void "test an exception that is thrown is not committed"() {
+        when:"A consumer throws an exception"
+        def context = embeddedServer.getApplicationContext()
+        ErrorClient myClient = context.getBean(ErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+
+        ErrorCausingConsumer myConsumer = context.getBean(ErrorCausingConsumer)
+
+        then:"The message is re-delivered and eventually handled"
+        conditions.eventually {
+            myConsumer.received.size() == 2
+            myConsumer.count.get() == 3
+        }
+
+
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, offsetStrategy = OffsetStrategy.SYNC)
+    static class ErrorCausingConsumer implements KafkaListenerExceptionHandler {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("errors")
+        void handleMessage(String message) {
+            println "RECEIVED $message"
+            if (count.getAndIncrement() == 1) {
+                throw new RuntimeException("Won't handle first")
+            }
+            received.add(message)
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            def record = exception.consumerRecord.orElse(null)
+            def consumer = exception.kafkaConsumer
+            consumer.seek(
+                    new TopicPartition("errors", record.partition()),
+                    record.offset()
+            )
+        }
+    }
+
+    @KafkaClient
+    static interface ErrorClient {
+        @Topic("errors")
+        void sendMessage(String message)
+    }
+}


### PR DESCRIPTION
This change breaks out of the poll loop and prevents committing offset on exception, that allows a custom exception handler to then seek back and resume the original message consumption avoiding message loss.
