### PR TITLE
Expose Consumer Assignment through ConsumerRegistry

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
@@ -43,8 +43,17 @@ public interface ConsumerRegistry {
     <K, V> Consumer<K, V> getConsumer(@Nonnull String id);
 
     /**
-     * Returns a managed Consumer's assignment info. Note that the consumer should not be interacted with directly from a
-     * different thread to the poll loop!
+     * Returns a managed Consumer's subscriptions.
+     *
+     * @param id The id of the producer.
+     * @return The consumer subscription
+     * @throws IllegalArgumentException If no consumer exists for the given ID
+     */
+    @Nonnull
+    Set<String> getConsumerSubscription(@Nonnull String id);
+
+    /**
+     * Returns a managed Consumer's assignment info.
      *
      * @param id The id of the producer.
      * @return The consumer assignment

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.kafka;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
@@ -35,11 +36,22 @@ public interface ConsumerRegistry {
      * @param id The id of the producer.
      * @param <K> The key generic type
      * @param <V> The value generic type
-     * @return The producer
+     * @return The consumer
      * @throws IllegalArgumentException If no consumer exists for the given ID
      */
     @Nonnull
     <K, V> Consumer<K, V> getConsumer(@Nonnull String id);
+
+    /**
+     * Returns a managed Consumer's assignment info. Note that the consumer should not be interacted with directly from a
+     * different thread to the poll loop!
+     *
+     * @param id The id of the producer.
+     * @return The consumer assignment
+     * @throws IllegalArgumentException If no consumer exists for the given ID
+     */
+    @Nonnull
+    Set<TopicPartition> getConsumerAssignment(@Nonnull String id);
 
     /**
      * The IDs of the available consumers.

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/ConsumerRegistrySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/ConsumerRegistrySpec.groovy
@@ -1,0 +1,117 @@
+
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.ConsumerRegistry
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.messaging.annotation.Body
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.common.TopicPartition
+import org.testcontainers.containers.KafkaContainer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.ConcurrentSkipListSet
+
+class ConsumerRegistrySpec extends Specification {
+
+    @Shared @AutoCleanup KafkaContainer kafkaContainer = new KafkaContainer()
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context
+
+    def setupSpec() {
+        kafkaContainer.start()
+        embeddedServer = ApplicationContext.run(EmbeddedServer,
+                CollectionUtils.mapOf(
+                        "kafka.bootstrap.servers", kafkaContainer.getBootstrapServers(),
+                        "micrometer.metrics.enabled", true,
+                        'endpoints.metrics.sensitive', false,
+                        AbstractKafkaConfiguration.EMBEDDED_TOPICS, ["fruits"]
+                )
+        )
+        context = embeddedServer.applicationContext
+    }
+
+    void "test consumer registry"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        ConsumerRegistry registry = context.getBean(ConsumerRegistry)
+        BicycleClient client = context.getBean(BicycleClient)
+        BicycleListener listener = context.getBean(BicycleListener)
+
+        when:
+        Consumer consumer = registry.getConsumer("bicycle-client")
+
+        then:
+        consumer
+
+        when:
+        Set<String> consumerIds = registry.getConsumerIds()
+
+        then:
+        consumerIds.contains("bicycle-client")
+
+        when:
+        Set<String> subscription = registry.getConsumerSubscription("bicycle-client")
+
+        then:
+        subscription
+        subscription.size() == 1
+        subscription[0] == "bicycles"
+
+        when:
+        registry.getConsumerAssignment("bicycle-client")
+
+        then:
+        IllegalArgumentException e = thrown(IllegalArgumentException)
+        e.message == "No consumer assignment found for ID: bicycle-client"
+
+        when:
+        client.send("Raleigh", "Professional")
+
+        then:
+        conditions.eventually {
+            listener.bicycles.size() == 1
+            listener.bicycles[0] == "Professional"
+        }
+
+        when:
+        Set<TopicPartition> topicPartitions = registry.getConsumerAssignment("bicycle-client")
+
+        then:
+        topicPartitions
+        topicPartitions.size() == 1
+        topicPartitions[0].topic() == "bicycles"
+        topicPartitions[0].partition() == 0
+    }
+
+    @KafkaClient
+    static interface BicycleClient {
+
+        @Topic("bicycles")
+        void send(@KafkaKey String make, @Body String model)
+    }
+
+    @KafkaListener(clientId = "bicycle-client", offsetReset = OffsetReset.EARLIEST)
+    static class BicycleListener {
+
+        Set<String> bicycles = new ConcurrentSkipListSet<>()
+
+        @Topic("bicycles")
+        void receive(@Body String model) {
+            println "RECEIVED BICYCLE $model"
+            bicycles.add(model)
+        }
+
+    }
+}


### PR DESCRIPTION
Expose each consumer's subscriptions and assignment through the `ConsumerRegistry` keyed by client id.  This information is hard to get since it can only be accessed from poll loop thread.