### PR TITLE
feat: add support for transaction

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
@@ -1,4 +1,11 @@
 package io.micronaut.configuration.kafka.annotation;
 
+
+/**
+ * Parameter level annotation to indicate when send to is all or None.
+ *
+ * @author Michael Pollind
+ * @since 1.2
+ */
 public @interface KafkaTransaction {
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.kafka.annotation;
 
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaTransaction.java
@@ -1,0 +1,4 @@
+package io.micronaut.configuration.kafka.annotation;
+
+public @interface KafkaTransaction {
+}


### PR DESCRIPTION
ref: https://github.com/micronaut-projects/micronaut-kafka/issues/104

Here is an implementation of transactions for sendTo. here is how its marked out in the documentation: [here](https://kafka.apache.org/0110/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html) . `commitTransaction` is blocking so it will throw an exception if any of the messages sent in that transaction fail. The other thing that comes to mind is do we want to batch up all the message from the emitter because if a transaction fails then none of those messages will be processed. 

Any clue how this can be tested? I was thinking about MockProducers but i couldn't figure out how to inject it as a replacement bean. 