### PR TITLE
Add global kafka.enabled config item

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
@@ -60,5 +60,6 @@ public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfigu
         String propertyKey = PREFIX + '.' + NameUtils.hyphenate(streamName, true);
         config.putAll(environment.getProperty(propertyKey, Properties.class).orElseGet(Properties::new));
         init(applicationConfiguration, environment, config);
+        this.setEnabled(defaultConfiguration.isEnabled());
     }
 }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.configuration.kafka.streams;
 
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.configuration.kafka.streams.event.AfterKafkaStreamsStart;
 import io.micronaut.configuration.kafka.streams.event.BeforeKafkaStreamStart;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.kstream.KStream;
@@ -39,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 1.0
  */
 @Factory
+@Requires(property = AbstractKafkaConfiguration.PREFIX + "." + AbstractKafkaConfiguration.ENABLED_CONFIG, value = "true", defaultValue = "true")
 public class KafkaStreamsFactory implements Closeable {
 
     private final Map<KafkaStreams, ConfiguredStreamBuilder> streams = new ConcurrentHashMap<>();

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsDisabledSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsDisabledSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.configuration.kafka.streams
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.kafka.streams.KafkaStreams
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class KafkaStreamsDisabledSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context
+
+    def setupSpec() {
+        embeddedServer = ApplicationContext.run(EmbeddedServer,
+                CollectionUtils.mapOf(
+                        "kafka.enabled", false
+                )
+        )
+
+        context = embeddedServer.getApplicationContext()
+    }
+
+    void "test no streams have been created"() {
+        expect:
+        context.getBeansOfType(KafkaStreams).isEmpty()
+    }
+
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/NoopProducer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/NoopProducer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.internals.FutureRecordMetadata;
+import org.apache.kafka.clients.producer.internals.ProduceRequestResult;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.Time;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ * No-Op Producer for use when kafka is disabled.
+ */
+public class NoopProducer implements Producer {
+    @Override
+    public void initTransactions() {
+
+    }
+
+    @Override
+    public void beginTransaction() throws ProducerFencedException {
+
+    }
+
+    @Override
+    public void commitTransaction() throws ProducerFencedException {
+
+    }
+
+    @Override
+    public void abortTransaction() throws ProducerFencedException {
+
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord record) {
+        return send(record, null);
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord record, Callback callback) {
+        TopicPartition topicPartition = new TopicPartition(record.topic(), 0);
+        ProduceRequestResult result = new ProduceRequestResult(topicPartition);
+        FutureRecordMetadata future = new FutureRecordMetadata(result, 0, RecordBatch.NO_TIMESTAMP,
+                0L, 0, 0, Time.SYSTEM);
+        result.set(0, 0, null);
+        result.done();
+        return future;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic) {
+        return null;
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void close(Duration timeout) {
+
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map offsets, ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map offsets, String consumerGroupId) throws ProducerFencedException {
+
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.configuration.kafka.config;
 
+import io.micronaut.core.util.Toggleable;
+
 import javax.annotation.Nonnull;
 import java.util.Properties;
 
@@ -26,7 +28,18 @@ import java.util.Properties;
  * @author Graeme Rocher
  * @since 1.0
  */
-public abstract class AbstractKafkaConfiguration<K, V> {
+public abstract class AbstractKafkaConfiguration<K, V> implements Toggleable {
+
+    /**
+     * The global kafka enabled config item name.
+     */
+    public static final String ENABLED_CONFIG = "enabled";
+
+    /**
+     * The default enabled status.
+     */
+    public static final boolean DEFAULT_ENABLED = true;
+
     /**
      * The default kafka port.
      */
@@ -55,6 +68,7 @@ public abstract class AbstractKafkaConfiguration<K, V> {
      */
     public static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:" + DEFAULT_KAFKA_PORT;
 
+    private boolean enabled = DEFAULT_ENABLED;
     private final Properties config;
 
     /**
@@ -64,6 +78,21 @@ public abstract class AbstractKafkaConfiguration<K, V> {
      */
     protected AbstractKafkaConfiguration(Properties config) {
         this.config = config;
+    }
+
+    /**
+     * @return Whether kafka is enabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @param enabled true if kafka is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/DefaultKafkaConsumerConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/DefaultKafkaConsumerConfiguration.java
@@ -60,6 +60,8 @@ public class DefaultKafkaConsumerConfiguration<K, V> extends AbstractKafkaConsum
     }
 
     private void init(AbstractKafkaConfiguration defaultConfiguration) {
+        this.setEnabled(defaultConfiguration.isEnabled());
+
         Properties config = getConfig();
         config.putAll(defaultConfiguration.getConfig());
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/DefaultKafkaProducerConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/DefaultKafkaProducerConfiguration.java
@@ -56,6 +56,8 @@ public class DefaultKafkaProducerConfiguration<K, V> extends AbstractKafkaProduc
     }
 
     private void init(AbstractKafkaConfiguration defaultConfiguration) {
+        this.setEnabled(defaultConfiguration.isEnabled());
+
         Properties config = getConfig();
         config.putAll(defaultConfiguration.getConfig());
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/KafkaDefaultConfiguration.java
@@ -58,6 +58,11 @@ public class KafkaDefaultConfiguration extends AbstractKafkaConfiguration {
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
                 AbstractKafkaConfiguration.DEFAULT_BOOTSTRAP_SERVERS
         );
+
+        if (getConfig().containsKey(ENABLED_CONFIG)) {
+            Optional<Boolean> enabledConfig = ConversionService.SHARED.convert(getConfig().get(ENABLED_CONFIG), Boolean.class);
+            enabledConfig.ifPresent(this::setEnabled);
+        }
     }
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.kafka.intercept;
 
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.configuration.kafka.NoopProducer;
 import io.micronaut.configuration.kafka.annotation.KafkaClient;
 import io.micronaut.configuration.kafka.annotation.KafkaKey;
 import io.micronaut.configuration.kafka.annotation.KafkaTimestamp;
@@ -599,6 +600,11 @@ public class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, 
             DefaultKafkaProducerConfiguration<?, ?> newConfiguration = new DefaultKafkaProducerConfiguration<>(
                     configuration
             );
+
+            if (!newConfiguration.isEnabled()) {
+                LOG.debug("Kafka is disabled, skipping producer configuration...");
+                return new NoopProducer();
+            }
 
             Properties newProperties = newConfiguration.getConfig();
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -19,6 +19,7 @@ import io.micronaut.configuration.kafka.*;
 import io.micronaut.configuration.kafka.annotation.*;
 import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry;
 import io.micronaut.configuration.kafka.bind.batch.BatchConsumerRecordsBinderRegistry;
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration;
 import io.micronaut.configuration.kafka.config.DefaultKafkaConsumerConfiguration;
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
@@ -87,6 +88,7 @@ import java.util.regex.Pattern;
  */
 @Singleton
 @Requires(beans = KafkaDefaultConfiguration.class)
+@Requires(property = AbstractKafkaConfiguration.PREFIX + "." + AbstractKafkaConfiguration.ENABLED_CONFIG, value = "true", defaultValue = "true")
 @Context
 public class KafkaConsumerProcessor
         implements ExecutableMethodProcessor<KafkaListener>, AutoCloseable, ConsumerRegistry {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaDisabledSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaDisabledSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.configuration.kafka.annotation
+
+
+import io.micronaut.configuration.kafka.ConsumerRegistry
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.messaging.annotation.Header
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.kafka.clients.consumer.Consumer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class KafkaDisabledSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    def setupSpec() {
+        embeddedServer = ApplicationContext.run(EmbeddedServer,
+                CollectionUtils.mapOf(
+                        "kafka.enabled", false
+                )
+        )
+        context = embeddedServer.applicationContext
+    }
+
+    void "test simple consumer"() {
+        expect: "No kafka consumers have been created"
+        !context.containsBean(ConsumerRegistry)
+    }
+
+    void "test simple producer"() {
+        given:
+        MyClient myClient = context.getBean(MyClient)
+
+        when:
+        myClient.sendSentence("abcd", "asdf", "words")
+
+        then:
+        noExceptionThrown()
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST)
+    static class MyConsumer {
+        int wordCount
+        String lastTopic
+
+        @Topic("words")
+        void receive(String sentence, @Header String topic) {
+            wordCount += sentence.split(/\s/).size()
+            lastTopic = topic
+        }
+    }
+
+    @KafkaClient
+    static interface MyClient {
+        @Topic("words")
+        void sendSentence(@KafkaKey String key, String sentence, @Header String topic)
+    }
+
+}


### PR DESCRIPTION
@graemerocher I'm trying to resolve #138, allowing consumers and streams to be disabled is relatively straight forward, but producers were a bit tougher, as they're created adhoc by the intro advice - any ideas on how this could be done better?