### PR TITLE
Support for ConsumerRecords container type on batch processing

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/bind/batch/BatchConsumerRecordsBinderRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/bind/batch/BatchConsumerRecordsBinderRegistry.java
@@ -59,6 +59,11 @@ public class BatchConsumerRecordsBinderRegistry implements ArgumentBinderRegistr
     @Override
     public <T> Optional<ArgumentBinder<T, ConsumerRecords<?, ?>>> findArgumentBinder(Argument<T> argument) {
         Class<T> argType = argument.getType();
+
+        if (ConsumerRecords.class.equals(argType)) {
+            return Optional.of((context, consumerRecords) -> () -> (Optional<T>) Optional.of(consumerRecords));
+        }
+
         if (Iterable.class.isAssignableFrom(argType) || argType.isArray() || Publishers.isConvertibleToPublisher(argType)) {
             Argument<?> batchType = argument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
             List bound = new ArrayList();
@@ -74,7 +79,6 @@ public class BatchConsumerRecordsBinderRegistry implements ArgumentBinderRegistr
                         if (result.isPresentAndSatisfied()) {
                             bound.add(result.get());
                         }
-
                     });
                 }
                 return () -> {

--- a/src/main/docs/guide/kafkaListener/kafkaListenerBatch.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerBatch.adoc
@@ -42,6 +42,23 @@ snippet::io.micronaut.kafka.docs.consumer.batch.manual.BookListener[tags=method,
 
 This example is fairly trivial in that it commits offsets after processing each record in a batch, but you can for example commit after processing every 10, or every 100 or whatever makes sense for your application.
 
+== Receiving a ConsumerRecords
+
+When batching you can receive the entire `ConsumerRecords` object being listened for. In this case you should specify appropriate generic types for the key and value of the `ConsumerRecords` so that Micronaut can pick the correct deserializer for each.
+
+This is useful when the need is to process or commit the records by partition, as the `ConsumerRecords` object already groups records by partition:
+
+.Commit only once for each partition
+
+snippet::io.micronaut.kafka.docs.consumer.batch.manual.BookListener[tags=consumerRecords, indent=0]
+
+<1> Committing offsets automatically is disabled
+<2> The method receives the batch of books as a `ConsumerRecords` holder object
+<3> Each partition is iterated over
+<4> Each record for the partition is processed
+<5> The last read offset for the partition is stored
+<6> The offset is committed once for each partition
+
 == Reactive Batch Processing
 
 Batch listeners also support defining reactive types (Reactor `Flux` or RxJava rx:Flowable[]) as the method argument.

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/batch/manual/BookListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/batch/manual/BookListener.kt
@@ -9,6 +9,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.kafka.docs.consumer.batch.Book
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
@@ -41,5 +42,33 @@ internal class BookListener {
         }
     }
     // end::method[]
+
+    // end::method[]
+
+    // end::method[]
+    // tag::consumerRecords[]
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, offsetStrategy = OffsetStrategy.DISABLED, batch = true) // <1>
+    @Topic("all-the-books")
+    fun receiveConsumerRecords(consumerRecords: ConsumerRecords<String?, Book?>, kafkaConsumer: Consumer<*, *>) { // <2>
+        for (partition in consumerRecords.partitions()) { // <3>
+            var offset = Long.MIN_VALUE
+            // process partition records
+            for (record in consumerRecords.records(partition)) { // <4>
+                // process the book
+                val book = record.value()
+                // keep last offset
+                offset = record.offset() // <5>
+            }
+
+            // commit partition offset
+            kafkaConsumer.commitSync(
+                Collections.singletonMap( // <6>
+                    partition,
+                    OffsetAndMetadata(offset + 1, "my metadata")
+                )
+            )
+        }
+    }
+    // end::consumerRecords[]
 }
 

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/batch/manual/BookListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/batch/manual/BookListener.java
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.kafka.docs.consumer.batch.Book;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
@@ -42,4 +43,27 @@ class BookListener {
         }
     }
     // end::method[]
+
+    // tag::consumerRecords[]
+    @KafkaListener(offsetReset = EARLIEST, offsetStrategy = DISABLED, batch = true) // <1>
+    @Topic("all-the-books")
+    public void receiveConsumerRecords(ConsumerRecords<String, Book> consumerRecords, Consumer kafkaConsumer) { // <2>
+        for (TopicPartition partition : consumerRecords.partitions()) { // <3>
+            long offset = Long.MIN_VALUE;
+            // process partition records
+            for (ConsumerRecord<String, Book> record : consumerRecords.records(partition)) { // <4>
+                // process the book
+                Book book = record.value();
+                // keep last offset
+                offset = record.offset(); // <5>
+            }
+
+            // commit partition offset
+            kafkaConsumer.commitSync(Collections.singletonMap( // <6>
+                partition,
+                new OffsetAndMetadata(offset + 1, "my metadata")
+            ));
+        }
+    }
+    // end::consumerRecords[]
 }


### PR DESCRIPTION
See #903

The changes are:
- Bind arguments of `ConsumerRecords` type;
- Consider `ConsumerRecords` type when looking for the "body argument" to configure the correct key and value deserializers;
- Add a test;