### PR TITLE
Suspend @KafkaListener functions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ micronaut-serde = "2.2.4"
 micronaut-tracing = "5.0.2"
 micronaut-test = "4.0.0"
 
+coroutines = "1.7.2"
+
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
@@ -51,6 +53,7 @@ micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", ver
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-tracing = { module = "io.micronaut.tracing:micronaut-tracing-bom", version.ref = "micronaut-tracing" }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
+kotlinx-coroutines = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = "coroutines"}
 
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }
 

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
     kaptTest(platform(mn.micronaut.core.bom))
     kaptTest(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(libs.kotlinx.coroutines)
 }


### PR DESCRIPTION
Proposal to fix a bug where method.isSuspended() always returns false and thus excludes the possibility of using suspend consumer functions