### PR TITLE
docs(OffsetStrategy): align with docs and implementation

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/OffsetStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/OffsetStrategy.java
@@ -43,11 +43,11 @@ public enum OffsetStrategy {
      */
     ASYNC,
     /**
-     * Synchronously commit offsets using {@link org.apache.kafka.clients.consumer.Consumer#commitSync()} after each {@link org.apache.kafka.clients.consumer.ConsumerRecord} is consumed.
+     * Synchronously commit offsets using {@link org.apache.kafka.clients.consumer.Consumer#commitSync()} after each {@link org.apache.kafka.clients.consumer.ConsumerRecord} is processed.
      */
     SYNC_PER_RECORD,
     /**
-     * Asynchronously commit offsets using {@link org.apache.kafka.clients.consumer.Consumer#commitSync()} after each {@link org.apache.kafka.clients.consumer.ConsumerRecord} is consumed.
+     * Asynchronously commit offsets using {@link org.apache.kafka.clients.consumer.Consumer#commitSync()} after each {@link org.apache.kafka.clients.consumer.ConsumerRecord} is processed.
      */
     ASYNC_PER_RECORD,
     /**


### PR DESCRIPTION
The documentation for `SYNC_PER_RECORD` and `ASYNC_PER_RECORD` were out of sync with other messaging. This change aligns the wording with the wording used in `SYNC` and `ASYNC` as well as with the official documentation for the micronaut-kafka module using the term "processed" to mean after a KafkaListener handles and acts on a ConsumerRecord.

official documentation: https://micronaut-projects.github.io/micronaut-kafka/4.5.2/guide/#kafkaOffsets

This also clarifies that the implementation calls Kafka commit methods AFTER a message is processed as defined by the current implementation

https://github.com/micronaut-projects/micronaut-kafka/blob/b5c9ebb1f9df6679a3b49ac874616ec1ff59444c/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java#LL515-L562C10