### PR TITLE
Issue-713

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/graal/KafkaSubstitutions.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/graal/KafkaSubstitutions.java
@@ -44,7 +44,6 @@ final class ChecksumFeature implements Feature {
 }
 
 @TargetClass(className = "org.apache.kafka.common.utils.Crc32C$Java9ChecksumFactory")
-@Substitute
 final class Java9ChecksumFactory {
 
     @Substitute

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '5.4.6'
+        id 'io.micronaut.build.shared.settings' version '5.4.9'
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
The `java.lang.IncompatibleClassChangeError` in Micronaut Kafka 4.5.x when running native image (GraalVM 23.0.x).

More details are at https://github.com/micronaut-projects/micronaut-kafka/issues/713 .
