### PR TITLE
fix: kafka health indicator requires kafka configuration

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
@@ -57,6 +57,7 @@ import static org.apache.kafka.common.utils.Time.SYSTEM;
  * @since 1.0
  */
 @Singleton
+@Requires(bean = KafkaDefaultConfiguration.class)
 @Requires(property = KafkaHealthConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceListener {
     private static final String ID = "kafka";

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaHealthIndicatorSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaHealthIndicatorSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.kafka.health
 
 import io.micronaut.configuration.kafka.AbstractKafkaSpec
+import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.management.health.indicator.HealthResult
@@ -68,6 +69,27 @@ class KafkaHealthIndicatorSpec extends AbstractKafkaSpec {
 
         where:
         configvalue << [false, "false", "no", ""]
+    }
+
+    void "test kafka health indicator - disabled when no kafka configuration provided"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(configuration +
+                ["test-resources.containers.kafka.enabled": false])
+
+        when:
+        Optional<KafkaDefaultConfiguration> config = applicationContext.findBean(KafkaDefaultConfiguration)
+
+        then:
+        config.isEmpty()
+
+        when:
+        Optional<KafkaHealthIndicator> healthIndicator = applicationContext.findBean(KafkaHealthIndicator)
+
+        then:
+        healthIndicator.isEmpty()
+
+        cleanup:
+        applicationContext.close()
     }
 
     @Unroll


### PR DESCRIPTION
When no kafka configuration is provided:
```
Error creating scheduled task for bean [HealthMonitorTask] Failed to inject value for parameter [defaultConfiguration] of class: io.micronaut.configuration.kafka.health.KafkaHealthIndicator

Message: No bean of type [io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration] exists. The following matching beans are disabled by bean requirements: 
* Bean of type [io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration] is disabled because: 
   - Required property [kafka] with value [null] not present
```