### PR TITLE
Kafka metrics enabled config Documentation

### DIFF
--- a/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
@@ -1,3 +1,3 @@
 You can enable Kafka Metrics collection by enabling https://micronaut-projects.github.io/micronaut-micrometer/latest/guide[Micrometer Metrics].
 
-If you do not wish to collect metrics you can set `micronaut.metrics.kafka.enabled` to `false` in `application.yml`.
+If you do not wish to collect Kafka metrics, you can set `micronaut.metrics.binders.kafka.enabled` to `false` in `application.yml`.


### PR DESCRIPTION
The kafka metric configuration refers to `MeterRegistryFactory.MICRONAUT_METRICS_BINDERS`:

https://github.com/micronaut-projects/micronaut-kafka/blob/1bc9749274ff759abe7c578c4cfc6c662f9cc6ed/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaConsumerMetrics.java#L41

Here is the relevant snippet from `io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory`:

```
    public static final String MICRONAUT_METRICS = "micronaut.metrics.";
    public static final String MICRONAUT_METRICS_BINDERS = MICRONAUT_METRICS + "binders";
```

https://github.com/micronaut-projects/micronaut-micrometer/blob/master/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/MeterRegistryFactory.java#L42

So the configuration needs to include `binders` for it to be picked up.