### PR TITLE
Extend KafkaListener annotation to define unique group ids

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.2.1.issue38.BUILD-SNAPSHOT
+projectVersion=1.2.1.BUILD-SNAPSHOT
 kafkaVersion=2.3.0
 micronautDocsVersion=1.0.3
 micronautVersion=1.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.2.1.BUILD-SNAPSHOT
+projectVersion=1.2.1.issue38.BUILD-SNAPSHOT
 kafkaVersion=2.3.0
 micronautDocsVersion=1.0.3
 micronautVersion=1.1.4

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -56,6 +56,14 @@ public @interface KafkaListener {
     String groupId() default "";
 
     /**
+     * A unique string (UUID) can be appended to the group ID.
+     * In that case, each consumer will be the only member of a unique consumer group.
+     *
+     * @return True to make each group ID unique. Defaults to false.
+     */
+    boolean uniqueGroupId() default false;
+
+    /**
      * Sets the client id of the Kafka consumer. If not specified the client id is configured
      * to be the value of {@link io.micronaut.runtime.ApplicationConfiguration#getName()}.
      *

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -221,6 +221,12 @@ public class KafkaConsumerProcessor
                 groupId = applicationConfiguration.getName().orElse(beanType.getName());
             }
 
+            boolean hasUniqueGroupId = consumerAnnotation.get("uniqueGroupId", Boolean.class).orElse(false);
+            String uniqueGroupId = groupId;
+            if (hasUniqueGroupId) {
+                uniqueGroupId += "_" + UUID.randomUUID().toString();
+            }
+
             String clientId = consumerAnnotation.get("clientId", String.class).orElse(null);
             if (StringUtils.isEmpty(clientId)) {
                 clientId = applicationConfiguration.getName().map(s -> s + '-' + NameUtils.hyphenate(beanType.getSimpleName())).orElse(null);
@@ -266,7 +272,7 @@ public class KafkaConsumerProcessor
                 );
             }
 
-            properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, hasUniqueGroupId ? uniqueGroupId : groupId);
 
             if (clientId != null) {
                 properties.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaUniqueGroupIdSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaUniqueGroupIdSpec.groovy
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.util.concurrent.PollingConditions
+
+@Stepwise
+class KafkaUniqueGroupIdSpec extends Specification {
+
+    static final String TOPIC = "groupid-topic"
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+            CollectionUtils.mapOf(
+                    "kafka.bootstrap.servers", 'localhost:${random.port}',
+                    AbstractKafkaConfiguration.EMBEDDED, true,
+                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, [KafkaUniqueGroupIdSpec.TOPIC]
+            )
+    )
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = embeddedServer.applicationContext
+
+    @Shared
+    @AutoCleanup
+    RxHttpClient httpClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL(), new DefaultHttpClientConfiguration(followRedirects: false))
+
+    void "test multiple consumers - single group id"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        MyClient myClient = context.getBean(MyClient)
+        MyConsumer1_1 myConsumer1_1 = context.getBean(MyConsumer1_1)
+        MyConsumer1_2 myConsumer1_2 = context.getBean(MyConsumer1_2)
+
+        when:
+        myClient.sendMessage("key", "Test message 1")
+
+        then:
+        conditions.eventually {
+            (myConsumer1_1.lastMessage == 'Test message 1' && myConsumer1_2.lastMessage == null) || (myConsumer1_1.lastMessage == null && myConsumer1_2.lastMessage == 'Test message 1')
+            myConsumer1_1.count + myConsumer1_2.count == 1
+        }
+    }
+
+    void "test multiple consumers - multiple unique group ids - group id defined"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        MyClient myClient = context.getBean(MyClient)
+        MyConsumer2_1 myConsumer2_1 = context.getBean(MyConsumer2_1)
+        MyConsumer2_2 myConsumer2_2 = context.getBean(MyConsumer2_2)
+
+        when:
+        myClient.sendMessage("key", "Test message 2")
+
+        then:
+        conditions.eventually {
+            (myConsumer2_1.lastMessage == 'Test message 2' && myConsumer2_2.lastMessage == 'Test message 2')
+            myConsumer2_1.count + myConsumer2_2.count == 4 // Twice 'Test message 1' + twice 'Test message 2'
+        }
+    }
+
+    void "test multiple consumers - multiple unique group ids - group id not defined"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        MyClient myClient = context.getBean(MyClient)
+        MyConsumer3_1 myConsumer3_1 = context.getBean(MyConsumer3_1)
+        MyConsumer3_2 myConsumer3_2 = context.getBean(MyConsumer3_2)
+
+        when:
+        myClient.sendMessage("key", "Test message 3")
+
+        then:
+        conditions.eventually {
+            (myConsumer3_1.lastMessage == 'Test message 3' && myConsumer3_2.lastMessage == 'Test message 3')
+            myConsumer3_1.count + myConsumer3_2.count == 6 // Twice 3 test messages
+        }
+    }
+
+    @KafkaClient
+    static interface MyClient {
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void sendMessage(@KafkaKey String key, String message)
+    }
+
+    @KafkaListener(groupId = "myGroup", offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer1_1 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+    @KafkaListener(groupId = "myGroup", uniqueGroupId = false, offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer1_2 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+    @KafkaListener(groupId = "myGroup", uniqueGroupId = true, offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer2_1 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+    @KafkaListener(groupId = "myGroup", uniqueGroupId = true, offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer2_2 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+    @KafkaListener(/* No group ID defined */ uniqueGroupId = true, offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer3_1 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+    @KafkaListener(/* No group ID defined */ uniqueGroupId = true, offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer3_2 {
+        Integer count = 0
+        String lastMessage
+
+        @Topic(KafkaUniqueGroupIdSpec.TOPIC)
+        void receiveMessage(@KafkaKey String key, String message) {
+            lastMessage = message
+            count++
+        }
+    }
+
+}

--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -8,9 +8,28 @@ Kafka consumers created with `@KafkaListener` will by default run within a consu
 @KafkaListener("myGroup")
 ----
 
-The above example will run the consumer within a consumer group called `myGroup`.
+or
+
+.Specifying a Consumer Group alternative
+[source,java]
+----
+@KafkaListener(groupId="myGroup")
+----
+
+The above examples will run the consumer within a consumer group called `myGroup`.
+In this case, each record will be consumed by one consumer instance of the consumer group.
 
 TIP: You can make the consumer group configurable using a placeholder: `@KafkaListener("${my.consumer.group:myGroup}")`
+
+To allow the records to be consumed by all the consumer instances (each instance will be part of a unique consumer group), `uniqueGroupId` can be set to `true`:
+
+.Unique group IDs
+[source,java]
+----
+@KafkaListener(groupId="myGroup", uniqueGroupId=true)
+----
+
+For more information, see for example https://kafka.apache.org/intro#intro_consumers
 
 === @KafkaListener and Consumer Properties
 


### PR DESCRIPTION
This allows to make sure consumer instances are - when needed - in different consumer groups

Refs #38