### PR TITLE
Commit successful records on error

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
@@ -102,7 +102,7 @@ public interface ConsumerRegistry {
      * Pause the consumer for the given ID to consume from the given topic partitions.
      * Note that this method will request that the consumer is paused, however
      * does not block until the consumer is actually paused.
-     * You can use the {@link #isPaused(String, Collection<TopicPartition>)} method to
+     * You can use the {@link #isPaused(String, Collection)} method to
      * establish when the consumer has actually been paused for the topic partitions.
      *
      * @param id The id of the consumer
@@ -125,7 +125,7 @@ public interface ConsumerRegistry {
      * Resume the consumer for the given ID to consume from the given topic partitions.
      * Note that this method will request that the consumer is resumed, however
      * does not block until the consumer is actually resumed.
-     * You can use the {@link #isPaused(String, Collection<TopicPartition>)} method to
+     * You can use the {@link #isPaused(String, Collection)} method to
      * establish when the consumer has actually been resumed to consume from the given topic partitions.
      *
      * @param id The id of the consumer

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Setting the error strategy allows you to resume at the next offset
+ * or to seek the consumer (stop on error) to the failed offset so that
+ * it can retry if an error occurs.
+ *
+ * The consumer bean is still able to implement a custom exception handler to replace
+ * {@link io.micronaut.configuration.kafka.exceptions.DefaultKafkaListenerExceptionHandler}
+ * as well as set the error strategy.
+ *
+ * @since 4.1
+ * @author Christopher Webb
+ * @author Vishal Sulibhavi
+ * @author Denis Stepanov
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ErrorStrategy {
+
+    /**
+     * Default retry delay in seconds.
+     */
+    int DEFAULT_DELAY_IN_SECONDS = 1;
+
+    /**
+     * Default retry delay in seconds.
+     */
+    int DEFAULT_RETRY_COUNT = 1;
+
+    /**
+     * The delay used with RETRY_ON_ERROR {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
+     *
+     * @return the delay by which to wait for the next retry
+     */
+    String retryDelay() default DEFAULT_DELAY_IN_SECONDS + "s";
+
+    /**
+     * The retry count used with RETRY_ON_ERROR {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
+     *
+     * @return the retry count of how many attempts should be made
+     */
+    int retryCount() default DEFAULT_RETRY_COUNT;
+
+    /**
+     * The strategy to use when an error occurs, see {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
+     *
+     * @return the error strategy
+     */
+    ErrorStrategyValue value() default ErrorStrategyValue.NONE;
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+/**
+ * Defines the type of error handling strategy that micronaut-kafka will perform in case
+ * of error. The default exception handler or any custom exception handler will be performed
+ * after the error handling strategy has been run.
+ *
+ * @author Christopher Webb
+ * @author Vishal Sulibhavi
+ * @since 4.1
+ */
+public enum ErrorStrategyValue {
+    /**
+     * This strategy will stop consuming subsequent records in the case of an error and will
+     * attempt to re-consume the current record indefinitely.
+     */
+    RETRY_ON_ERROR,
+
+    /**
+     * This strategy will ignore the current error and will resume at the next offset.
+     */
+    RESUME_AT_NEXT_RECORD,
+
+    /**
+     * This error strategy will skip over all records from the current offset in
+     * the current poll when the consumer encounters an error.
+     *
+     * @deprecated maintain broken, but consistent behaviour with previous versions of micronaut-kafka that
+     * do not support error strategy.
+     *
+     * See https://github.com/micronaut-projects/micronaut-kafka/issues/372
+     */
+    @Deprecated
+    NONE
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -84,6 +84,19 @@ public @interface KafkaListener {
     OffsetReset offsetReset() default OffsetReset.LATEST;
 
     /**
+     * Setting the error strategy allows you to resume at the next offset
+     * or to seek the consumer (stop on error) to the failed offset so that
+     * it can retry if an error occurs
+     *
+     * The consumer bean is still able to implement a custom exception handler to replace
+     * {@link io.micronaut.configuration.kafka.exceptions.DefaultKafkaListenerExceptionHandler}
+     * and set the error strategy.
+     *
+     * @return The strategy to use when an error occurs
+     */
+    ErrorStrategy errorStrategy() default @ErrorStrategy();
+
+    /**
      * Kafka consumers are by default single threaded. If you wish to increase the number of threads
      * for a consumer you can alter this setting. Note that this means that multiple partitions will
      * be allocated to a single application.

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaSpec.groovy
@@ -5,7 +5,11 @@ import spock.util.concurrent.PollingConditions
 
 abstract class AbstractKafkaSpec extends Specification {
 
-    protected final PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+    protected final PollingConditions conditions = new PollingConditions(timeout: conditionsTimeout, delay: 1)
+
+    protected int getConditionsTimeout() {
+        30
+    }
 
     protected Map<String, Object> getConfiguration() {
         Map<String, Object> config = [:]

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -1,0 +1,154 @@
+package io.micronaut.configuration.kafka.errors
+
+import io.micronaut.configuration.kafka.AbstractEmbeddedServerSpec
+import io.micronaut.configuration.kafka.annotation.*
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.context.annotation.Requires
+import org.apache.kafka.common.TopicPartition
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.NONE
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RESUME_AT_NEXT_RECORD
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_ON_ERROR
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+import static io.micronaut.configuration.kafka.annotation.OffsetStrategy.SYNC
+
+class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
+
+    void "test when the error strategy is 'resume at next offset' the next message is consumed"() {
+        when:"A consumer throws an exception"
+        ResumeErrorClient myClient = context.getBean(ResumeErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+
+        ResumeAtNextRecordErrorCausingConsumer myConsumer = context.getBean(ResumeAtNextRecordErrorCausingConsumer)
+
+        then:"The message that threw the exception is skipped and the next message in the poll is processed"
+        conditions.eventually {
+            myConsumer.received == ["One", "Two"]
+            myConsumer.count.get() == 2
+        }
+    }
+
+    void "test when the error strategy is 'retry on error' the second message is not consumed"() {
+        when:"A consumer throws an exception"
+        RetryErrorClient myClient = context.getBean(RetryErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+
+        RetryOnErrorErrorCausingConsumer myConsumer = context.getBean(RetryOnErrorErrorCausingConsumer)
+
+        then:"The message that threw the exception is re-consumed"
+        conditions.eventually {
+            myConsumer.received == ["One", "One", "Two"]
+            myConsumer.count.get() == 3
+        }
+        and:"the retry of the first message is delivered at least 50ms afterwards"
+        myConsumer.times[1] - myConsumer.times[0] >= 50
+    }
+
+    /**
+     * @deprecated This test is deprecated as the poll next strategy is default to ensure backwards
+     * compatibility with existing (broken) functionality that people may have workarounds for with
+     * custom error handlers.
+     */
+    @Deprecated
+    void "test an exception that is thrown is not committed with default error strategy"() {
+        when:"A consumer throws an exception"
+        PollNextErrorClient myClient = context.getBean(PollNextErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+
+        PollNextErrorCausingConsumer myConsumer = context.getBean(PollNextErrorCausingConsumer)
+
+        then:"The message is re-delivered and eventually handled"
+        conditions.eventually {
+            myConsumer.received.size() == 2
+            myConsumer.count.get() == 3
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(offsetReset = EARLIEST, offsetStrategy = SYNC, errorStrategy = @ErrorStrategy(value = RESUME_AT_NEXT_RECORD))
+    static class ResumeAtNextRecordErrorCausingConsumer {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("errors-resume")
+        void handleMessage(String message) {
+            received.add(message)
+            if (count.getAndIncrement() == 0) {
+                throw new RuntimeException("Won't handle first")
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(
+        offsetReset = EARLIEST,
+        offsetStrategy = SYNC,
+        errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, retryDelay = "50ms")
+    )
+    static class RetryOnErrorErrorCausingConsumer {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+        List<Long> times = []
+
+        @Topic("errors-retry")
+        void handleMessage(String message) {
+            received.add(message)
+            times.add(System.currentTimeMillis())
+            if (count.getAndIncrement() == 0) {
+                throw new RuntimeException("Won't handle first")
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(offsetReset = EARLIEST, offsetStrategy = SYNC, errorStrategy = @ErrorStrategy(value = NONE))
+    static class PollNextErrorCausingConsumer implements KafkaListenerExceptionHandler {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("errors-poll")
+        void handleMessage(String message) {
+            if (count.getAndIncrement() == 1) {
+                throw new RuntimeException("Won't handle first")
+            }
+            received.add(message)
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            def record = exception.consumerRecord.orElse(null)
+            def consumer = exception.kafkaConsumer
+            consumer.seek(
+                    new TopicPartition("errors-poll", record.partition()),
+                    record.offset()
+            )
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface ResumeErrorClient {
+        @Topic("errors-resume")
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface RetryErrorClient {
+        @Topic("errors-retry")
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface PollNextErrorClient {
+        @Topic("errors-poll")
+        void sendMessage(String message)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorsSpec.groovy
@@ -55,15 +55,13 @@ class KafkaErrorsSpec extends AbstractEmbeddedServerSpec {
 
                 listenerWithErrorStrategyRetryOnError.failed.size() == 2 // One retry
                 listenerWithErrorStrategyRetryOnError.events.size() == 29
-//                listenerWithErrorStrategyRetryOnError.exceptions.size() == 1
+                listenerWithErrorStrategyRetryOnError.exceptions.size() == 1
 
                 listenerWithErrorStrategyRetryOnError10Times.failed.size() == 11 // 10 times retry
                 listenerWithErrorStrategyRetryOnError10Times.events.size() == 29
-//                listenerWithErrorStrategyRetryOnError10Times.exceptions.size() == 1
+                listenerWithErrorStrategyRetryOnError10Times.exceptions.size() == 1
 
                 listenerWithErrorStrategyNone.failed.size() == 1
-                listenerWithErrorStrategyNone.events.size() < 29 // some from the failed 10 records batch will be lost
-                listenerWithErrorStrategyNone.events.size() > 20
                 listenerWithErrorStrategyNone.events.stream().anyMatch(e -> e.count == 29)
                 listenerWithErrorStrategyNone.exceptions.size() == 1
             }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorsSpec.groovy
@@ -1,0 +1,134 @@
+package io.micronaut.configuration.kafka.errors
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import groovy.util.logging.Slf4j
+import io.micronaut.configuration.kafka.AbstractEmbeddedServerSpec
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaKey
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import spock.lang.Shared
+
+import java.util.stream.IntStream
+
+class KafkaErrorsSpec extends AbstractEmbeddedServerSpec {
+
+    @Shared
+    TestListenerWithErrorStrategyResumeAtNextRecord listenerWithErrorStrategyResumeAtNextRecord
+    @Shared
+    TestListenerWithErrorStrategyRetryOnError listenerWithErrorStrategyRetryOnError
+    @Shared
+    TestListenerWithErrorStrategyRetryOnError10Times listenerWithErrorStrategyRetryOnError10Times
+    @Shared
+    TestListenerWithErrorStrategyNone listenerWithErrorStrategyNone
+    @Shared
+    TestProducer producer
+
+    protected Map<String, Object> getConfiguration() {
+        super.configuration + ['kafka.consumers.default.max.poll.records': 10]
+    }
+
+    void setupSpec() {
+        listenerWithErrorStrategyResumeAtNextRecord = context.getBean(TestListenerWithErrorStrategyResumeAtNextRecord)
+        listenerWithErrorStrategyRetryOnError = context.getBean(TestListenerWithErrorStrategyRetryOnError)
+        listenerWithErrorStrategyRetryOnError10Times = context.getBean(TestListenerWithErrorStrategyRetryOnError10Times)
+        listenerWithErrorStrategyNone = context.getBean(TestListenerWithErrorStrategyNone)
+        producer = context.getBean(TestProducer)
+    }
+
+    def "should correctly handle error strategies"() {
+        when:
+            IntStream.range(0, 30).forEach { i -> producer.send(UUID.randomUUID(), new TestEvent(i)) }
+        then:
+            conditions.eventually {
+                listenerWithErrorStrategyResumeAtNextRecord.failed.size() == 1
+                listenerWithErrorStrategyResumeAtNextRecord.events.size() == 29
+                listenerWithErrorStrategyResumeAtNextRecord.exceptions.size() == 1
+
+                listenerWithErrorStrategyRetryOnError.failed.size() == 2 // One retry
+                listenerWithErrorStrategyRetryOnError.events.size() == 29
+//                listenerWithErrorStrategyRetryOnError.exceptions.size() == 1
+
+                listenerWithErrorStrategyRetryOnError10Times.failed.size() == 11 // 10 times retry
+                listenerWithErrorStrategyRetryOnError10Times.events.size() == 29
+//                listenerWithErrorStrategyRetryOnError10Times.exceptions.size() == 1
+
+                listenerWithErrorStrategyNone.failed.size() == 1
+                listenerWithErrorStrategyNone.events.size() < 29 // some from the failed 10 records batch will be lost
+                listenerWithErrorStrategyNone.events.size() > 20
+                listenerWithErrorStrategyNone.events.stream().anyMatch(e -> e.count == 29)
+                listenerWithErrorStrategyNone.exceptions.size() == 1
+            }
+    }
+
+    @Introspected
+    @EqualsAndHashCode
+    @ToString
+    static class TestEvent {
+
+        int count
+
+        TestEvent() {
+        }
+
+        TestEvent(int count) {
+            this.count = count
+        }
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, errorStrategy = @ErrorStrategy(value = ErrorStrategyValue.RESUME_AT_NEXT_RECORD))
+    static class TestListenerWithErrorStrategyResumeAtNextRecord extends AbstractTestListener {
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, errorStrategy = @ErrorStrategy(value = ErrorStrategyValue.RETRY_ON_ERROR))
+    static class TestListenerWithErrorStrategyRetryOnError extends AbstractTestListener {
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, errorStrategy = @ErrorStrategy(value = ErrorStrategyValue.RETRY_ON_ERROR, retryCount = 10))
+    static class TestListenerWithErrorStrategyRetryOnError10Times extends AbstractTestListener {
+    }
+
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST)
+    static class TestListenerWithErrorStrategyNone extends AbstractTestListener {
+    }
+
+    @Slf4j
+    @Requires(property = 'spec.name', value = 'KafkaErrorsSpec')
+    static abstract class AbstractTestListener implements KafkaListenerExceptionHandler {
+
+        List<TestEvent> failed = new ArrayList<>()
+        Set<TestEvent> events = new HashSet<>()
+        List<KafkaListenerException> exceptions = new ArrayList<>()
+
+        @Topic("test-topic")
+        void receive(@KafkaKey UUID key, TestEvent event) {
+            if (event.count == 3) {
+                failed.add(event)
+                throw new IllegalArgumentException("BOOM")
+            }
+            events.add(event)
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            exceptions.add(exception)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorsSpec')
+    @KafkaClient
+    static interface TestProducer {
+
+        @Topic("test-topic")
+        void send(@KafkaKey UUID key, TestEvent event);
+    }
+
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
@@ -1,0 +1,176 @@
+package io.micronaut.configuration.kafka.errors
+
+import io.micronaut.configuration.kafka.AbstractEmbeddedServerSpec
+import io.micronaut.configuration.kafka.ConsumerAware
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+import static io.micronaut.configuration.kafka.annotation.OffsetStrategy.SYNC
+import static io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration.EMBEDDED_TOPICS
+
+class KafkaShutdownHandlingSpec extends AbstractEmbeddedServerSpec {
+
+    protected Map<String, Object> getConfiguration() {
+        super.configuration +
+                [(EMBEDDED_TOPICS): ["wakeup", "wakeup-batch"]]
+    }
+
+    void "test wakeup does not commit"() {
+        given:
+            WakeupClient myClient = context.getBean(WakeupClient)
+            WakeupConsumer wakeupConsumer = context.getBean(WakeupConsumer)
+            KafkaConsumer<byte[], String> consumer = createKafkaConsumer()
+
+        when:"An exception occurs when consumer shuts down"
+            myClient.sendMessage("One")
+            myClient.sendMessage("Two")
+
+            ScheduledExecutorService schedule = Executors.newScheduledThreadPool(1)
+            schedule.schedule(() -> {
+                wakeupConsumer.wakeup()
+            }, 100, TimeUnit.MILLISECONDS)
+
+            // wait a moment for first wakeup / consumer to close
+            sleep(1_000)
+
+        then:"The messages are not committed"
+            TopicPartition topicPartition = new TopicPartition("wakeup", 0)
+            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Set.of(topicPartition))
+            offsetAndMetadata == null
+                    || offsetAndMetadata.get(topicPartition) == null
+                    || offsetAndMetadata.get(topicPartition).offset() == 0
+
+        cleanup:
+            consumer.close()
+    }
+
+    void "test batch shut down does not commit"() {
+        given:
+            WakeupBatchClient myClient = context.getBean(WakeupBatchClient)
+            WakeupBatchConsumer wakeupConsumer = context.getBean(WakeupBatchConsumer)
+            KafkaConsumer<byte[], String> consumer = createKafkaConsumer()
+
+        when:"An exception occurs when consumer shuts down"
+            myClient.sendMessage("One")
+            myClient.sendMessage("Two")
+
+            ScheduledExecutorService schedule = Executors.newScheduledThreadPool(1)
+            schedule.schedule(() -> {
+                wakeupConsumer.wakeup()
+            }, 100, TimeUnit.MILLISECONDS)
+
+            // wait a moment for first wakeup / consumer to close
+            sleep(1_000)
+
+
+        then:"The messages are not committed"
+            TopicPartition topicPartition = new TopicPartition("wakeup-batch", 0)
+            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Set.of(topicPartition))
+            offsetAndMetadata == null
+                    || offsetAndMetadata.get(topicPartition) == null
+                    || offsetAndMetadata.get(topicPartition).offset() == 0
+
+        cleanup:
+            consumer.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaShutdownHandlingSpec')
+    @KafkaListener(clientId = "shutdown-spec-wakeup-consumer", groupId = "myGroup", offsetReset = EARLIEST, offsetStrategy = SYNC)
+    static class WakeupConsumer implements ConsumerAware {
+        Consumer kafkaConsumer
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("wakeup")
+        void handleMessage(String message) {
+            sleep(500)
+            if (count.getAndIncrement() == 0) {
+                throw new RuntimeException("Won't handle first")
+            }
+
+            received.add(message)
+        }
+
+        @Override
+        void setKafkaConsumer(Consumer consumer) {
+            kafkaConsumer = consumer
+        }
+
+        void wakeup() {
+            kafkaConsumer.wakeup()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaShutdownHandlingSpec')
+    @KafkaListener(
+            clientId = "shutdown-spec-wakeup-batch-consumer",
+            groupId = "myGroup",
+            offsetReset = EARLIEST,
+            offsetStrategy = SYNC,
+            batch = true
+    )
+    static class WakeupBatchConsumer implements ConsumerAware {
+        Consumer kafkaConsumer
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+
+        @Topic("wakeup-batch")
+        void handleMessage(List<String> messages) {
+            for (String message : messages) {
+                sleep(500)
+                if (count.getAndIncrement() == 0) {
+                    throw new RuntimeException("Won't handle first")
+                }
+
+                received.add(message)
+            }
+        }
+
+        @Override
+        void setKafkaConsumer(Consumer consumer) {
+            kafkaConsumer = consumer
+        }
+
+        void wakeup() {
+            kafkaConsumer.wakeup()
+        }
+    }
+
+    KafkaConsumer<byte[], String> createKafkaConsumer() {
+        Properties props = new Properties()
+        props.setProperty("bootstrap.servers", kafkaContainer.bootstrapServers)
+        props.setProperty("enable.auto.commit", "false")
+        props.setProperty("auto.offset.reset", "earliest")
+        props.setProperty("group.id", "myGroup")
+        props.setProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+        props.setProperty("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
+
+        return new KafkaConsumer<>(props)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaShutdownHandlingSpec')
+    @KafkaClient
+    static interface WakeupClient {
+        @Topic("wakeup")
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaShutdownHandlingSpec')
+    @KafkaClient
+    static interface WakeupBatchClient {
+        @Topic("wakeup-batch")
+        void sendMessage(String message)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
@@ -49,8 +49,8 @@ class KafkaShutdownHandlingSpec extends AbstractEmbeddedServerSpec {
             TopicPartition topicPartition = new TopicPartition("wakeup", 0)
             Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed([topicPartition] as Set)
             offsetAndMetadata == null
-            offsetAndMetadata.get(topicPartition) == null
-            offsetAndMetadata.get(topicPartition).offset() == 0
+                    || offsetAndMetadata.get(topicPartition) == null
+                    || offsetAndMetadata.get(topicPartition).offset() == 0
 
         cleanup:
             consumer.close()
@@ -79,8 +79,8 @@ class KafkaShutdownHandlingSpec extends AbstractEmbeddedServerSpec {
             TopicPartition topicPartition = new TopicPartition("wakeup-batch", 0)
             Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed([topicPartition] as Set)
             offsetAndMetadata == null
-            offsetAndMetadata.get(topicPartition) == null
-            offsetAndMetadata.get(topicPartition).offset() == 0
+                    || offsetAndMetadata.get(topicPartition) == null
+                    || offsetAndMetadata.get(topicPartition).offset() == 0
 
         cleanup:
             consumer.close()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaShutdownHandlingSpec.groovy
@@ -47,10 +47,10 @@ class KafkaShutdownHandlingSpec extends AbstractEmbeddedServerSpec {
 
         then:"The messages are not committed"
             TopicPartition topicPartition = new TopicPartition("wakeup", 0)
-            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Set.of(topicPartition))
+            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed([topicPartition] as Set)
             offsetAndMetadata == null
-                    || offsetAndMetadata.get(topicPartition) == null
-                    || offsetAndMetadata.get(topicPartition).offset() == 0
+            offsetAndMetadata.get(topicPartition) == null
+            offsetAndMetadata.get(topicPartition).offset() == 0
 
         cleanup:
             consumer.close()
@@ -77,10 +77,10 @@ class KafkaShutdownHandlingSpec extends AbstractEmbeddedServerSpec {
 
         then:"The messages are not committed"
             TopicPartition topicPartition = new TopicPartition("wakeup-batch", 0)
-            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Set.of(topicPartition))
+            Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed([topicPartition] as Set)
             offsetAndMetadata == null
-                    || offsetAndMetadata.get(topicPartition) == null
-                    || offsetAndMetadata.get(topicPartition).offset() == 0
+            offsetAndMetadata.get(topicPartition) == null
+            offsetAndMetadata.get(topicPartition).offset() == 0
 
         cleanup:
             consumer.close()

--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -1,0 +1,32 @@
+=== Consumer error strategies
+
+It's possible to define a different error strategy for ann:configuration.kafka.annotation.KafkaListener[] using `errorStrategy` attribute:
+
+.Specifying an error strategy
+[source,java]
+----
+@KafkaListener(value = "myGroup", errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, retryDelay = "50ms", retryCount=3))
+----
+
+Setting the error strategy allows you to resume at the next offset or to seek the consumer (stop on error) to the failed offset so that it can retry if an error occurs.
+
+You can choose one of the error strategies:
+
+- `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and will attempt to re-consume the current record indefinitely. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`
+
+- `RETRY_ON_ERROR` - This strategy will ignore the current error and will resume at the next offset, in this case it's recommended to have a custom exception handler that moves the failed message into an error queue.
+
+- `NONE` - This error strategy will skip over all records from the current offset in the current poll when the consumer encounters an error. This option is deprecated and kept for consistent behaviour with previous versions of Micronaut Kafka that do not support error strategy.
+
+NOTE: The error strategies apply only for non-batch messages processing.
+
+
+=== Exception handlers
+
+When an exception occurs in a ann:configuration.kafka.annotation.KafkaListener[] method by default the exception is simply logged. This is handled by api:configuration.kafka.exceptions.DefaultKafkaListenerExceptionHandler[].
+
+If you wish to replace this default exception handling with another implementation you can use the Micronaut's <<replaces, Bean Replacement>> feature to define a bean that replaces it: `@Replaces(DefaultKafkaListenerExceptionHandler.class)`.
+
+You can also define per bean exception handling logic by implementing the api:configuration.kafka.exceptions.KafkaListenerExceptionHandler[] interface in your ann:configuration.kafka.annotation.KafkaListener[] class.
+
+The api:configuration.kafka.exceptions.KafkaListenerExceptionHandler[] receives an exception of type api:configuration.kafka.exceptions.KafkaListenerException[] which allows access to the original `ConsumerRecord`, if available.

--- a/src/main/docs/guide/kafkaListener/kafkaExceptions.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaExceptions.adoc
@@ -1,8 +1,0 @@
-When an exception occurs in a ann:configuration.kafka.annotation.KafkaListener[] method by default the exception is simply logged. This is handled by api:configuration.kafka.exceptions.DefaultKafkaListenerExceptionHandler[].
-
-If you wish to replace this default exception handling with another implementation you can use the Micronaut's <<replaces, Bean Replacement>> feature to define a bean that replaces it: `@Replaces(DefaultKafkaListenerExceptionHandler.class)`.
-
-
-You can also define per bean exception handling logic by implementing the api:configuration.kafka.exceptions.KafkaListenerExceptionHandler[] interface in your ann:configuration.kafka.annotation.KafkaListener[] class.
-
-The api:configuration.kafka.exceptions.KafkaListenerExceptionHandler[] receives an exception of type api:configuration.kafka.exceptions.KafkaListenerException[] which allows access to the original `ConsumerRecord`, if available.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -16,7 +16,7 @@ kafkaListener:
   kafkaOffsets: Commiting Kafka Offsets
   kafkaListenerBatch: Kafka Batch Processing
   kafkaSendTo: Forwarding Messages with @SendTo
-  kafkaExceptions: Handling Consumer Exceptions
+  kafkaErrors: Handling Consumer Exceptions
 kafkaApplications:
   title: Running Kafka Applications
   kafkaHealth: Kafka Health Checks


### PR DESCRIPTION
Fixes #372
Fixes #315 Replaces https://github.com/micronaut-projects/micronaut-kafka/pull/413

+ Refactoring of consumer implementation, extracting one consumer state bean and synchronizing on its state.