### PR TITLE
Decorate user-provided instances of `ProducerRecord`, instead of using them as a raw values

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -507,7 +507,6 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
                 headers));
     }
 
-
     @SuppressWarnings("unchecked")
     private ProducerState getProducer(MethodInvocationContext<?, ?> context) {
         ProducerKey key = new ProducerKey(context.getTarget(), context.getExecutableMethod());


### PR DESCRIPTION
While looking into #52, I realized Kafka producers can't handle `ProducerRecord` objects properly at the moment.

Since consumers can receive `ConsumerRecord` objects, I thought producers should be able to send `ProducerRecord` objects for the sake of symmetry.

This implementation works for both modes batch/single. Fields not populated by the user may be populated by the context as usual.

```java
@KafkaClient
interface SingleProducer {
    @Topic("foo")
    String sendRecord(ProducerRecord<String, String> record);
}

@KafkaClient(batch = true)
interface BatchProducer {
    @Topic("foo")
    String sendRecords(List<ProducerRecord<String, String>> records);
}
```
