### PR TITLE
Dont pause TopicPartitions the consumer is not assigned to

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -445,7 +445,7 @@ class KafkaConsumerProcessor
 
             //noinspection InfiniteLoopStatement
             while (true) {
-                consumerState.assignments = Collections.unmodifiableSet(kafkaConsumer.assignment());
+                consumerState.updateAssignments();
                 if (consumerState.autoPaused) {
                     consumerState.pause(consumerState.assignments);
                     kafkaConsumer.pause(consumerState.assignments);
@@ -1125,6 +1125,12 @@ class KafkaConsumerProcessor
             _pausedTopicPartitions.addAll(_pauseRequests);
         }
 
+        synchronized void updateAssignments() {
+            assignments = Collections.unmodifiableSet(kafkaConsumer.assignment());
+            if (_pauseRequests != null && _pauseRequests.retainAll(assignments)) {
+                LOG.error("Pending pause requests for Consumer [{}] were invalidated because the consumer assignments changed", clientId);
+            }
+        }
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '5.3.14'
+        id 'io.micronaut.build.shared.settings' version '6.0.2'
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
Fixes #610 which is caused by a retried record and rebalance occuring simultaneously, e.g. if the record handler both takes too long, and throws an exception.

Because assignments are only updated on calls to `poll()`, I don't believe it is possible to respect the RETRY_DELAY via the `pause()` mechanism that the retry logic currently uses when the consumer is rebalanced