### PR TITLE
Update kafkaCli.adoc

### DIFF
--- a/src/main/docs/guide/kafkaCli.adoc
+++ b/src/main/docs/guide/kafkaCli.adoc
@@ -21,9 +21,9 @@ As you'd expect, you can start the application with `./gradlew run` (for Gradle)
 Within the new project, you can now run the Kafka-specific code generation commands:
 
 ----
-$ mn create-kafka-producer Message
+$ mn create-kafka-producer MessageProducer
 | Rendered template Producer.java to destination src/main/java/my/kafka/app/MessageProducer.java
 
-$ mn create-kafka-listener Message
+$ mn create-kafka-listener MessageListener
 | Rendered template Listener.java to destination src/main/java/my/kafka/app/MessageListener.java
 ----


### PR DESCRIPTION
with the current code the output file is Message.java and the second one cannot created and prints a warning as follows:

$ mn create-kafka-listener Message
| Warning Rendering skipped for src/main/java/my/kafka/app/Message.java because it already exists. Run again with -f to overwrite.