### PR TITLE
build: pin graal-sdk

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-module.gradle
@@ -24,3 +24,10 @@ dependencies {
 test {
     maxHeapSize = '2048m'
 }
+
+
+configurations.all {
+    resolutionStrategy {
+        force 'org.graalvm.sdk:graal-sdk:22.0.0.2'
+    }
+}


### PR DESCRIPTION
This an attempt to solve: 

https://github.com/micronaut-projects/micronaut-kafka/runs/7275178598?check_suite_focus=true

```
import org.graalvm.nativeimage.hosted.Feature;
[84](https://github.com/micronaut-projects/micronaut-kafka/runs/7275178598?check_suite_focus=true#step:10:85)
                                     ^
[85](https://github.com/micronaut-projects/micronaut-kafka/runs/7275178598?check_suite_focus=true#step:10:86)
  bad class file: /home/runner/.gradle/caches/modules-2/files-2.1/org.graalvm.sdk/graal-sdk/22.1.0.1/dbdb86af102a25d64a59b828937894576a5700d1/graal-sdk-22.1.0.1.jar(org/graalvm/nativeimage/hosted/Feature.class)
[86](https://github.com/micronaut-projects/micronaut-kafka/runs/7275178598?check_suite_focus=true#step:10:87)
    class file has wrong version 55.0, should be 52.0
```