### PR TITLE
Fix disabling kafka-streams health check

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.configuration.kafka.streams.health;
 
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
-import io.micronaut.configuration.kafka.streams.KafkaStreamsConfiguration;
 import io.micronaut.configuration.kafka.streams.KafkaStreamsFactory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
@@ -50,8 +50,10 @@ import java.util.stream.Stream;
  */
 @Singleton
 @Requires(classes = HealthIndicator.class)
-@Requires(property = KafkaStreamsConfiguration.PREFIX + ".health.enabled", value = "true", defaultValue = "true")
+@Requires(property = KafkaStreamsHealth.ENABLED_PROPERTY, value = "true", defaultValue = "true")
 public class KafkaStreamsHealth implements HealthIndicator {
+
+    public static final String ENABLED_PROPERTY = AbstractKafkaConfiguration.PREFIX + ".health.streams.enabled";
 
     private static final String NAME = "kafkaStreams";
 

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealthDisabledSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealthDisabledSpec.groovy
@@ -15,7 +15,7 @@ class KafkaStreamsHealthDisabledSpec extends AbstractTestContainersSpec {
     @Override
     protected List<Object> getConfiguration() {
         List<Object> config = super.getConfiguration()
-        config.addAll(["kafka.streams.health.enabled", 'false'])
+        config.addAll(["kafka.health.streams.enabled", 'false'])
         return config
     }
 }

--- a/src/main/docs/guide/kafkaApplications/kafkaHealth.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaHealth.adoc
@@ -25,6 +25,6 @@ If you wish to disable the kafka health check while still using the `management`
 [source,yaml]
 ----
 kafka:
-	health:
-		enabled: false
+    health:
+        enabled: false
 ----

--- a/src/main/docs/guide/kafkaStreams/kafkaStreamHealth.adoc
+++ b/src/main/docs/guide/kafkaStreams/kafkaStreamHealth.adoc
@@ -34,12 +34,12 @@ For example stream health at the `/health` endpoint will return:
 
 NOTE: By default, the details visible above are only shown to authenticated users. See the <<healthEndpoint, Health Endpoint>> documentation for how to configure that setting.
 
-If you wish to disable the Kafka streams health check while still using the `management` dependency you can set the property `kafka.streams.health.enabled` to `false` in your application configuration.
+If you wish to disable the Kafka streams health check while still using the `management` dependency you can set the property `kafka.health.streams.enabled` to `false` in your application configuration.
 
 [source,yaml]
 ----
 kafka:
-    streams:
-	    health:
-		    enabled: false
+    health:
+        streams:
+            enabled: false
 ----


### PR DESCRIPTION
changed `kafka.streams.health.enabled` to `kafka.health.streams.enabled` to avoid creating a stream called "health"

Fixes https://github.com/micronaut-projects/micronaut-kafka/issues/196