### PR TITLE
@KafkaClient Header and Headers Argument Enhancements

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -178,7 +179,7 @@ public class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, 
                     final AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
                     String argumentName = argument.getName();
                     String name = annotationMetadata
-                            .stringValue(io.micronaut.messaging.annotation.Header.class,"name")
+                            .stringValue(io.micronaut.messaging.annotation.Header.class, "name")
                             .orElseGet(() ->
                                     annotationMetadata.stringValue(io.micronaut.messaging.annotation.Header.class).orElse(argumentName));
                     Object v = parameterValues.get(argumentName);
@@ -665,7 +666,7 @@ public class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, 
 
     private Optional<Argument> findHeadersArgument(ExecutableMethod<?, ?> method) {
         return Arrays.stream(method.getArguments())
-                .filter(arg -> arg.getFirstTypeVariable().get().getType() == Headers.class || arg.getFirstTypeVariable().get().getType() == RecordHeaders.class)
+                .filter(arg -> arg.getType() == Headers.class || arg.getType() == RecordHeaders.class)
                 .findFirst();
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -71,7 +71,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientSpec.groovy
@@ -17,10 +17,12 @@ package io.micronaut.configuration.kafka.annotation
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
-import io.micronaut.messaging.annotation.Header
 import io.micronaut.messaging.exceptions.MessagingClientException
 import org.apache.kafka.clients.producer.ProducerConfig
-import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.header.internals.RecordHeaders
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 
@@ -36,7 +38,7 @@ class KafkaClientSpec extends Specification {
         MyClient client = ctx.getBean(MyClient)
 
         when:
-        client.sendSync("test", "hello-world")
+        client.sendSync("test", "hello-world", [new RecordHeader("hello", "world".bytes)])
 
         then:
         def e = thrown(MessagingClientException)
@@ -51,7 +53,7 @@ class KafkaClientSpec extends Specification {
         MyClient client = ctx.getBean(MyClient)
 
         when:
-        client.sendRx("test", "hello-world").block()
+        client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])).block()
 
         then:
         def e = thrown(MessagingClientException)
@@ -91,9 +93,9 @@ class KafkaClientSpec extends Specification {
                                 value = "org.apache.kafka.common.serialization.ByteArraySerializer")
                 ]
         )
-        String sendSync(@KafkaKey String key, String sentence)
+        String sendSync(@KafkaKey String key, String sentence, Collection<Header> headers)
 
         @Topic("words")
-        Mono<String> sendRx(@KafkaKey String key, String sentence)
+        Mono<String> sendRx(@KafkaKey String key, String sentence, Headers headers)
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaProducerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaProducerSpec.groovy
@@ -146,7 +146,7 @@ class KafkaProducerSpec extends Specification {
             listener.brands.size() == 1
             listener.brands["Raleigh"] == "Professional"
             listener.others.isEmpty()
-            listener.additionalInfo.size() == 1
+            !listener.additionalInfo.isEmpty()
             listener.additionalInfo["size"] == "60cm"
         }
     }
@@ -169,7 +169,7 @@ class KafkaProducerSpec extends Specification {
             listener.brands.isEmpty()
             listener.others.size() == 1
             listener.others["Raleigh"] == "International"
-            listener.additionalInfo.size() == 1
+            !listener.additionalInfo.isEmpty()
             listener.additionalInfo["year"] == "1971"
         }
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaProducerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaProducerSpec.groovy
@@ -21,8 +21,13 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.event.BeanCreatedEvent
 import io.micronaut.context.event.BeanCreatedEventListener
 import io.micronaut.core.util.CollectionUtils
+import io.micronaut.messaging.MessageHeaders
 import io.micronaut.messaging.annotation.SendTo
 import io.opentracing.mock.MockTracer
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.testcontainers.containers.KafkaContainer
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.Producer
@@ -123,6 +128,52 @@ class KafkaProducerSpec extends Specification {
             context.getBean(KafkaProducerInstrumentation).counter.get() > 0
     }
 
