### PR TITLE
Add KafkaPartition and KafkaPartitionKey annotations

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartition.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartition.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.lang.annotation.*;
+
+/**
+ * Parameter level annotation to indicate which parameter is bound to the Kafka Partition.
+ * It can be used in {@link java.lang.Integer} or {@code int}.
+ *
+ * <p>When used in producers, indicates which partition is to be used. If the provided value is {@code null}
+ * then the configured/default partitioning strategy takes place.</p>
+ *
+ * <p>When used in consumers, it is populated with the partition that the record was received from.</p>
+ *
+ * <p>Note that while using {@link KafkaPartition} in the same method as {@link KafkaPartitionKey}
+ * will not throw an exception, the outcome of doing so is left unspecified.</p>
+ *
+ * @author André Prata
+ * @since 3.3.4
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@Bindable
+public @interface KafkaPartition {
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartitionKey.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartitionKey.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.lang.annotation.*;
+
+/**
+ * Parameter level annotation for Kafka producers to indicate which parameter to compute the Kafka Partition from.
+ *
+ * <p>The partition is computed by first serializing the object and using the {@code murmur2} algorithm over the result,
+ * yielding exactly the same values as Kafka's own {@code DefaultStrategy}.<p/>
+ *
+ * <p>If the provided value is {@code null} then the configured/default partitioning strategy takes place.</p>
+ *
+ * <p>Note that while using {@link KafkaPartitionKey} in the same method as {@link KafkaPartition}
+ * will not throw an exception, the outcome of doing so is left unspecified.</p>
+ *
+ * @author André Prata
+ * @since 3.3.4
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@Bindable
+public @interface KafkaPartitionKey {
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartitionKey.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaPartitionKey.java
@@ -22,8 +22,9 @@ import java.lang.annotation.*;
 /**
  * Parameter level annotation for Kafka producers to indicate which parameter to compute the Kafka Partition from.
  *
- * <p>The partition is computed by first serializing the object and using the {@code murmur2} algorithm over the result,
- * yielding exactly the same values as Kafka's own {@code DefaultStrategy}.<p/>
+ * <p>The partition is computed by first serializing the object, using an appropriate serializer from
+ * {@link io.micronaut.configuration.kafka.serde.SerdeRegistry} as determined by, and then computing the partition
+ * number using the same algorithm as Kafka's own {@code DefaultStrategy} ({@code murmur2})<p/>
  *
  * <p>If the provided value is {@code null} then the configured/default partitioning strategy takes place.</p>
  *

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/bind/KafkaPartitionBinder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/bind/KafkaPartitionBinder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.bind;
+
+import io.micronaut.configuration.kafka.annotation.KafkaPartition;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+
+/**
+ * Binder for binding the parameters that is designated the {@link KafkaPartition}.
+ *
+ * @param <T> The target type
+ * @author André Prata
+ * @since 3.3.4
+ */
+@Singleton
+public class KafkaPartitionBinder<T> implements AnnotatedConsumerRecordBinder<KafkaPartition, T> {
+
+    @Override
+    public Class<KafkaPartition> annotationType() {
+        return KafkaPartition.class;
+    }
+
+    @Override
+    public BindingResult<T> bind(ArgumentConversionContext<T> context, ConsumerRecord<?, ?> source) {
+        Object partition = source.partition();
+        Optional<T> converted = ConversionService.SHARED.convert(partition, context);
+        return () -> converted;
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Shared
 
 abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
 
-    @Shared @AutoCleanup KafkaContainer kafkaContainer = new KafkaContainer()
+    @Shared @AutoCleanup KafkaContainer kafkaContainer = new KafkaContainer().withEnv(getEnvVariables())
     @Shared @AutoCleanup ApplicationContext context
 
     void setupSpec() {
@@ -17,4 +17,9 @@ abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
                         ['kafka.bootstrap.servers': kafkaContainer.bootstrapServers]
         )
     }
+
+    protected Map<String, String> getEnvVariables() {
+        return [:]
+    }
+
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaPartitionSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaPartitionSpec.groovy
@@ -1,0 +1,213 @@
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.AbstractKafkaContainerSpec
+import io.micronaut.context.annotation.Requires
+
+import java.util.concurrent.ConcurrentLinkedDeque
+
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+import static io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration.EMBEDDED_TOPICS
+
+class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
+
+    public static final String TOPIC_WORDS = "KafkaPartitionSpec-words"
+
+    protected Map<String, String> getEnvVariables() {
+        super.envVariables + ["KAFKA_NUM_PARTITIONS": "3"]
+    }
+
+    protected Map<String, Object> getConfiguration() {
+        super.configuration + [(EMBEDDED_TOPICS): [TOPIC_WORDS]]
+    }
+
+    def "test client without partition"() {
+        given:
+        ClientWithoutPartition client = context.getBean(ClientWithoutPartition)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence("key1", "sentence1")
+        client.sendSentence("key2", "sentence2")
+        client.sendSentence("key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 2 // "key1" happens to result in this
+            listener.partitions[1] == 2 // "key2" happens to result in this
+            listener.partitions[2] == 1 // "key3" happens to result in this
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    def "test client with integer partition"() {
+        given:
+        ClientWithIntegerPartition client = context.getBean(ClientWithIntegerPartition)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence(1, "key1", "sentence1")
+        client.sendSentence(2, "key2", "sentence2")
+        client.sendSentence(2, "key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 1
+            listener.partitions[1] == 2
+            listener.partitions[2] == 2
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    def "test client with integer partition null"() {
+        given:
+        ClientWithIntegerPartition client = context.getBean(ClientWithIntegerPartition)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence(null, "key1", "sentence1")
+        client.sendSentence(null, "key2", "sentence2")
+        client.sendSentence(null, "key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 2 // "key1" happens to result in this
+            listener.partitions[1] == 2 // "key2" happens to result in this
+            listener.partitions[2] == 1 // "key3" happens to result in this
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    def "test client with int partition"() {
+        given:
+        ClientWithIntPartition client = context.getBean(ClientWithIntPartition)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence(1, "key1", "sentence1")
+        client.sendSentence(2, "key2", "sentence2")
+        client.sendSentence(2, "key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 1
+            listener.partitions[1] == 2
+            listener.partitions[2] == 2
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    def "test client with partition key"() {
+        given:
+        ClientWithPartitionKey client = context.getBean(ClientWithPartitionKey)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence("par-key1", "key1", "sentence1")
+        client.sendSentence("par-key2", "key2", "sentence2")
+        client.sendSentence("par-key3", "key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 2 // "par-key1" happens to result in this
+            listener.partitions[1] == 0 // "par-key2" happens to result in this
+            listener.partitions[2] == 2 // "par-key3" happens to result in this
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    def "test client with partition key null"() {
+        given:
+        ClientWithPartitionKey client = context.getBean(ClientWithPartitionKey)
+        SentenceListener listener = context.getBean(SentenceListener)
+        listener.partitions.clear()
+        listener.sentences.clear()
+
+        when:
+        client.sendSentence(null, "key1", "sentence1")
+        client.sendSentence(null, "key2", "sentence2")
+        client.sendSentence(null, "key3", "sentence3")
+
+        then:
+        conditions.eventually {
+            listener.partitions.size() == 3
+            listener.partitions[0] == 2 // "key1" happens to result in this
+            listener.partitions[1] == 2 // "key2" happens to result in this
+            listener.partitions[2] == 1 // "key3" happens to result in this
+            listener.sentences.size() == 3
+            listener.sentences[0] == "sentence1"
+            listener.sentences[1] == "sentence2"
+            listener.sentences[2] == "sentence3"
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
+    @KafkaClient
+    static interface ClientWithoutPartition {
+        @Topic(KafkaPartitionSpec.TOPIC_WORDS)
+        void sendSentence(@KafkaKey String key, String sentence)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
+    @KafkaClient
+    static interface ClientWithIntPartition {
+        @Topic(KafkaPartitionSpec.TOPIC_WORDS)
+        void sendSentence(@KafkaPartition int partition, @KafkaKey String key, String sentence)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
+    @KafkaClient
+    static interface ClientWithIntegerPartition {
+        @Topic(KafkaPartitionSpec.TOPIC_WORDS)
+        void sendSentence(@KafkaPartition Integer partition, @KafkaKey String key, String sentence)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
+    @KafkaClient
+    static interface ClientWithPartitionKey {
+        @Topic(KafkaPartitionSpec.TOPIC_WORDS)
+        void sendSentence(@KafkaPartitionKey String partitionKey, @KafkaKey String key, String sentence)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
+    @KafkaListener(offsetReset = EARLIEST)
+    static class SentenceListener {
+        Queue<Integer> partitions = new ConcurrentLinkedDeque<>()
+        Queue<String> sentences = new ConcurrentLinkedDeque<>()
+
+        @Topic(KafkaPartitionSpec.TOPIC_WORDS)
+        void receive(@KafkaPartition int partition, String sentence) {
+            partitions << partition
+            sentences << sentence
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaPartitionSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaPartitionSpec.groovy
@@ -3,8 +3,9 @@ package io.micronaut.configuration.kafka.annotation
 import io.micronaut.configuration.kafka.AbstractKafkaContainerSpec
 import io.micronaut.context.annotation.Requires
 
-import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.ConcurrentHashMap
 
+import static io.micronaut.configuration.kafka.annotation.KafkaClient.Acknowledge.ALL
 import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
 import static io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration.EMBEDDED_TOPICS
 
@@ -24,8 +25,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithoutPartition client = context.getBean(ClientWithoutPartition)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence("key1", "sentence1")
@@ -34,14 +34,10 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 2 // "key1" happens to result in this
-            listener.partitions[1] == 2 // "key2" happens to result in this
-            listener.partitions[2] == 1 // "key3" happens to result in this
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"] == 2 // "key1" happens to result in this
+            listener.entries["sentence2"] == 2 // "key2" happens to result in this
+            listener.entries["sentence3"] == 1 // "key3" happens to result in this
         }
     }
 
@@ -49,8 +45,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithIntegerPartition client = context.getBean(ClientWithIntegerPartition)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence(1, "key1", "sentence1")
@@ -59,14 +54,10 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 1
-            listener.partitions[1] == 2
-            listener.partitions[2] == 2
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"] == 1
+            listener.entries["sentence2"] == 2
+            listener.entries["sentence3"] == 2
         }
     }
 
@@ -74,8 +65,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithIntegerPartition client = context.getBean(ClientWithIntegerPartition)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence(null, "key1", "sentence1")
@@ -84,14 +74,10 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 2 // "key1" happens to result in this
-            listener.partitions[1] == 2 // "key2" happens to result in this
-            listener.partitions[2] == 1 // "key3" happens to result in this
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"] == 2 // "key1" happens to result in this
+            listener.entries["sentence2"] == 2 // "key2" happens to result in this
+            listener.entries["sentence3"] == 1 // "key3" happens to result in this
         }
     }
 
@@ -99,8 +85,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithIntPartition client = context.getBean(ClientWithIntPartition)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence(1, "key1", "sentence1")
@@ -109,14 +94,10 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 1
-            listener.partitions[1] == 2
-            listener.partitions[2] == 2
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"]  == 1
+            listener.entries["sentence2"]  == 2
+            listener.entries["sentence3"]  == 2
         }
     }
 
@@ -124,8 +105,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithPartitionKey client = context.getBean(ClientWithPartitionKey)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence("par-key1", "key1", "sentence1")
@@ -134,14 +114,10 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 2 // "par-key1" happens to result in this
-            listener.partitions[1] == 0 // "par-key2" happens to result in this
-            listener.partitions[2] == 2 // "par-key3" happens to result in this
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"] == 2 // "par-key1" happens to result in this
+            listener.entries["sentence2"] == 0 // "par-key2" happens to result in this
+            listener.entries["sentence3"] == 2 // "par-key3" happens to result in this
         }
     }
 
@@ -149,8 +125,7 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
         given:
         ClientWithPartitionKey client = context.getBean(ClientWithPartitionKey)
         SentenceListener listener = context.getBean(SentenceListener)
-        listener.partitions.clear()
-        listener.sentences.clear()
+        listener.entries.clear()
 
         when:
         client.sendSentence(null, "key1", "sentence1")
@@ -159,40 +134,36 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
 
         then:
         conditions.eventually {
-            listener.partitions.size() == 3
-            listener.partitions[0] == 2 // "key1" happens to result in this
-            listener.partitions[1] == 2 // "key2" happens to result in this
-            listener.partitions[2] == 1 // "key3" happens to result in this
-            listener.sentences.size() == 3
-            listener.sentences[0] == "sentence1"
-            listener.sentences[1] == "sentence2"
-            listener.sentences[2] == "sentence3"
+            listener.entries.size() == 3
+            listener.entries["sentence1"] == 2 // "key1" happens to result in this
+            listener.entries["sentence2"] == 2 // "key2" happens to result in this
+            listener.entries["sentence3"] == 1 // "key3" happens to result in this
         }
     }
 
     @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
-    @KafkaClient
+    @KafkaClient(acks = ALL)
     static interface ClientWithoutPartition {
         @Topic(KafkaPartitionSpec.TOPIC_WORDS)
         void sendSentence(@KafkaKey String key, String sentence)
     }
 
     @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
-    @KafkaClient
+    @KafkaClient(acks = ALL)
     static interface ClientWithIntPartition {
         @Topic(KafkaPartitionSpec.TOPIC_WORDS)
         void sendSentence(@KafkaPartition int partition, @KafkaKey String key, String sentence)
     }
 
     @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
-    @KafkaClient
+    @KafkaClient(acks = ALL)
     static interface ClientWithIntegerPartition {
         @Topic(KafkaPartitionSpec.TOPIC_WORDS)
         void sendSentence(@KafkaPartition Integer partition, @KafkaKey String key, String sentence)
     }
 
     @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
-    @KafkaClient
+    @KafkaClient(acks = ALL)
     static interface ClientWithPartitionKey {
         @Topic(KafkaPartitionSpec.TOPIC_WORDS)
         void sendSentence(@KafkaPartitionKey String partitionKey, @KafkaKey String key, String sentence)
@@ -201,13 +172,11 @@ class KafkaPartitionSpec extends AbstractKafkaContainerSpec {
     @Requires(property = 'spec.name', value = 'KafkaPartitionSpec')
     @KafkaListener(offsetReset = EARLIEST)
     static class SentenceListener {
-        Queue<Integer> partitions = new ConcurrentLinkedDeque<>()
-        Queue<String> sentences = new ConcurrentLinkedDeque<>()
+        ConcurrentHashMap<String, Integer> entries = new ConcurrentHashMap<>()
 
         @Topic(KafkaPartitionSpec.TOPIC_WORDS)
         void receive(@KafkaPartition int partition, String sentence) {
-            partitions << partition
-            sentences << sentence
+            entries.put(sentence, partition)
         }
     }
 }


### PR DESCRIPTION
Hi all,

Although I haven't faced this need in micronaut projects yet, I have found it potentially useful to control partitioning separately from record keys.

This is useful when Keys have specific functional requirement (deduplication, log compaction, etc), but where partitioning of a topic needs to be made on a separate field (often having a one to many relationship with record keys, although that's not a requirement).


This PR brings in the ability to do just that with two new additional annotations: `@KafkaPartition` and `@KafkaPartitionKey`.