### PR TITLE
Fixing test-suite docs examples to use test-resources

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.kafka-testsuite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.kafka-testsuite.gradle
@@ -10,6 +10,6 @@ tasks.withType(Test) {
 micronaut {
     importMicronautPlatform.set(false)
     testResources {
-        sharedServer = true
+        additionalModules.add("kafka")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ testcontainers = "1.18.3"
 zipkin-brave-kafka-clients = '5.16.0'
 
 micronaut-cache = "4.0.2"
+micronaut-logging = "1.0.0"
 micronaut-micrometer = "5.0.1"
 micronaut-reactor = "3.0.1"
 micronaut-rxjava2 = "2.0.1"
@@ -26,7 +27,6 @@ micronaut-serde = "2.2.0"
 micronaut-tracing = "5.0.1"
 micronaut-test = "4.0.0"
 
-logback = "1.4.6"
 
 
 [libraries]
@@ -56,4 +56,3 @@ micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", ver
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
 
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }
-

--- a/test-suite-groovy/build.gradle.kts
+++ b/test-suite-groovy/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     testCompileOnly(mn.micronaut.inject.groovy)
     testImplementation(libs.testcontainers.kafka)
     testImplementation(mnTest.micronaut.test.spock)
+    testRuntimeOnly(mnLogging.logback.classic)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/QuickStartTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/QuickStartTest.groovy
@@ -2,13 +2,14 @@ package io.micronaut.kafka.docs.quickstart
 
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.Property
-import io.micronaut.kafka.docs.AbstractKafkaTest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import spock.lang.Specification
 
 @Property(name = 'spec.name', value = 'QuickStartTest')
+@Property(name = 'kafka.enabled', value = 'true')
 @MicronautTest
-class QuickStartTest extends AbstractKafkaTest {
+class QuickStartTest extends Specification {
 
     @Inject
     BeanContext beanContext

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     testImplementation(libs.testcontainers.kafka)
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(mnLogging.logback.classic)
     testImplementation(libs.awaitility)
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
@@ -3,7 +3,6 @@ package io.micronaut.kafka.docs
 import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.utility.DockerImageName
-import java.util.*
 
 /**
  * @see <a href="https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers">Singleton containers</a>
@@ -12,18 +11,14 @@ abstract class AbstractKafkaTest : TestPropertyProvider {
 
     companion object {
         var MY_KAFKA: KafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
-
-        init {
-            MY_KAFKA.start()
-        }
     }
 
     override fun getProperties(): MutableMap<String, String> {
-        while(!MY_KAFKA.isRunning()) {
+        if(!MY_KAFKA.isRunning) {
             MY_KAFKA.start()
         }
-        return Collections.singletonMap(
-            "kafka.bootstrap.servers", MY_KAFKA.getBootstrapServers()
+        return mutableMapOf(
+            "kafka.bootstrap.servers" to MY_KAFKA.bootstrapServers
         )
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
@@ -1,23 +1,27 @@
 package io.micronaut.kafka.docs
 
-import io.micronaut.configuration.kafka.annotation.*
-import io.micronaut.context.annotation.*
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.awaitility.Awaitility.await
-import org.junit.jupiter.api.*
-import java.util.concurrent.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.TimeUnit
 
 @Property(name = "spec.name", value = "MyTest")
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class MyTest : AbstractKafkaTest() {
+
     @Test
     fun testKafkaRunning(producer: MyProducer, consumer: MyConsumer) {
         val message = "hello"
         producer.produce(message)
-        await().atMost(5, TimeUnit.SECONDS)
-            .until { consumer.consumed == message }
-        MY_KAFKA.stop()
+        await().atMost(5, TimeUnit.SECONDS).until { consumer.consumed == message }
     }
 
     @Requires(property = "spec.name", value = "MyTest")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/QuickstartTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/QuickstartTest.kt
@@ -2,16 +2,14 @@ package io.micronaut.kafka.docs.quickstart
 
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.Property
-import io.micronaut.kafka.docs.AbstractKafkaTest
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 
 @Property(name = "spec.name", value = "QuickstartTest")
+@Property(name = "kafka.enabled", value = "true")
 @MicronautTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class QuickstartTest : AbstractKafkaTest() {
+internal class QuickstartTest {
     @Inject
     lateinit var beanContext: BeanContext
 
@@ -21,7 +19,5 @@ internal class QuickstartTest : AbstractKafkaTest() {
         val client = beanContext.getBean(ProductClient::class.java)
         client.sendProduct("Nike", "Blue Trainers")
         // end::quickstart[]
-
-        MY_KAFKA.stop()
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/QuickstartTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/QuickstartTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 @Property(name = "kafka.enabled", value = "true")
 @MicronautTest
 internal class QuickstartTest {
+
     @Inject
     lateinit var beanContext: BeanContext
 

--- a/test-suite/build.gradle.kts
+++ b/test-suite/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     testImplementation(libs.testcontainers.kafka)
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(mnLogging.logback.classic)
     testImplementation(libs.awaitility)
     testImplementation(mnReactor.micronaut.reactor)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/AbstractKafkaTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/AbstractKafkaTest.java
@@ -4,24 +4,21 @@ import io.micronaut.test.support.TestPropertyProvider;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * @see <a href="https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers">Singleton containers</a>
  */
 public abstract class AbstractKafkaTest implements TestPropertyProvider {
 
-    static protected final KafkaContainer MY_KAFKA;
-
-    static {
-        MY_KAFKA = new KafkaContainer(
-            DockerImageName.parse("confluentinc/cp-kafka:latest"));
-        MY_KAFKA.start();
-    }
+    static protected final KafkaContainer MY_KAFKA = new KafkaContainer(
+        DockerImageName.parse("confluentinc/cp-kafka:latest")
+    );
 
     @Override
     public Map<String, String> getProperties() {
-        while (!MY_KAFKA.isRunning()) {
+        if (!MY_KAFKA.isRunning()) {
             MY_KAFKA.start();
         }
         return Collections.singletonMap(

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
@@ -1,9 +1,14 @@
 package io.micronaut.kafka.docs;
 
-import io.micronaut.configuration.kafka.annotation.*;
-import io.micronaut.context.annotation.*;
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.OffsetReset;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -18,7 +23,6 @@ class MyTest extends AbstractKafkaTest {
         final String message = "hello";
         producer.produce(message);
         await().atMost(5, SECONDS).until(() -> message.equals(consumer.consumed));
-        MY_KAFKA.stop();
     }
 
     @Requires(property = "spec.name", value = "MyTest")

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/QuickstartTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/QuickstartTest.java
@@ -5,13 +5,11 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import io.micronaut.kafka.docs.AbstractKafkaTest;
 
 @Property(name = "spec.name", value = "QuickstartTest")
+@Property(name = "kafka.enabled", value = "true")
 @MicronautTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class QuickstartTest extends AbstractKafkaTest {
+class QuickstartTest {
     @Inject
     ApplicationContext applicationContext;
 
@@ -21,7 +19,5 @@ class QuickstartTest extends AbstractKafkaTest {
         ProductClient client = applicationContext.getBean(ProductClient.class);
         client.sendProduct("Nike", "Blue Trainers");
         // end::quickstart[]
-
-        MY_KAFKA.stop();
     }
 }


### PR DESCRIPTION
 except for `MyTest` used by docs as example for using Testcontainers directly.