### PR TITLE
Revert "Ensure KafkaConsumerProcessor is initialized before polling"

### DIFF
--- a/kafka-streams/src/test/resources/logback.xml
+++ b/kafka-streams/src/test/resources/logback.xml
@@ -12,6 +12,6 @@
         <appender-ref ref="STDOUT" />
     </root>
 <!--    <logger name="io.micronaut.context" level="TRACE"/>-->
-<!--    <logger name="io.micronaut.configuration.kafka.embedded" level="TRACE" />-->
-<!--    <logger name="com.testcontainers" level="INFO" />-->
+    <logger name="io.micronaut.configuration.kafka.embedded" level="TRACE" />
+    <logger name="com.testcontainers" level="INFO" />
 </configuration>

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -35,7 +35,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @MessageListener
-@DefaultScope(Context.class)
 public @interface KafkaListener {
 
     /**


### PR DESCRIPTION
This reverts commit 0561addba7a0f7366b0aa6a0fd735f8f180bc064.

Fixes #190 