### PR TITLE
Skip string metrics (like these: 'kafka.producer.commit-id', 'version', 'commitId', 'applicationId', 'topologyDescription')

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterType.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterType.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
 @Internal
 class KafkaMetricMeterType {
     private MeterType meterType = MeterType.GAUGE;
-    private String description = null;
+    private String description;
     private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
-    private String baseUnit = null;
+    private String baseUnit;
 
     /**
      * Class for hosing a metric type, description, time unit and base unit.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * A builder class for constructing a typed kafka meter.  Will lookup the
+ * A builder class for constructing a typed kafka meter.  Will look up the
  * type in {@link KafkaMetricMeterTypeRegistry}.  Supported meter types can
  * be seen in {@link MeterType}.
  *
@@ -131,7 +131,7 @@ public class KafkaMetricMeterTypeBuilder {
             name = kafkaMetric.metricName().name();
         }
 
-        KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
+        KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(name);
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE) {
                 return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
@@ -139,13 +139,13 @@ public class KafkaMetricMeterTypeBuilder {
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
-        } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && this.kafkaMetric.metricValue() instanceof Double) {
+        } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && kafkaMetric.metricValue() instanceof Double) {
             return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, value -> (Double) value.metricValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
-        } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && this.kafkaMetric.metricValue() instanceof Double) {
+        } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && kafkaMetric.metricValue() instanceof Double) {
             return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), value -> (Double) value.metricValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
@@ -159,6 +159,7 @@ public class KafkaMetricMeterTypeBuilder {
         return tagFunction != null &&
                 meterRegistry != null &&
                 kafkaMetric != null &&
+                kafkaMetric.metricValue() instanceof Number &&
                 StringUtils.isNotEmpty(prefix);
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeRegistry.java
@@ -45,7 +45,7 @@ class KafkaMetricMeterTypeRegistry {
     /**
      * Constructor that will populate the metric name to type map.
      */
-    public KafkaMetricMeterTypeRegistry() {
+    KafkaMetricMeterTypeRegistry() {
         meterTypeMap = new HashMap<>();
         meterTypeMap.put("records-lag", new KafkaMetricMeterType(MeterType.GAUGE, "The latest lag of the partition", RECORDS));
         meterTypeMap.put("records-lag-avg", new KafkaMetricMeterType(MeterType.GAUGE, "The average lag of the partition", RECORDS));


### PR DESCRIPTION
Fixed #648 and #671

Fixes exceptions like this:
```
WARN [0;39m [35mi.m.c.i.internal.DefaultGauge[0;39m - Failed to apply the value function for the gauge 'kafka.producer.commit-id'. Note that subsequent logs will be logged at debug level.
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
at io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilder.lambda$build$0(KafkaMetricMeterTypeBuilder.java:137)
at io.micrometer.core.instrument.Gauge.lambda$builder$0(Gauge.java:58)
at io.micrometer.core.instrument.StrongReferenceGaugeFunction.applyAsDouble(StrongReferenceGaugeFunction.java:48)
at io.micrometer.core.instrument.internal.DefaultGauge.value(DefaultGauge.java:53)
at io.micrometer.prometheus.PrometheusMeterRegistry.lambda$newGauge$5(PrometheusMeterRegistry.java:331)
at io.micrometer.prometheus.MicrometerCollector.collect(MicrometerCollector.java:75)
at io.prometheus.client.Collector.collect(Collector.java:45)
at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:204)
at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:219)

```