+    def "test collection of headers"() {
+        given:
+        BicycleClient client = context.getBean(BicycleClient)
+        BicycleListener listener = context.getBean(BicycleListener)
+        listener.brands.clear()
+        listener.others.clear()
+        listener.additionalInfo.clear()
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+
+        when:
+        client.send("Raleigh", "Professional", [new RecordHeader("size", "60cm".bytes)])
+
+        then:
+        conditions.eventually {
+            mockTracer.finishedSpans().size() > 0
+            listener.brands.size() == 1
+            listener.brands["Raleigh"] == "Professional"
+            listener.others.isEmpty()
+            listener.additionalInfo.size() == 1
+            listener.additionalInfo["size"] == "60cm"
+        }
+    }
+
+    def "test kafka record headers"() {
+        given:
+        BicycleClient client = context.getBean(BicycleClient)
+        BicycleListener listener = context.getBean(BicycleListener)
+        listener.brands.clear()
+        listener.others.clear()
+        listener.additionalInfo.clear()
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+
+        when:
+        client.send2("Raleigh", "International", new RecordHeaders([new RecordHeader("year", "1971".bytes)]))
+
+        then:
+        conditions.eventually {
+            mockTracer.finishedSpans().size() > 0
+            listener.brands.isEmpty()
+            listener.others.size() == 1
+            listener.others["Raleigh"] == "International"
+            listener.additionalInfo.size() == 1
+            listener.additionalInfo["year"] == "1971"
+        }
+    }
+
     @KafkaClient(acks = KafkaClient.Acknowledge.ALL, id = "named")
     static interface NamedClient {
         @Topic(KafkaProducerSpec.TOPIC_BLOCKING)
@@ -146,7 +197,14 @@ class KafkaProducerSpec extends Specification {
         void send3(@Topic String topic, @KafkaKey String key, String name)
     }
 
+    @KafkaClient(acks = KafkaClient.Acknowledge.ALL)
+    static interface BicycleClient {
+        @Topic("ProducerSpec-my-bicycles")
+        void send(@KafkaKey String brand, String name, Collection<Header> headers)
 
+        @Topic("ProducerSpec-my-bicycles-2")
+        void send2(@KafkaKey String key, String name, Headers headers)
+    }
 
     @KafkaListener(offsetReset = OffsetReset.EARLIEST)
     static class UserListener {
@@ -178,6 +236,29 @@ class KafkaProducerSpec extends Specification {
         void receive2(@KafkaKey String key, String name) {
             log.info("Got Lineup info - {} by {}", key, name)
             others[key] = name
+        }
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST)
+    @Slf4j
+    static class BicycleListener {
+
+        Map<String, String> brands = [:]
+        Map<String, String> others = [:]
+        Map<String, String> additionalInfo = [:]
+
+        @Topic("ProducerSpec-my-bicycles")
+        void receive(@KafkaKey String brand, String name, MessageHeaders messageHeaders) {
+            log.info("Got Bicycle - {} by {}", brand, name)
+            brands[brand] = name
+            messageHeaders.each { header -> additionalInfo.put(header.key, new String(header.value[0])) }
+        }
+
+        @Topic("ProducerSpec-my-bicycles-2")
+        void receive2(@KafkaKey String key, String name, MessageHeaders messageHeaders) {
+            log.info("Got Bicycle info - {} by {}", key, name)
+            others[key] = name
+            messageHeaders.each { header -> additionalInfo.put(header.key, new String(header.value[0])) }
         }
     }
 

--- a/src/main/docs/guide/kafkaClient/kafkaClientMethods.adoc
+++ b/src/main/docs/guide/kafkaClient/kafkaClientMethods.adoc
@@ -43,6 +43,35 @@ The above example will send a header called `X-Token` with the value read from t
 
 If the `my.application.token` is not set then an error will occur creating the client.
 
+It is also possible to pass `Collection<Header>>` or `Headers` object as method arguments as seen below.
+
+.Collection<Header> Argument
+[source,java]
+----
+@Topic("my-bicycles")
+void sendBicycle(
+    @KafkaKey String brand,
+    String model,
+    Collection<Header> headers);
+----
+
+https://javadoc.io/doc/org.apache.kafka/kafka-clients/latest/org/apache/kafka/common/header/Header.html[Kafka Header Javadocs]
+
+.Headers Argument
+[source,java]
+----
+@Topic("my-bicycles")
+void sendBicycle(
+    @KafkaKey String brand,
+    String model,
+    Headers headers);
+----
+
+https://javadoc.io/doc/org.apache.kafka/kafka-clients/latest/org/apache/kafka/common/header/Headers.html[Kafka Headers Javadocs]
+
+In the above examples, all of the key/value pairs in `headers` will be added to the list of headers produced to the topic.  `Header` and `Headers` are
+part of the `kafka-clients` library:
+
 === Reactive and Non-Blocking Method Definitions
 
 The ann:configuration.kafka.annotation.KafkaClient[] annotation supports the definition of reactive return types (such as rx:Flowable[] or Reactor `Flux`) as well as Futures.


### PR DESCRIPTION
## New Features
- Added ability to pass `Collection<org.apache.kafka.common.header.Header>` to `@KafkaClient` interface methods
- Added ability to pass `org.apache.kafka.common.header.Headers` to `@KafkaClient` interface methods
