### PR TITLE
Safely destructure numerical values when configuring Kafka Metrics

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -133,20 +133,20 @@ public class KafkaMetricMeterTypeBuilder {
 
         KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
 
-        if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE) {
+        if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
                 return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
-        } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && this.kafkaMetric.metricValue() instanceof Double) {
-            return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, value -> (Double) value.metricValue())
+        } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && this.kafkaMetric.metricValue() instanceof Number) {
+            return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, value -> ((Number) value.metricValue()).doubleValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
-        } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && this.kafkaMetric.metricValue() instanceof Double) {
-            return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), value -> (Double) value.metricValue())
+        } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
+            return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), value -> ((Number) value.metricValue()).doubleValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .register(meterRegistry));


### PR DESCRIPTION
Related to: 
- https://github.com/micronaut-projects/micronaut-kafka/issues/671
- https://github.com/micronaut-projects/micronaut-kafka/pull/668

Addresses the following:
```
05:06:46.307 [elastic-apm-shared] WARN  io.micrometer.core.instrument.internal.DefaultGauge - Failed to apply the value function for the gauge 'kafka.consumer.commit-id'. Note that subsequent logs will be logged at debug level.
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
	at io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilder.lambda$build$0(KafkaMetricMeterTypeBuilder.java:137) ~[XXX.jar:?]
	at io.micrometer.core.instrument.Gauge.lambda$builder$0(Gauge.java:58) ~[XXX.jar:?]
	at io.micrometer.core.instrument.StrongReferenceGaugeFunction.applyAsDouble(StrongReferenceGaugeFunction.java:48) ~[XXX.jar:?]
	at io.micrometer.core.instrument.internal.DefaultGauge.value(DefaultGauge.java:53) ~[invoice.jar:?]
	at co.elastic.apm.agent.micrometer.MicrometerMeterRegistrySerializer.serializeMetricSet(MicrometerMeterRegistrySerializer.java:137) ~[?:?]
	at co.elastic.apm.agent.micrometer.MicrometerMeterRegistrySerializer.serialize(MicrometerMeterRegistrySerializer.java:90) ~[?:?]
	at co.elastic.apm.agent.micrometer.MicrometerMetricsReporter.run(MicrometerMetricsReporter.java:192) ~[?:?]
	at co.elastic.apm.agent.micrometer.MicrometerMetricsReporter.run(MicrometerMetricsReporter.java:145) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at co.elastic.apm.agent.util.ExecutorUtils$2.run(ExecutorUtils.java:99) ~[?:?]
```