### PR TITLE
Avoid log pollution while waiting for consumer to close

### DIFF
--- a/kafka/src/test/resources/logback.xml
+++ b/kafka/src/test/resources/logback.xml
@@ -14,5 +14,5 @@
     <!--<logger name="org.apache.kafka" level="TRACE" />-->
 <!--    <logger name="io.micronaut.context" level="TRACE"/>-->
     <!--<logger name="io.micronaut.configuration.kafka.processor" level="TRACE"/>-->
-<!--    <logger name="io.micronaut.configuration.kafka " level="TRACE" />-->
+    <logger name="io.micronaut.configuration.kafka" level="TRACE" />
 </configuration>


### PR DESCRIPTION
While investigating #557, I came across this nagging TRACE message that keeps polluting my logs:

```
TRACE i.m.c.k.p.KafkaConsumerProcessor - consumer not closed yet
TRACE i.m.c.k.p.KafkaConsumerProcessor - consumer not closed yet
TRACE i.m.c.k.p.KafkaConsumerProcessor - consumer not closed yet
...
```

I've made some changes to limit how often we log this message while we're actively waiting for a consumer to close.
