### PR TITLE
Fix Incorrect Error Strategy Item in KafkaErrors.adoc

### DIFF
--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -14,7 +14,7 @@ You can choose one of the error strategies:
 
 - `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and will attempt to re-consume the current record indefinitely. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`
 
-- `RETRY_ON_ERROR` - This strategy will ignore the current error and will resume at the next offset, in this case it's recommended to have a custom exception handler that moves the failed message into an error queue.
+- `RESUME_AT_NEXT_RECORD` - This strategy will ignore the current error and will resume at the next offset, in this case it's recommended to have a custom exception handler that moves the failed message into an error queue.
 
 - `NONE` - This error strategy will skip over all records from the current offset in the current poll when the consumer encounters an error. This option is deprecated and kept for consistent behaviour with previous versions of Micronaut Kafka that do not support error strategy.
 


### PR DESCRIPTION
KafkaErrors.adoc incorrectly includes `RETRY_ON_ERROR` error strategy twice. Updates second to `RESUME_AT_NEXT_RECORD`