### PR TITLE
Update BookSenderTest.java

### DIFF
--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/inject/BookSenderTest.java
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/docs/producer/inject/BookSenderTest.java
@@ -1,6 +1,6 @@
 package io.micronaut.configuration.kafka.docs.producer.inject;
 
-import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import io.micronaut.configuration.kafka.docs.consumer.batch.Book;
 import io.micronaut.context.ApplicationContext;
 import org.junit.Test;
@@ -18,7 +18,7 @@ public class BookSenderTest {
         try (KafkaContainer container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))) {
             container.start();
             Map<String, Object> config = Collections.singletonMap( // <1>
-               AbstractKafkaConfiguration.DEFAULT_BOOTSTRAP_SERVERS,
+               ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
                container.getBootstrapServers()
             );
 


### PR DESCRIPTION
DEFAULT_BOOTSTRAP_SERVERS is defined as:
    public static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:" + DEFAULT_KAFKA_PORT;

we want to set the kafka.bootstrap.servers or simply bootstrap.servers as seems to be used in KafkaDefaultConfiguration

The code as it stands sets the property `localhost:9021` to the value of `localhost:<random port>` which then fails to connect.