### PR TITLE
CI never ends for unit tests with manual test container lifecycle control

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.0.3-SNAPSHOT
+projectVersion=5.1.0-SNAPSHOT
 projectGroup=io.micronaut.kafka
 
 title=Micronaut Kafka

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.1.0-SNAPSHOT
+projectVersion=5.0.3-SNAPSHOT
 projectGroup=io.micronaut.kafka
 
 title=Micronaut Kafka

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1084,7 +1084,7 @@ class KafkaConsumerProcessor
         final boolean useSendOffsetsToTransaction;
         final boolean isMessageReturnType;
         final boolean isMessagesIterableReturnType;
-        ConsumerCloseState closedState;
+        volatile ConsumerCloseState closedState;
 
         private ConsumerState(String clientId, String groupId, OffsetStrategy offsetStrategy, Consumer<?, ?> consumer, Object consumerBean, Set<String> subscriptions,
                               AnnotationValue<KafkaListener> kafkaListener, ExecutableMethod<?, ?> method) {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/MyTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/MyTest.groovy
@@ -4,14 +4,12 @@ import io.micronaut.configuration.kafka.annotation.*
 import io.micronaut.context.annotation.*
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import spock.lang.Ignore
 
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.awaitility.Awaitility.await
 
 @Property(name = "spec.name", value = "MyTest")
 @MicronautTest
-@Ignore("It hangs forever in the CI")
 class MyTest extends AbstractKafkaTest {
 
     @Inject

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
@@ -10,7 +10,6 @@ import java.util.concurrent.*
 @Property(name = "spec.name", value = "MyTest")
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Disabled("It hangs forever in the CI")
 internal class MyTest : AbstractKafkaTest() {
     @Test
     fun testKafkaRunning(producer: MyProducer, consumer: MyConsumer) {

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
@@ -11,7 +11,6 @@ import static org.awaitility.Awaitility.await;
 @Property(name = "spec.name", value = "MyTest")
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Disabled("It hangs forever in the CI")
 class MyTest extends AbstractKafkaTest {
     @Test
     void testKafkaRunning(MyProducer producer, MyConsumer consumer) {


### PR DESCRIPTION
Steps to reproduce the problem:
- A unit test must create a singleton kafka container.
- There must be some kafka consumer in the application context.

Example:
```java
@MicronautTest
@TestInstance(TestInstance.Lifecycle.PER_CLASS)
class MyTest implements TestPropertyProvider {

  static final KafkaContainer MY_KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
  static { MY_KAFKA.start(); }

  @Override
  public Map<String, String> getProperties() {
    return Map.of("kafka.bootstrap.servers", MY_KAFKA.getBootstrapServers());
  }

  @Test
  void testKafkaRunning(MyProducer producer) {
    producer.produce("hello");
  }

  @KafkaClient interface MyProducer {
    @Topic("my-topic")
    void produce(String message);
  }

  @KafkaListener static class MyConsumer {
    @Topic("my-topic")
    public void consume(String message) { }
  }
}
```

At the end of the test, the "main" thread will try to detect [if the kafka consumer is closed](https://github.com/micronaut-projects/micronaut-kafka/blob/master/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java#L320):

```java
    @Override
    @PreDestroy
    public void close() {
        for (ConsumerState consumerState : consumers.values()) {
            consumerState.kafkaConsumer.wakeup();
        }
        for (ConsumerState consumerState : consumers.values()) {
            while (consumerState.closedState == ConsumerCloseState.POLLING) {
                LOG.trace("consumer not closed yet");
            }
        }
        consumers.clear();
    }
```

Since `consumerState.closedState` was updated by another thread, the "main" thread will use a cached version of this value indefinitely (ie. "consumer not closed yet").

By declaring this field as `volatile` we will prevent the "main" thread from caching its value.

The lifecycle of this field is `NOT_STARTED` -> `POLLING` -> `CLOSED`. It's set when the state changes and it's only queried when the kafka consumer is destroyed, so the performance penalty should be negligible.