### PR TITLE
Improve docs for `@KafkaClient`/`@KafkaListener` behavior

### DIFF
--- a/src/main/docs/guide/kafkaClient/kafkaClientConfiguration.adoc
+++ b/src/main/docs/guide/kafkaClient/kafkaClientConfiguration.adoc
@@ -9,9 +9,12 @@ kafka:
     producers:
         default:
             retries: 5
+            bootstrap:
+              servers: localhost:9096
+
 ----
 
-Any property in the link:{kafkaapi}/org/apache/kafka/clients/producer/ProducerConfig.html[ProducerConfig] class can be set. The above example will set the default number of times to retry sending a record.
+Any property in the link:{kafkaapi}/org/apache/kafka/clients/producer/ProducerConfig.html[ProducerConfig] class can be set, _including_ any overrides over the global Micronaut Kafka configs. The above example will set the default number of times to retry sending a record as well as override `kafka.bootstrap.servers`.
 
 === Per @KafkaClient Producer Properties
 
@@ -32,6 +35,11 @@ kafka:
     producers:
         product-client:
             retries: 5
+            bootstrap:
+              servers: localhost:9097
+        product-client-2:
+            bootstrap:
+              servers: localhost:9098
 ----
 
 Finally, the ann:configuration.kafka.annotation.KafkaClient[] annotation itself provides a `properties` member that you can use to set producer specific properties:

--- a/src/main/docs/guide/kafkaListener.adoc
+++ b/src/main/docs/guide/kafkaListener.adoc
@@ -29,3 +29,17 @@ The above example will create 10 link:{kafkaapi}/org/apache/kafka/clients/consum
 NOTE: @KafkaListener beans are by default singleton. When using multiple threads you must either synchronize access to local state or declare the bean as `@Prototype`.
 
 By default Micronaut will inspect the method signature of the method annotated with `@Topic` that will listen for `ConsumerRecord` instances and from the types infer an appropriate key and value link:{kafkaapi}/org/apache/kafka/common/serialization/Deserializer.html[Deserializer].
+
+.Applying Configuration
+[source,yaml]
+----
+kafka:
+    consumers:
+        default:
+            allow.auto.create.topics: true
+        product:
+            bootstrap:
+              servers: localhost:9098
+----
+
+Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the . The above example will enable the consumer to create a topic if it doesn't exist for the `default` (`@KafkaListener`) client and set a custom bootstrap server for the `product` client (`@KafkaListener(value = "product")`)


### PR DESCRIPTION
A colleague and I had some issues figuring out how to apply custom bootstrap server configs for different `@KafkaClient` instances. Once we figured out the intended way to do it, I figured we should add some docs on it.