### PR TITLE
Fix graalvm issues with micronaut-kafka not working

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1039,9 +1039,9 @@ class KafkaConsumerProcessor
             redelivery = kafkaListener.isTrue("redelivery");
 
             AnnotationValue<ErrorStrategy> errorStrategyAnnotation = kafkaListener.getAnnotation("errorStrategy", ErrorStrategy.class).orElse(null);
-            errorStrategy = errorStrategyAnnotation == null ? ErrorStrategyValue.NONE : kafkaListener.get("errorStrategy", ErrorStrategy.class)
-                    .map(ErrorStrategy::value)
-                    .orElse(ErrorStrategyValue.NONE);
+            errorStrategy = errorStrategyAnnotation != null
+                ? errorStrategyAnnotation.getRequiredValue(ErrorStrategyValue.class)
+                : ErrorStrategyValue.NONE;
 
             if (errorStrategy == ErrorStrategyValue.RETRY_ON_ERROR) {
                 Duration retryDelay = errorStrategyAnnotation.get("retryDelay", Duration.class)


### PR DESCRIPTION
If you set a value for errorStrategy, micronaut-kafka was not working with graalvm. I got the following stacktrace:

```2023-02-02 15:11:32.383 [main] ERROR io.micronaut.runtime.Micronaut - Error starting Micronaut server: Proxy class defined by interfaces [interface io.micronaut.configuration.kafka.annotation.ErrorStrategy, interface io.micronaut.core.annotation.AnnotationValueProvider] not found. Generating proxy classes at runtime is not supported. Proxy classes need to be defined at image build time by specifying the list of interfaces that they implement. To define proxy classes use -H:DynamicProxyConfigurationFiles=<comma-separated-config-files> and -H:DynamicProxyConfigurationResources=<comma-separated-config-resources> options.
com.oracle.svm.core.jdk.UnsupportedFeatureError: Proxy class defined by interfaces [interface io.micronaut.configuration.kafka.annotation.ErrorStrategy, interface io.micronaut.core.annotation.AnnotationValueProvider] not found. Generating proxy classes at runtime is not supported. Proxy classes need to be defined at image build time by specifying the list of interfaces that they implement. To define proxy classes use -H:DynamicProxyConfigurationFiles=<comma-separated-config-files> and -H:DynamicProxyConfigurationResources=<comma-separated-config-resources> options.
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:89)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:171)
	at java.base@17.0.5/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:47)
	at java.base@17.0.5/java.lang.reflect.Proxy.getProxyClass(Proxy.java:398)
	at io.micronaut.inject.annotation.AnnotationMetadataSupport.lambda$getProxyClass$3(AnnotationMetadataSupport.java:272)
	at java.base@17.0.5/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.micronaut.inject.annotation.AnnotationMetadataSupport.getProxyClass(AnnotationMetadataSupport.java:271)
	at io.micronaut.inject.annotation.AnnotationMetadataSupport.buildAnnotation(AnnotationMetadataSupport.java:284)
	at io.micronaut.inject.annotation.AnnotationConvertersRegistrar.lambda$register$0(AnnotationConvertersRegistrar.java:42)
	at java.base@17.0.5/java.util.Optional.map(Optional.java:260)
	at io.micronaut.inject.annotation.AnnotationConvertersRegistrar.lambda$register$1(AnnotationConvertersRegistrar.java:42)
	at io.micronaut.core.convert.DefaultConversionService.convert(DefaultConversionService.java:155)
	at io.micronaut.core.convert.ConversionService.convert(ConversionService.java:117)
	at io.micronaut.core.convert.value.ConvertibleValuesMap.get(ConvertibleValuesMap.java:83)
	at io.micronaut.core.annotation.AnnotationValue.get(AnnotationValue.java:1016)
	at io.micronaut.core.value.ValueResolver.get(ValueResolver.java:53)
	at io.micronaut.configuration.kafka.processor.KafkaConsumerProcessor$ConsumerState.<init>(KafkaConsumerProcessor.java:1042)
	at io.micronaut.configuration.kafka.processor.KafkaConsumerProcessor$ConsumerState.<init>(KafkaConsumerProcessor.java:993)
	at io.micronaut.configuration.kafka.processor.KafkaConsumerProcessor.submitConsumerThread(KafkaConsumerProcessor.java:423)
	at io.micronaut.configuration.kafka.processor.KafkaConsumerProcessor.submitConsumerThreads(KafkaConsumerProcessor.java:404)
	at io.micronaut.configuration.kafka.processor.KafkaConsumerProcessor.process(KafkaConsumerProcessor.java:309)
	at io.micronaut.context.DefaultBeanContext.lambda$initializeContext$39(DefaultBeanContext.java:1996)
	at java.base@17.0.5/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base@17.0.5/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base@17.0.5/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base@17.0.5/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base@17.0.5/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base@17.0.5/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base@17.0.5/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base@17.0.5/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base@17.0.5/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at io.micronaut.context.DefaultBeanContext.lambda$initializeContext$40(DefaultBeanContext.java:1969)
	at java.base@17.0.5/java.util.HashMap.forEach(HashMap.java:1421)
	at io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:1967)
	at io.micronaut.context.DefaultApplicationContext.initializeContext(DefaultApplicationContext.java:249)
	at io.micronaut.context.DefaultBeanContext.readAllBeanDefinitionClasses(DefaultBeanContext.java:3326)
	at io.micronaut.context.DefaultBeanContext.finalizeConfiguration(DefaultBeanContext.java:3684)
	at io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:341)
	at io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:194)
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:75)```