### PR TITLE
Fix kafka consumer shutdown

### DIFF
--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaPartitionedErrorsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaPartitionedErrorsSpec.groovy
@@ -1,10 +1,12 @@
 package io.micronaut.configuration.kafka.errors
 
+import spock.lang.Ignore
 import spock.lang.Stepwise
 import spock.lang.Retry
 
 @Stepwise
 @Retry
+@Ignore("https://github.com/micronaut-projects/micronaut-kafka/issues/514")
 class KafkaPartitionedErrorsSpec extends KafkaErrorsSpec {
 
     @Override


### PR DESCRIPTION
This makes the `close()` method of `KafkaConsumerProcessor` wait for all
consumers to be properly closed

Refs #601
