### PR TITLE
Add option to customise close() wait (fixes #901)

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/AbstractKafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/AbstractKafkaStreamsConfiguration.java
@@ -18,11 +18,14 @@ package io.micronaut.configuration.kafka.streams;
 import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 import org.apache.kafka.streams.StreamsConfig;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Properties;
 
 /**
@@ -33,7 +36,15 @@ import java.util.Properties;
  * @param <K> The key deserializer type
  * @param <V> The value deserializer type
  */
-public class AbstractKafkaStreamsConfiguration<K, V> extends AbstractKafkaConfiguration<K, V> {
+public class AbstractKafkaStreamsConfiguration<K, V> extends AbstractKafkaConfiguration<K, V> implements Named {
+
+    public static final String DEFAULT_NAME = "default";
+
+    public static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(3);
+
+    private String name = DEFAULT_NAME;
+
+    private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
 
     /**
      * Construct a new {@link KafkaStreamsConfiguration} for the given defaults.
@@ -66,5 +77,40 @@ public class AbstractKafkaStreamsConfiguration<K, V> extends AbstractKafkaConfig
                 }
             }
         }
+    }
+
+    /**
+     * The time to wait for the stream to shut down. Default value is 3s.
+     *
+     * @return the time to wait for the stream to shut down.
+     */
+    public Duration getCloseTimeout() {
+        return closeTimeout;
+    }
+
+    /**
+     *
+     * @param closeTimeout the time to wait for the stream to shut down
+     */
+    public void setCloseTimeout(Duration closeTimeout) {
+        this.closeTimeout = closeTimeout;
+    }
+
+    /**
+     * The logical name of the stream.
+     *
+     * @return the logical name of the stream
+     */
+    @Override
+    public @NonNull String getName() {
+        return this.name;
+    }
+
+    /**
+     *
+     * @param name the logical name of the stream
+     */
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/ConfiguredStreamBuilder.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/ConfiguredStreamBuilder.java
@@ -15,9 +15,11 @@
  */
 package io.micronaut.configuration.kafka.streams;
 
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.naming.Named;
 import org.apache.kafka.streams.StreamsBuilder;
 
-import io.micronaut.core.annotation.NonNull;
+import java.time.Duration;
 import java.util.Properties;
 
 /**
@@ -26,17 +28,36 @@ import java.util.Properties;
  * @author graemerocher
  * @since 1.0
  */
-public class ConfiguredStreamBuilder extends StreamsBuilder {
+public class ConfiguredStreamBuilder extends StreamsBuilder implements Named {
 
     private final Properties configuration = new Properties();
+
+    private final String streamName;
+
+    private final Duration closeTimeout;
 
     /**
      * Default constructor.
      *
      * @param configuration The configuration
+     * @deprecated Use {@link #ConfiguredStreamBuilder(Properties, String, Duration)}
      */
+    @Deprecated(since = "5.4.0")
     public ConfiguredStreamBuilder(Properties configuration) {
+        this(configuration, AbstractKafkaStreamsConfiguration.DEFAULT_NAME, AbstractKafkaStreamsConfiguration.DEFAULT_CLOSE_TIMEOUT);
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param configuration The configuration
+     * @param streamName The logical name of the stream
+     * @param closeTimeout The time to wait for the stream to shut down
+     */
+    public ConfiguredStreamBuilder(Properties configuration, String streamName, Duration closeTimeout) {
         this.configuration.putAll(configuration);
+        this.streamName = streamName;
+        this.closeTimeout = closeTimeout;
     }
 
     /**
@@ -46,5 +67,24 @@ public class ConfiguredStreamBuilder extends StreamsBuilder {
      */
     public @NonNull Properties getConfiguration() {
         return configuration;
+    }
+
+    /**
+     * The logical name of the stream.
+     *
+     * @return the logical name of the stream
+     */
+    @Override
+    public @NonNull String getName() {
+        return this.streamName;
+    }
+
+    /**
+     * The timeout to use when closing the stream.
+     *
+     * @return the timeout to use when closing the stream
+     */
+    public @NonNull Duration getCloseTimeout() {
+        return closeTimeout;
     }
 }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/DefaultKafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/DefaultKafkaStreamsConfiguration.java
@@ -20,13 +20,13 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.runtime.ApplicationConfiguration;
-
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+
 import java.util.Properties;
 
 /**
- * The default streams configuration is non other is present.
+ * The default streams configuration if no other is present.
  *
  * @author graemerocher
  * @since 1.0
@@ -36,7 +36,7 @@ import java.util.Properties;
 @Requires(missingProperty = KafkaStreamsConfiguration.PREFIX + ".default")
 @Singleton
 @Requires(beans = KafkaDefaultConfiguration.class)
-@Named("default")
+@Named(AbstractKafkaStreamsConfiguration.DEFAULT_NAME)
 @Primary
 public class DefaultKafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfiguration<K, V> {
     /**

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.kafka.streams;
 
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
+import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
@@ -34,6 +35,7 @@ import static io.micronaut.configuration.kafka.streams.KafkaStreamsConfiguration
  * @param <V> The generic value type
  */
 @EachProperty(value = PREFIX, primary = "default")
+@ConfigurationProperties(PREFIX)
 @Requires(beans = KafkaDefaultConfiguration.class)
 public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfiguration<K, V> {
 
@@ -56,9 +58,9 @@ public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfigu
             ApplicationConfiguration applicationConfiguration,
             Environment environment) {
         super(defaultConfiguration);
+        setName(streamName);
         Properties config = getConfig();
         String propertyKey = PREFIX + '.' + NameUtils.hyphenate(streamName, true);
-
         Properties properties = environment.getProperty(propertyKey, Properties.class).orElseGet(Properties::new);
         config.putAll(toKafkaProperties(environment, properties));
         init(applicationConfiguration, environment, config);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
@@ -62,6 +63,9 @@ public class KafkaStreamsFactory implements Closeable {
     private final Map<KafkaStreams, ConfiguredStreamBuilder> streams = new ConcurrentHashMap<>();
 
     private final ApplicationEventPublisher eventPublisher;
+
+    @Value("${kafka.streams-close-seconds:3}")
+    private int closeWaitSeconds;
 
     /**
      * Default constructor.
@@ -159,7 +163,7 @@ public class KafkaStreamsFactory implements Closeable {
     public void close() {
         for (KafkaStreams stream : streams.keySet()) {
             try {
-                stream.close(Duration.ofSeconds(3));
+                stream.close(Duration.ofSeconds(closeWaitSeconds));
             } catch (Exception e) {
                 // ignore
             }

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -17,12 +17,7 @@ package io.micronaut.configuration.kafka.streams;
 
 import io.micronaut.configuration.kafka.streams.event.AfterKafkaStreamsStart;
 import io.micronaut.configuration.kafka.streams.event.BeforeKafkaStreamStart;
-import io.micronaut.context.annotation.Context;
-import io.micronaut.context.annotation.EachBean;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Secondary;
-import io.micronaut.context.annotation.Value;
+import io.micronaut.context.annotation.*;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
@@ -37,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -64,9 +58,6 @@ public class KafkaStreamsFactory implements Closeable {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    @Value("${kafka.streams-close-seconds:3}")
-    private int closeWaitSeconds;
-
     /**
      * Default constructor.
      *
@@ -84,7 +75,7 @@ public class KafkaStreamsFactory implements Closeable {
      */
     @EachBean(AbstractKafkaStreamsConfiguration.class)
     ConfiguredStreamBuilder streamsBuilder(AbstractKafkaStreamsConfiguration<?, ?> configuration) {
-        return new ConfiguredStreamBuilder(configuration.getConfig());
+        return new ConfiguredStreamBuilder(configuration.getConfig(), configuration.getName(), configuration.getCloseTimeout());
     }
 
     /**
@@ -161,13 +152,19 @@ public class KafkaStreamsFactory implements Closeable {
     @Override
     @PreDestroy
     public void close() {
-        for (KafkaStreams stream : streams.keySet()) {
+        streams.forEach((stream, builder) -> {
             try {
-                stream.close(Duration.ofSeconds(closeWaitSeconds));
+                if (LOG.isInfoEnabled()) {
+                    LOG.info("Shutting down kafka stream {} ", builder.getName());
+                }
+                boolean success = stream.close(builder.getCloseTimeout());
+                if (!success) {
+                    LOG.warn("Timeout was exceeded while attempting to close kafka stream {}", builder.getName());
+                }
             } catch (Exception e) {
                 // ignore
             }
-        }
+        });
     }
 
     /**

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractKafkaSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractKafkaSpec.groovy
@@ -1,9 +1,13 @@
 package io.micronaut.configuration.kafka.streams
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 abstract class AbstractKafkaSpec extends Specification {
+
+    static log = LoggerFactory.getLogger(getClass())
 
     protected final PollingConditions conditions = new PollingConditions(timeout: conditionsTimeout, delay: 1)
 

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/CloseTimeoutKafkaStreamsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/CloseTimeoutKafkaStreamsSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.configuration.kafka.streams
+
+import java.time.Duration
+
+class CloseTimeoutKafkaStreamsSpec extends AbstractTestContainersSpec {
+
+    void "test default close configuration"() {
+        when:
+        def factory = context.getBean(KafkaStreamsFactory)
+        def stream = factory.getStreams().entrySet().stream().filter(e -> e.getValue().name == 'my-stream').findAny().orElseThrow()
+
+        then:
+        stream.value.getCloseTimeout() == Duration.ofMillis(1)
+        stream.key.state().isRunningOrRebalancing()
+
+        when:
+        factory.close()
+
+        then:
+        stream.key.state().hasStartedOrFinishedShuttingDown()
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        return super.getConfiguration() + ["kafka.streams.my-stream.close-timeout": '1ms']
+    }
+}

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
@@ -11,6 +11,8 @@ import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.clients.admin.TopicListing
 import org.apache.kafka.streams.KafkaStreams
 
+import java.time.Duration
+
 import static io.micronaut.configuration.kafka.streams.optimization.OptimizationStream.OPTIMIZATION_OFF_STORE
 import static io.micronaut.configuration.kafka.streams.optimization.OptimizationStream.OPTIMIZATION_ON_STORE
 import static io.micronaut.configuration.kafka.streams.wordcount.WordCountStream.WORD_COUNT_STORE
@@ -33,6 +35,16 @@ class KafkaStreamsSpec extends AbstractTestContainersSpec {
         then:
         stream.applicationConfigs.originals()['application.id'] == myStreamApplicationId
         stream.applicationConfigs.originals()['generic.config'] == "hello"
+    }
+
+    void "test default close configuration"() {
+
+        when:
+        def factory = context.getBean(KafkaStreamsFactory)
+        def builder = factory.getStreams().values().stream().filter(v -> v.name == 'my-stream').findAny().orElseThrow()
+
+        then:
+        builder.getCloseTimeout() == AbstractKafkaStreamsConfiguration.DEFAULT_CLOSE_TIMEOUT
     }
 
     void "test kafka stream application"() {

--- a/kafka-streams/src/test/resources/logback.xml
+++ b/kafka-streams/src/test/resources/logback.xml
@@ -11,5 +11,6 @@
     <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
+    <logger name="io.micronaut.configuration.kafka" level="INFO" />
     <logger name="io.micronaut.configuration.kafka.streams.health" level="DEBUG" />
 </configuration>

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -117,3 +117,13 @@ kafka:
         default:
             start-kafka-streams: false
 ----
+
+You may want to customize how long you wait for Kafka Streams to shut down between tests, with `kafka.streams-close-seconds`.
+
+For example, this will make Micronaut Kafka wait for up to 10 seconds to shut down each stream:
+
+[configuration]
+----
+kafka:
+    streams-close-seconds: 10
+----

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -69,7 +69,19 @@ kafka:
           auto.offset.reset: "earliest"
 ----
 
-The above configuration example sets the `processing.guarantee` and `auto.offset.reset` setting of the `default` Stream.
+The above configuration example sets the `processing.guarantee` and `auto.offset.reset` setting of the `default` Stream. Most of the configuration properties pass directly through to the `KafkaStreams` instance being initialized.
+
+In addition to those standard properties, you may want to customize how long you wait for Kafka Streams to shut down (this is mostly useful during testing), with `close-timeout`.
+
+For example, this will make Micronaut Kafka wait for up to 10 seconds to shut down the default stream:
+
+[configuration]
+----
+kafka:
+    streams:
+        default:
+            close-timeout: 10s
+----
 
 .Configuring multiple Stream definitions on the same Micronaut Service.
 You can define multiple Kafka Streams on the same Micronaut application, each with their own unique configuration.
@@ -98,7 +110,7 @@ You can then inject an `api:configuration.kafka.streams.ConfiguredStreamBuilder[
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="myOtherStream", indent=0]
 
-NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have multiple KStreams defined that share the default configurations like client id, application id, etc.It is advisable when using multiple streams in a single app to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
+NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have multiple KStreams defined that share the default configurations like client id, application id, etc. It is advisable when using multiple streams in a single app to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
 
 .Kafka Streams Word Count
 
@@ -116,14 +128,4 @@ kafka:
     streams:
         default:
             start-kafka-streams: false
-----
-
-You may want to customize how long you wait for Kafka Streams to shut down between tests, with `kafka.streams-close-seconds`.
-
-For example, this will make Micronaut Kafka wait for up to 10 seconds to shut down each stream:
-
-[configuration]
-----
-kafka:
-    streams-close-seconds: 10
 ----


### PR DESCRIPTION
This pull request proposes a new option to customise how long we wait for each `KafkaStreams` to close, as a fix for #901.

If you have a better idea for the name of the option, please let me know. I was not sure whether to go with `kafka.streams.close-seconds` or `kafka.streams-close-seconds`.