### PR TITLE
build: target Micronaut 4.0.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-kafka
 developers=Graeme Rocher
 
-githubCoreBranch=3.6.x
+githubCoreBranch=4.0.x
 bomProperty=micronautKafkaVersion
 
 testskafka=kafka/src/test/groovy/io/micronaut/configuration/kafka/docs


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-core/wiki/Module-Upgrade-Strategy

> A major version of the module will be included in a minor version of Micronaut only if we are sure that the change will not introduce breaking changes in users apps.

We think updating from Kafka 2 to Kafka 3 may break user applications

[ci skip]