### PR TITLE
Remove deprecated kafka streams store api usage

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/InteractiveQueryService.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.kafka.streams;
 
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
@@ -57,7 +58,7 @@ public class InteractiveQueryService {
     public <T> Optional<T> getQueryableStore(String storeName, QueryableStoreType<T> storeType) {
         for (KafkaStreams kafkaStream : this.streams) {
             try {
-                T store = kafkaStream.store(storeName, storeType);
+                T store = kafkaStream.store(StoreQueryParameters.fromNameAndType(storeName, storeType));
                 if (store != null) {
                     return Optional.of(store);
                 }


### PR DESCRIPTION
This removes usage of the `KafkaStreams.store(String, QueryableStoreType)` in favor of `store(StoreQueryParameters)`, as recommended in the kafka streams code:
![image](https://user-images.githubusercontent.com/5193063/94916610-61a07800-0485-11eb-8ac6-25d163aef87b.png)
