### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/native-image.properties
+++ b/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/native-image.properties
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.apache.kafka,net.jpountz --initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator -H:AdditionalSecurityProviders=com.sun.security.sasl.Provider
+Args = --initialize-at-build-time=org.apache.kafka,net.jpountz \
+       -H:AdditionalSecurityProviders=com.sun.security.sasl.Provider \
+       --initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator,io.micronaut.configuration.kafka.health.$KafkaHealthIndicator$Definition,io.micronaut.configuration.kafka.tracing.$KafkaConsumerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.$KafkaProducerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaConsumerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaProducerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaTracingFactory$KafkaTracing0$Definition


### PR DESCRIPTION
This PR fixes the following warnings during native image creation

```
...
...
Warning: class initialization of class io.micronaut.configuration.kafka.health.$KafkaHealthIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/management/health/indicator/HealthIndicator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.health.$KafkaHealthIndicator$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.kafka.tracing.$KafkaConsumerTracingInstrumentation$Definition failed with exception java.lang.NoClassDefFoundError: io/opentracing/Tracer. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.tracing.$KafkaConsumerTracingInstrumentation$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.kafka.tracing.$KafkaProducerTracingInstrumentation$Definition failed with exception java.lang.NoClassDefFoundError: io/opentracing/Tracer. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.tracing.$KafkaProducerTracingInstrumentation$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaConsumerTracingInstrumentation$Definition failed with exception java.lang.NoClassDefFoundError: brave/kafka/clients/KafkaTracing. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaConsumerTracingInstrumentation$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaProducerTracingInstrumentation$Definition failed with exception java.lang.NoClassDefFoundError: brave/kafka/clients/KafkaTracing. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaProducerTracingInstrumentation$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaTracingFactory$KafkaTracing0$Definition failed with exception java.lang.NoClassDefFoundError: brave/Tracing. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaTracingFactory$KafkaTracing0$Definition to explicitly request delayed initialization of this class.
...
...
```