### PR TITLE
Replace deprecated method call `findArgumentBinder`

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/bind/batch/BatchConsumerRecordsBinderRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/bind/batch/BatchConsumerRecordsBinderRegistry.java
@@ -65,8 +65,7 @@ public class BatchConsumerRecordsBinderRegistry implements ArgumentBinderRegistr
 
             return Optional.of((context, consumerRecords) -> {
                 for (ConsumerRecord<?, ?> consumerRecord : consumerRecords) {
-                    Optional<ArgumentBinder<?, ConsumerRecord<?, ?>>> binder = consumerRecordBinderRegistry.findArgumentBinder((Argument) argument, consumerRecord);
-                    binder.ifPresent(b -> {
+                    consumerRecordBinderRegistry.findArgumentBinder(argument).ifPresent(b -> {
                         Argument<?> newArg = Argument.of(batchType.getType(), argument.getName(), argument.getAnnotationMetadata(), batchType.getTypeParameters());
                         ArgumentConversionContext conversionContext = ConversionContext.of(newArg);
                         ArgumentBinder.BindingResult<?> result = b.bind(


### PR DESCRIPTION
`findArgumentBinder(io.micronaut.core.type.Argument<T>, S)` is deprecated and marked for removal