### PR TITLE
[#610] Dont pause unassigned TopicPartitions

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -445,8 +445,8 @@ class KafkaConsumerProcessor
 
             //noinspection InfiniteLoopStatement
             while (true) {
-                final var newAssignments = Collections.unmodifiableSet(kafkaConsumer.assignment());
-                if (!newAssignments.equals(consumerState.assignments)) {
+                final Set<TopicPartition> newAssignments = Collections.unmodifiableSet(kafkaConsumer.assignment());
+                if (LOG.isInfoEnabled() && !newAssignments.equals(consumerState.assignments)) {
                     LOG.info("Consumer [{}] assignments changed: {} -> {}", consumerState.clientId, consumerState.assignments, newAssignments);
                 }
                 consumerState.assignments = newAssignments;
@@ -1127,7 +1127,7 @@ class KafkaConsumerProcessor
             if (validPauseRequests.isEmpty()) {
                 return;
             }
-            LOG.debug("Pausing Kafka consumption for Consumer [{}] from topic partition: {}", clientId, validPauseRequests);
+            LOG.trace("Pausing Kafka consumption for Consumer [{}] from topic partition: {}", clientId, validPauseRequests);
             kafkaConsumer.pause(validPauseRequests);
             LOG.debug("Paused Kafka consumption for Consumer [{}] from topic partition: {}", clientId, kafkaConsumer.paused());
             if (_pausedTopicPartitions == null) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1117,14 +1117,19 @@ class KafkaConsumerProcessor
             if (_pauseRequests == null || _pauseRequests.isEmpty()) {
                 return;
             }
-            kafkaConsumer.pause(_pauseRequests);
+            // Only attempt to pause actual assignments
+            Set<TopicPartition> validPauseRequests = new HashSet<>(_pauseRequests);
+            validPauseRequests.retainAll(assignments);
+            if (validPauseRequests.isEmpty()) {
+                return;
+            }
+            kafkaConsumer.pause(validPauseRequests);
             LOG.debug("Paused Kafka consumption for Consumer [{}] from topic partition: {}", clientId, kafkaConsumer.paused());
             if (_pausedTopicPartitions == null) {
                 _pausedTopicPartitions = new HashSet<>();
             }
-            _pausedTopicPartitions.addAll(_pauseRequests);
+            _pausedTopicPartitions.addAll(validPauseRequests);
         }
-
     }
 
     /**

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -111,9 +111,9 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
     @KafkaListener(
-            offsetReset = EARLIEST,
-            offsetStrategy = SYNC,
-            errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, retryDelay = "50ms")
+        offsetReset = EARLIEST,
+        offsetStrategy = SYNC,
+        errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, retryDelay = "50ms")
     )
     static class RetryOnErrorErrorCausingConsumer {
         AtomicInteger count = new AtomicInteger(0)
@@ -156,7 +156,11 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     }
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
-    @KafkaListener(offsetReset = EARLIEST, errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR), properties = @Property(name = ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, value = "5000"))
+    @KafkaListener(
+        offsetReset = EARLIEST,
+        errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR),
+        properties = @Property(name = ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, value = "5000")
+    )
     static class RetryAndRebalanceOnErrorErrorCausingConsumer implements KafkaListenerExceptionHandler {
         AtomicInteger count = new AtomicInteger(0)
         AtomicInteger exceptionCount = new AtomicInteger(0)

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -67,7 +67,7 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         conditions.eventually {
             myConsumer.received == ["One", "One", "Two"]
             myConsumer.count.get() == 3
-            myConsumer.exceptionCount.get() == 1
+            myConsumer.exceptionCount.get() == 0
         }
         and:"the retry of the first message is delivered at least 5000ms afterwards"
         myConsumer.times[1] - myConsumer.times[0] >= 5_000
@@ -165,17 +165,17 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
         @Topic("errors-timeout-and-retry")
         void handleMessage(String message) {
-            received << message;
+            received << message
             times << System.currentTimeMillis()
             if (count.getAndIncrement() == 0) {
-                Thread.sleep(10_000);
+                Thread.sleep(10_000)
                 throw new RuntimeException("Won't handle first")
             }
         }
 
         @Override
         void handle(KafkaListenerException exception) {
-            exceptionCount.getAndIncrement();
+            exceptionCount.getAndIncrement()
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '6.0.2'
+        id 'io.micronaut.build.shared.settings' version '5.3.14'
     }
     repositories {
         gradlePluginPortal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '5.3.14'
+        id 'io.micronaut.build.shared.settings' version '6.0.2'
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-kafka/issues/610 which is caused by a retried record and rebalance occuring simultaneously, e.g. if the record handler both takes too long, and throws an exception.

Because assignments are only updated on calls to poll(), I don't believe it is possible to respect the RETRY_DELAY via the pause() mechanism that the retry logic currently uses.