### PR TITLE
Update kafkaErrors.adoc

### DIFF
--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -12,7 +12,7 @@ Setting the error strategy allows you to resume at the next offset or to seek th
 
 You can choose one of the error strategies:
 
-- `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and will attempt to re-consume the current record indefinitely. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`
+- `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`
 
 - `RESUME_AT_NEXT_RECORD` - This strategy will ignore the current error and will resume at the next offset, in this case it's recommended to have a custom exception handler that moves the failed message into an error queue.
 


### PR DESCRIPTION
Existing doc on error handling strategies states that using `RETRY_ON_ERROR` will retry consuming events indefinitely. That does not seem to square with the source of the `@ErrorStrategy` annotation where the default behaviour is that only a single retry is attempted unless the `retryCount` property is set to some other value.