### PR TITLE
Allow micronaut-kafka to be globally disabled

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/package-info.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/package-info.java
@@ -19,4 +19,10 @@
  * @author graemerocher
  * @since 1.0
  */
+@Configuration
+@Requires(property = "kafka.enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 package io.micronaut.configuration.kafka;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/fallback/MessageClient.java
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/fallback/MessageClient.java
@@ -1,0 +1,11 @@
+package io.micronaut.configuration.kafka.docs.producer.fallback;
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.Topic;
+
+@KafkaClient
+public interface MessageClient {
+
+    @Topic("messages")
+    void send(String message);
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/fallback/MessageClientFallback.java
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/fallback/MessageClientFallback.java
@@ -1,0 +1,21 @@
+package io.micronaut.configuration.kafka.docs.producer.fallback;
+
+// tag::imports[]
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+// end::imports[]
+
+
+// tag::clazz[]
+@Requires(property = "kafka.enabled", notEquals = StringUtils.TRUE, defaultValue = StringUtils.TRUE) // <1>
+@Replaces(MessageClient.class) // <2>
+public class MessageClientFallback implements MessageClient { // <3>
+
+    @Override
+    public void send(String message) {
+        throw new UnsupportedOperationException(); // <4>
+    }
+}
+// end::clazz[]
+

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledClient.java
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledClient.java
@@ -1,0 +1,10 @@
+package io.micronaut.test;
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.Topic;
+
+@KafkaClient
+public interface DisabledClient {
+    @Topic("disabled-topic")
+    public abstract void send(String message);
+}

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledClient.java
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledClient.java
@@ -6,5 +6,5 @@ import io.micronaut.configuration.kafka.annotation.Topic;
 @KafkaClient
 public interface DisabledClient {
     @Topic("disabled-topic")
-    public abstract void send(String message);
+    void send(String message);
 }

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledClientFallback.java
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledClientFallback.java
@@ -1,0 +1,14 @@
+package io.micronaut.test;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+
+@Requires(property = "kafka.enabled", notEquals = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Replaces(DisabledClient.class)
+public class DisabledClientFallback implements DisabledClient {
+    @Override
+    public void send(String message) {
+        System.out.println("No-Op");
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledConsumer.java
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledConsumer.java
@@ -11,7 +11,7 @@ public class DisabledConsumer {
 
     @KafkaListener
     @Topic("disable-topic")
-    void receive(@KafkaKey String key,  String value) {
+    void receive(@KafkaKey String key, String value) {
         throw new UnsupportedOperationException();
     }
 

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledConsumer.java
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledConsumer.java
@@ -1,0 +1,21 @@
+package io.micronaut.test;
+
+import io.micronaut.configuration.kafka.annotation.KafkaKey;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.Topic;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class DisabledConsumer {
+
+    @KafkaListener
+    @Topic("disable-topic")
+    void receive(@KafkaKey String key,  String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    int getNum() {
+        return 1;
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/test/DisabledSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/test/DisabledSpec.groovy
@@ -6,6 +6,12 @@ import spock.lang.Specification
 
 import javax.inject.Singleton
 
+/**
+ * Test that micronaut-kafka can be disabled by setting 'kafka.enabled': 'false'.
+ *
+ * Note that this test and associated classes are in a different package so that they are not affected by the package-level
+ * annotation which would otherwise disable them.
+ */
 class DisabledSpec extends Specification {
 
     void "Starting app with kafka disabled works correctly"() {

--- a/src/main/docs/guide/kafkaApplications/kafkaDisabled.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaDisabled.adoc
@@ -1,0 +1,19 @@
+If you want to disable micronaut-kafka entirely, you can set `kafka.enabled` to `false` in `application.yml`.
+
+This will prevent the instantiation of all kafka-related beans.
+
+You must, however, provide your own replacement implementations of any `@KafkaClient` interfaces:
+
+.Creating Replacement KafkaClient Implementations
+[source,java]
+----
+include::{testskafka}/producer/fallback/MessageClientFallback.java[tags=imports, indent=0]
+
+include::{testskafka}/producer/fallback/MessageClientFallback.java[tags=clazz, indent=0]
+----
+
+<1> Only instantiate when `kafka.enabled` is set to `false`
+<2> Replace the `@KafkaClient` interface
+<3> Implement the interface
+<4> Provide an alternative implementation for all client methods
+

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -22,6 +22,7 @@ kafkaApplications:
   kafkaHealth: Kafka Health Checks
   kafkaMetrics: Kafka Metrics
   kafkaTracing: Kafka Distributed Tracing
+  kafkaDisabled: Disabling Micronaut-Kafka
 kafkaStreams:
   title: Kafka Streams
   kafkaStreamInteractiveQuery: Interactive Query Service


### PR DESCRIPTION
As requested in https://github.com/micronaut-projects/micronaut-kafka/pull/211, this has been rewritten to apply the `@Requires` annotation at the `package-info.java` level.

A couple of notes:

- Without providing replacement beans for `@KafkaClient` interfaces, you get startup failures: `Caused by: java.lang.IllegalStateException: At least one @Introduction method interceptor required, but missing.`, which isn't particularly helpful, so I've added instructions to the docs
- I had to write my tests in a different package (`io.micronaut.test`), as otherwise they were affected by the `package-info.java` change
- I wrote my test fixture classes as separate .java files, as for some reason I kept hitting this exception whenever I tried to implement one of my `@KafkaClient` interfaces in groovy:

```
Caused by: BUG! exception in phase 'canonicalization' in source unit '/home/mitch/src/micronaut-kafka/kafka/src/test/groovy/io/micronaut/test/Test.groovy' null
	at org.gradle.api.internal.tasks.compile.ApiGroovyCompiler.execute(ApiGroovyCompiler.java:277)
	....
Caused by: java.lang.NullPointerException
	at io.micronaut.ast.groovy.InjectTransform$InjectVisitor.visitExecutableMethod(InjectTransform.groovy:1193)
	at io.micronaut.ast.groovy.InjectTransform$InjectVisitor.visitConstructorOrMethod(InjectTransform.groovy:990)
	at io.micronaut.ast.groovy.InjectTransform$InjectVisitor.visitClass(InjectTransform.groovy:443)
	at io.micronaut.ast.groovy.InjectTransform.visit(InjectTransform.groovy:196)
	... 28 more
```

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/138