### PR TITLE
Fix exception handling for reactive consumers

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -793,7 +793,7 @@ public class KafkaConsumerProcessor
                 });
 
         recordMetadataProducer = recordMetadataProducer.onErrorResume((Function<Throwable, Publisher<RecordMetadata>>) throwable -> {
-            handleException(consumerState, new KafkaListenerException(
+            handleException(consumerState.consumerBean, new KafkaListenerException(
                     "Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + method + "]: " + throwable.getMessage(),
                     throwable,
                     consumerState.consumerBean,
@@ -823,7 +823,7 @@ public class KafkaConsumerProcessor
                     );
 
                     return producerSend(consumerState, kafkaProducer, record).doOnError(ex -> {
-                        handleException(consumerState, new KafkaListenerException(
+                        handleException(consumerState.consumerBean, new KafkaListenerException(
                                 "Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + method + "]: " + throwable.getMessage(),
                                 throwable,
                                 consumerState.consumerBean,

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorHandlingSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
 import io.micronaut.context.annotation.Requires
 import org.apache.kafka.common.TopicPartition
+import reactor.core.publisher.Mono
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -37,6 +38,19 @@ class KafkaErrorHandlingSpec extends AbstractEmbeddedServerSpec {
         }
     }
 
+    void "test custom exception handler in reactive consumer"() {
+        when:"A reactive consumer with custom exception handler throws a Mono error"
+        ErrorClient myClient = context.getBean(ErrorClient)
+        myClient.sendMessage("One")
+
+        ErrorCausingReactiveConsumer myConsumer = context.getBean(ErrorCausingReactiveConsumer)
+
+        then:"The bean's exception handler is used"
+        conditions.eventually {
+            myConsumer.exceptionHandled
+        }
+    }
+
     @Requires(property = 'spec.name', value = 'KafkaErrorHandlingSpec')
     @KafkaListener(offsetReset = EARLIEST, offsetStrategy = SYNC)
     static class ErrorCausingConsumer implements KafkaListenerExceptionHandler {
@@ -59,6 +73,22 @@ class KafkaErrorHandlingSpec extends AbstractEmbeddedServerSpec {
                     new TopicPartition("errors", record.partition()),
                     record.offset()
             )
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorHandlingSpec')
+    @KafkaListener(offsetReset = EARLIEST, offsetStrategy = SYNC)
+    static class ErrorCausingReactiveConsumer implements KafkaListenerExceptionHandler {
+        boolean exceptionHandled = false
+
+        @Topic("errors")
+        Mono<Void> handleMessage(String message) {
+            return Mono.error(new RuntimeException())
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            this.exceptionHandled = true
         }
     }
 


### PR DESCRIPTION
Version 4.1.0 introduced a bug for reactive consumers, the `DefaultKafkaListenerExceptionHandler` is always used even when a bean implements its own `KafkaListenerExceptionHandler`.

The problem was introduced here https://github.com/micronaut-projects/micronaut-kafka/pull/441, there are a couple of calls to the `handleException()` that expects a `consumerBean` which are receiving a `consumerState`. Added a test to verify that the simple fix works.

cc @dstepanov 