### PR TITLE
bug: Failure with nativecompile

### DIFF
--- a/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/native-image.properties
+++ b/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/native-image.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.apache.kafka,net.jpountz \
+Args = --initialize-at-build-time=org.apache.kafka,net.jpountz,com.sun.org.slf4j.internal.Logger \
        -H:AdditionalSecurityProviders=com.sun.security.sasl.Provider \
        --initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator,io.micronaut.configuration.kafka.health.$KafkaHealthIndicator$Definition,io.micronaut.configuration.kafka.tracing.$KafkaConsumerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.$KafkaProducerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaConsumerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaProducerTracingInstrumentation$Definition,io.micronaut.configuration.kafka.tracing.brave.$BraveKafkaTracingFactory$KafkaTracing0$Definition

--- a/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/reflect-config.json
+++ b/kafka/src/main/resources/META-INF/native-image/io.micronaut.kafka/micronaut-kafka/reflect-config.json
@@ -126,10 +126,5 @@
   {
     "name":"sun.security.x509.SubjectKeyIdentifierExtension",
     "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
-  },
-  {
-    "name":"org.apache.commons.compress.archivers.ArchiveOutputStream",
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
   }
 ]


### PR DESCRIPTION
This tags com.sun.org.slf4j.internal.Logger as being required at build time
without this, it breaks with Graal 17 22.2

It also removes the reflection on org.apache.commons.compress.archivers.ArchiveOutputStream
which Graal complains is not on the classpath, and I don't believe is required any more

Fixes #574 