### PR TITLE
#705 Log exception thrown from custom exception handler

### DIFF
--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation libs.opentracing.mock
     testImplementation libs.opentracing.kafka.client
     testImplementation mn.micronaut.rxjava2
+    testImplementation 'io.github.hakky54:logcaptor:2.9.0'
 
     testRuntimeOnly mn.micronaut.micrometer.registry.statsd
     testRuntimeOnly mn.micronaut.tracing.core

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -499,6 +499,9 @@ class KafkaConsumerProcessor
             }
         } catch (WakeupException e) {
             consumerState.closedState = ConsumerCloseState.CLOSED;
+        } catch (Throwable ex) {
+            consumerState.closedState = ConsumerCloseState.CLOSED;
+            LOG.error("Unhandled exception caused infinite loop exit: {}", ex.getMessage(), ex);
         }
     }
 


### PR DESCRIPTION
Uncaught exceptions cause breaking infinite loop. These exceptions can originate from custom exception handler for listener.
This change catches unhandled exception and log it so in case of a bug it will be easier to debug and understand what caused closing kafka consumer.

