### PR TITLE
Add RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR KafkaListener error strategies to conditionally retry messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,13 @@ In this case, to fix the issues, we need to:
 - Add an space after `if` in line 34
 
 The plugin also adds a new tab in the bottom of the IDE to run Checkstyle and show errors and warnings. We recommend that you run the report and fix all issues before submitting a pull request.
+
+## File headers
+
+All files should contain the license header which can be added automatically by running:
+
+```
+./gradlew spotlessApply
+```
+
+The copyright year should be updated manually when editing existing files.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
@@ -108,7 +108,8 @@ public @interface ErrorStrategy {
     /**
      * The types of exceptions to retry, used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR,
      * see {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
-     * Not compatible with RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR.
+     * When used with RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR,
+     * the skip behaviour will be overridden if the thrown exception is one of these types.
      *
      * @return the list of exceptions types
      * @since 4.5.0

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
@@ -55,7 +55,8 @@ public @interface ErrorStrategy {
     boolean DEFAULT_HANDLE_ALL_EXCEPTIONS = false;
 
     /**
-     * The delay used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR
+     * The delay used with RETRY_ON_ERROR, RETRY_EXPONENTIALLY_ON_ERROR,
+     * RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR
      * {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
      *
      * @return the delay by which to wait for the next retry
@@ -63,7 +64,8 @@ public @interface ErrorStrategy {
     String retryDelay() default DEFAULT_DELAY_IN_SECONDS + "s";
 
     /**
-     * The fixed retry count used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR
+     * The fixed retry count used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR,
+     * RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR
      * {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
      *
      * <p>{@code retryCount} takes precedence over {@code retryCountValue} if they are both set.
@@ -104,7 +106,9 @@ public @interface ErrorStrategy {
     ErrorStrategyValue value() default ErrorStrategyValue.NONE;
 
     /**
-     * The types of exceptions to retry, used with RETRY_ON_ERROR, see {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
+     * The types of exceptions to retry, used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR,
+     * see {@link io.micronaut.configuration.kafka.annotation.ErrorStrategyValue}.
+     * Not compatible with RETRY_CONDITIONALLY_ON_ERROR and RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR.
      *
      * @return the list of exceptions types
      * @since 4.5.0

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -427,7 +427,8 @@ abstract class ConsumerState {
 
     protected boolean shouldRetryException(Throwable e, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
         if (info.errorStrategy.isConditionalRetry()) {
-            return kafkaConsumerProcessor.shouldRetryMessage(consumerBean, wrapExceptionInKafkaListenerException(e.getMessage(), e, consumerRecords, consumerRecord));
+            return kafkaConsumerProcessor.shouldRetryMessage(consumerBean, wrapExceptionInKafkaListenerException(e.getMessage(), e, consumerRecords, consumerRecord)) ||
+                info.exceptionTypes.stream().anyMatch(e.getClass()::equals);
         }
 
         return info.exceptionTypes.isEmpty() ||

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -144,7 +144,7 @@ final class ConsumerStateBatch extends ConsumerState {
         Map<TopicPartition, OffsetAndMetadata> currentOffsets, Throwable e) {
         if (info.errorStrategy.isRetry()) {
             final Set<TopicPartition> partitions = consumerRecords != null ? consumerRecords.partitions() : currentOffsets.keySet();
-            if (shouldRetryException(e) && info.retryCount > 0) {
+            if (shouldRetryException(e, consumerRecords, null) && info.retryCount > 0) {
                 // Check how many retries so far
                 final int currentRetryCount = getCurrentRetryCount(partitions, currentOffsets);
                 if (info.retryCount >= currentRetryCount) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -132,13 +132,14 @@ final class ConsumerStateSingle extends ConsumerState {
                 // Check how many retries so far
                 final int currentRetryCount = getCurrentRetryCount(consumerRecord);
                 if (info.retryCount >= currentRetryCount) {
+                    // Move back to the previous position
+                    kafkaConsumer.seek(topicPartition, consumerRecord.offset());
 
-                    // We will retry this batch again next time
+                    // We will retry this batch again next time unless the exception handler chooses not to
                     if (info.shouldHandleAllExceptions) {
                         handleException(e, consumerRecords, consumerRecord);
                     }
-                    // Move back to the previous position
-                    kafkaConsumer.seek(topicPartition, consumerRecord.offset());
+
                     // Decide how long should we wait to retry this batch again
                     delayRetry(currentRetryCount, Collections.singleton(topicPartition));
                     return true;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/retry/ConditionalRetryBehaviourHandler.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/retry/ConditionalRetryBehaviourHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/retry/ConditionalRetryBehaviourHandler.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/retry/ConditionalRetryBehaviourHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.retry;
+
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException;
+
+/**
+ * Interface that can be implemented to provide conditional retry behaviour for a {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+ * when a {@link org.apache.kafka.clients.consumer.ConsumerRecord} fails to be processed and the error strategy is set to conditionally retry.
+ *
+ * @author Ryan Evans
+ * @since 5.4.0
+ */
+public interface ConditionalRetryBehaviourHandler {
+
+    /**
+     * Returns the seek behaviour for the given exception.
+     *
+     * @param exception The exception that occurred when attempting to process a record
+     * @return The conditional retry behaviour
+     */
+    ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception);
+
+    /**
+     * The conditional retry behaviours.
+     */
+    enum ConditionalRetryBehaviour {
+        RETRY,
+        SKIP
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/retry/DefaultConditionalRetryBehaviourHandler.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/retry/DefaultConditionalRetryBehaviourHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/retry/DefaultConditionalRetryBehaviourHandler.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/retry/DefaultConditionalRetryBehaviourHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.retry;
+
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException;
+import io.micronaut.context.annotation.Primary;
+import jakarta.inject.Singleton;
+
+/**
+ * The default ConditionalRetryBehaviourHandler used when a {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+ * fails to process a {@link org.apache.kafka.clients.consumer.ConsumerRecord} and the error strategy is set to conditionally retry.
+ *
+ * @author Ryan Evans
+ * @since 5.4.0
+ */
+@Singleton
+@Primary
+public class DefaultConditionalRetryBehaviourHandler implements ConditionalRetryBehaviourHandler {
+
+    /**
+     * Retries the record by default. This can be overridden by implementing a
+     * custom ConditionalRetryBehaviourHandler that replaces this bean.
+     */
+    @Override
+    public ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+        return ConditionalRetryBehaviour.RETRY;
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -5,8 +5,10 @@ import io.micronaut.configuration.kafka.annotation.ErrorStrategy
 import io.micronaut.configuration.kafka.annotation.KafkaClient
 import io.micronaut.configuration.kafka.annotation.KafkaListener
 import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.configuration.kafka.retry.DefaultConditionalRetryBehaviourHandler
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -19,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.NONE
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RESUME_AT_NEXT_RECORD
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_CONDITIONALLY_ON_ERROR
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_EXPONENTIALLY_ON_ERROR
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_ON_ERROR
 import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
@@ -72,6 +76,26 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         myConsumer.times[1] - myConsumer.times[0] >= 50
     }
 
+    void "test when the error strategy is 'retry conditionally on error' messages can be conditionally skipped when errors occur"() {
+        when:"A consumer throws an exception"
+        ConditionallyRetryErrorClient myClient = context.getBean(ConditionallyRetryErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+        myClient.sendMessage("Three")
+
+        ConditionallyRetryOnErrorErrorCausingConsumer myConsumer = context.getBean(ConditionallyRetryOnErrorErrorCausingConsumer)
+
+        then:"The message that threw the exception is re-consumed"
+        conditions.eventually {
+            myConsumer.received == ["One", "One", "Two", "Three"]
+            myConsumer.successful == ["Three"]
+            myConsumer.count.get() == 4
+        }
+        and:"the retry of the first message is delivered at least 50ms afterwards"
+        myConsumer.times[1] - myConsumer.times[0] >= 50
+        myConsumer.skipped == ["Two"]
+    }
+
     void "test when the error strategy is 'retry on error' and there are serialization errors"() {
         when:"A record cannot be deserialized"
         DeserializationErrorClient myClient = context.getBean(DeserializationErrorClient)
@@ -88,20 +112,42 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         myConsumer.exceptionCount.get() == 2
     }
 
-    void "test when the error strategy is 'retry on error' and there are serialization errors, some messages should be skipped"() {
-        when:"A record cannot be deserialized"
-        ConditionalDeserializationErrorClient myClient = context.getBean(ConditionalDeserializationErrorClient)
+    void "test when the error strategy is 'retry conditionally on error' messages are retried with the default seek behaviour when deserialization errors occur"() {
+        when: "A record cannot be deserialized"
+        ConditionalRetryAlwaysRetryDeserializationErrorClient myClient = context.getBean(ConditionalRetryAlwaysRetryDeserializationErrorClient)
+        myClient.sendText("Not an integer and should be retried")
+        myClient.sendNumber(123)
+
+        ConditionallyRetryOnErrorAlwaysRetryDeserializationErrorConsumer myConsumer = context.getBean(ConditionallyRetryOnErrorAlwaysRetryDeserializationErrorConsumer)
+
+        then: "The message that threw the exception is eventually left behind"
+        conditions.eventually {
+            myConsumer.number == 123
+        }
+
+        and: "the default conditional retry behaviour handler bean exists"
+        ConditionalRetryBehaviourHandler conditionalRetryBehaviourHandler = context.getBean(ConditionalRetryBehaviourHandler.class)
+        conditionalRetryBehaviourHandler instanceof DefaultConditionalRetryBehaviourHandler
+
+        and: "the first message was retried"
+        myConsumer.exceptionCount.get() == 2
+    }
+
+    void "test when the error strategy is 'retry conditionally on error' messages can be conditionally skipped when deserialization errors occur"() {
+        when: "A record cannot be deserialized"
+        ConditionalLogicInConsumerBeanDeserializationErrorClient myClient = context.getBean(ConditionalLogicInConsumerBeanDeserializationErrorClient)
         myClient.sendText("Not an integer and should be immediately skipped")
         myClient.sendText("Not an integer and should be retried")
         myClient.sendNumber(123)
 
-        ConditionallyRetryOnErrorDeserializationErrorConsumer myConsumer = context.getBean(ConditionallyRetryOnErrorDeserializationErrorConsumer)
+        ConditionallyRetryOnErrorLogicInConsumerBeanDeserializationErrorConsumer myConsumer = context.getBean(ConditionallyRetryOnErrorLogicInConsumerBeanDeserializationErrorConsumer)
 
-        then:"The message that threw the exception is eventually left behind"
+        then: "The messages that threw the exception are eventually left behind"
         conditions.eventually {
             myConsumer.number == 123
         }
-        and:"the first message was only tried once and the latter was retried"
+
+        and: "the first message was only tried once and the second was tried twice"
         myConsumer.skippedMessagesCount.get() == 1
         myConsumer.exceptionCount.get() == 3
     }
@@ -136,6 +182,28 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         conditions.eventually {
             myConsumer.received == ["One", "One", "One", "One"]
             myConsumer.count.get() == 4
+        }
+        and: "message was retried with exponential breaks between deliveries"
+        myConsumer.times[1] - myConsumer.times[0] >= 50
+        myConsumer.times[2] - myConsumer.times[1] >= 100
+        myConsumer.times[3] - myConsumer.times[2] >= 200
+    }
+
+    void "test when error strategy is 'retry exponentially and conditionally on error' then message is retried with exponential backoff"() {
+        when: "A consumer throws an exception"
+        ExpAndConditionalRetryErrorClient myClient = context.getBean(ExpAndConditionalRetryErrorClient)
+        myClient.sendMessage("One")
+        myClient.sendMessage("Two")
+        myClient.sendMessage("Three")
+
+        RetryExpAndConditionallyOnErrorErrorCausingConsumer myConsumer = context.getBean(RetryExpAndConditionallyOnErrorErrorCausingConsumer)
+
+        then: "First message retries and is eventually skipped, the second is immediately skipped, and the last is eventually consumed"
+        conditions.eventually {
+            myConsumer.received == ["One", "One", "One", "One", "Two", "Three"]
+            myConsumer.successful == ["Three"]
+            myConsumer.count.get() == 6
+            myConsumer.skipped == ["Two"]
         }
         and: "message was retried with exponential breaks between deliveries"
         myConsumer.times[1] - myConsumer.times[0] >= 50
@@ -266,6 +334,40 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
     @KafkaListener(
+        offsetReset = EARLIEST,
+        offsetStrategy = SYNC,
+        errorStrategy = @ErrorStrategy(value = RETRY_CONDITIONALLY_ON_ERROR, retryDelay = "50ms")
+    )
+    static class ConditionallyRetryOnErrorErrorCausingConsumer implements ConditionalRetryBehaviourHandler {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+        List<Long> times = []
+        List<String> skipped = []
+        List<String> successful = []
+
+        @Topic("errors-conditional-retry")
+        void handleMessage(String message) {
+            received << message
+            times << System.currentTimeMillis()
+            if (count.getAndIncrement() < 3) {
+                throw new RuntimeException("Won't handle the first message and the first attempt of the second")
+            }
+            successful << message
+        }
+
+        @Override
+        ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+            if (exception.consumerRecord.get().value() == "Two") {
+                skipped << (String) exception.consumerRecord.get().value()
+                return ConditionalRetryBehaviour.SKIP
+            } else {
+                return ConditionalRetryBehaviour.RETRY
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(
             value="errors-retry-multiple-partitions",
             offsetStrategy = SYNC,
             errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR)
@@ -303,6 +405,40 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
             times << System.currentTimeMillis()
             if (count.getAndIncrement() < 4) {
                 throw new RuntimeException("Won't handle first three delivery attempts")
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(
+            offsetReset = EARLIEST,
+            offsetStrategy = SYNC,
+            errorStrategy = @ErrorStrategy(value = RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR, retryCount = 3, retryDelay = "50ms", handleAllExceptions = true)
+    )
+    static class RetryExpAndConditionallyOnErrorErrorCausingConsumer implements ConditionalRetryBehaviourHandler {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> received = []
+        List<Long> times = []
+        List<String> skipped = []
+        List<String> successful = []
+
+        @Topic("errors-exp-conditional-retry")
+        void handleMessage(String message) {
+            received << message
+            times << System.currentTimeMillis()
+            if (count.getAndIncrement() < 5) {
+                throw new RuntimeException("Won't handle the first message and the first attempt of the second")
+            }
+            successful << message
+        }
+
+        @Override
+        ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+            if (exception.consumerRecord.get().value() == "Two") {
+                skipped << (String) exception.consumerRecord.get().value()
+                return ConditionalRetryBehaviour.SKIP
+            } else {
+                return ConditionalRetryBehaviour.RETRY
             }
         }
     }
@@ -381,15 +517,13 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
     @KafkaListener(
             offsetReset = EARLIEST,
-            value="errors-conditionally-retry-deserialization-error",
-            errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, handleAllExceptions = true)
+            errorStrategy = @ErrorStrategy(value = RETRY_CONDITIONALLY_ON_ERROR, handleAllExceptions = true)
     )
-    static class ConditionallyRetryOnErrorDeserializationErrorConsumer implements KafkaListenerExceptionHandler {
+    static class ConditionallyRetryOnErrorAlwaysRetryDeserializationErrorConsumer implements KafkaListenerExceptionHandler {
         int number = 0
         AtomicInteger exceptionCount = new AtomicInteger(0)
-        AtomicInteger skippedMessagesCount = new AtomicInteger(0)
 
-        @Topic("conditional-deserialization-errors-retry")
+        @Topic("errors-conditionally-retry-always-retry-deserialization-error")
         void handleMessage(int number) {
             this.number = number
         }
@@ -397,11 +531,36 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         @Override
         void handle(KafkaListenerException exception) {
             exceptionCount.getAndIncrement()
-            var record = exception.consumerRecord.get()
-            if (record.offset() == 0) {
-                exception.kafkaConsumer.seek(new TopicPartition(record.topic(), record.partition()), record.offset() + 1)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(
+            offsetReset = EARLIEST,
+            errorStrategy = @ErrorStrategy(value = RETRY_CONDITIONALLY_ON_ERROR, handleAllExceptions = true)
+    )
+    static class ConditionallyRetryOnErrorLogicInConsumerBeanDeserializationErrorConsumer implements ConditionalRetryBehaviourHandler, KafkaListenerExceptionHandler {
+        int number = 0
+        AtomicInteger exceptionCount = new AtomicInteger(0)
+        AtomicInteger skippedMessagesCount = new AtomicInteger(0)
+
+        @Topic("errors-conditionally-retry-logic-in-consumer-bean-deserialization-error")
+        void handleMessage(int number) {
+            this.number = number
+        }
+
+        @Override
+        ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+            if (exception.consumerRecord.get().offset() == 0) {
                 skippedMessagesCount.getAndIncrement()
+                return ConditionalRetryBehaviour.SKIP
             }
+            return ConditionalRetryBehaviour.RETRY
+        }
+
+        @Override
+        void handle(KafkaListenerException exception) {
+            exceptionCount.getAndIncrement()
         }
     }
 
@@ -508,6 +667,13 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
     @KafkaClient
+    static interface ConditionallyRetryErrorClient {
+        @Topic("errors-conditional-retry")
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
     static interface DeserializationErrorClient {
         @Topic("deserialization-errors-retry")
         void sendText(String text)
@@ -518,11 +684,21 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
     @KafkaClient
-    static interface ConditionalDeserializationErrorClient {
-        @Topic("conditional-deserialization-errors-retry")
+    static interface ConditionalRetryAlwaysRetryDeserializationErrorClient {
+        @Topic("errors-conditionally-retry-always-retry-deserialization-error")
         void sendText(String text)
 
-        @Topic("conditional-deserialization-errors-retry")
+        @Topic("errors-conditionally-retry-always-retry-deserialization-error")
+        void sendNumber(int number)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface ConditionalLogicInConsumerBeanDeserializationErrorClient {
+        @Topic("errors-conditionally-retry-logic-in-consumer-bean-deserialization-error")
+        void sendText(String text)
+
+        @Topic("errors-conditionally-retry-logic-in-consumer-bean-deserialization-error")
         void sendNumber(int number)
     }
 
@@ -537,6 +713,13 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     @KafkaClient
     static interface ExpRetryErrorClient {
         @Topic("errors-exp-retry")
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface ExpAndConditionalRetryErrorClient {
+        @Topic("errors-exp-conditional-retry")
         void sendMessage(String message)
     }
 

--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -9,7 +9,13 @@ Setting the error strategy allows you to resume at the next offset or to seek th
 
 You can choose one of the error strategies:
 
-- `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`
+- `RETRY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`.
+
+- `RETRY_EXPONENTIALLY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. The exponentially growing time breaks between consumption attempts is computed using the `n * 2^(k - 1)` formula where the initial delay `n` is `retryDelay` and the number of retries is `retryCount`.
+
+- `RETRY_CONDITIONALLY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. The retry behaviour can be overridden. Possible retry delay can be defined by `retryDelay` and retry count by `retryCount`.
+
+- `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR` - This strategy will stop consuming subsequent records in the case of an error and by default will attempt to re-consume the current record once. The retry behaviour can be overridden. The exponentially growing time breaks between consumption attempts is computed using the `n * 2^(k - 1)` formula where the initial delay `n` is `retryDelay` and the number of retries is `retryCount`.
 
 - `RESUME_AT_NEXT_RECORD` - This strategy will ignore the current error and will resume at the next offset, in this case it's recommended to have a custom exception handler that moves the failed message into an error queue.
 
@@ -33,7 +39,21 @@ It's possible to define only exceptions from which the retry will occur.
 
 snippet::io.micronaut.kafka.docs.consumer.errors.ExceptionProductListener[tags = annotation, indent = 0]
 
-NOTE: Specify exception to retry apply only for RETRY_ON_ERROR error strategy.
+NOTE: Specify exception to retry apply only for `RETRY_ON_ERROR` and `RETRY_EXPONENTIALLY_ON_ERROR` error strategies.
+
+==== Conditional retries
+
+It is possible to conditionally retry a message based on the exception thrown when the error strategy is `RETRY_CONDITIONALLY_ON_ERROR` or `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR`.
+
+.Specifying conditional retry behaviour on the listener
+
+snippet::io.micronaut.kafka.docs.consumer.errors.ConditionalRetryListener[tags = annotation, indent = 0]
+
+When a ann:configuration.kafka.annotation.KafkaListener[] does not implement ann:configuration.kafka.retry.ConditionalRetryBehaviourHandler[], the ann:configuration.kafka.exceptions.DefaultConditionalRetryBehaviourHandler[] will be used and all messages that failed processing will be retried.
+
+If you wish to apply the same conditional retry strategy for all of your ann:configuration.kafka.annotation.KafkaListener[] you can define a bean that implements `ConditionalRetryBehaviourHandler` and use Micronaut's <<replaces, Bean Replacement>> feature to replace the default bean: `@Replaces(DefaultConditionalRetryBehaviourHandler.class)`.
+
+NOTE: Conditional retry behaviour only applies to `RETRY_CONDITIONALLY_ON_ERROR` and `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR` error strategies.
 
 === Exception handlers
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = 'spec.name', value = 'RetryProductListenerTest')
+// tag::annotation[]
+@KafkaListener(
+    value = 'myGroup',
+    errorStrategy = @ErrorStrategy(
+            value = ErrorStrategyValue.RETRY_CONDITIONALLY_ON_ERROR
+    )
+)
+class ConditionalRetryListener implements ConditionalRetryBehaviourHandler {
+    @Override
+    ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+        return shouldRetry(exception) ? ConditionalRetryBehaviour.RETRY : ConditionalRetryBehaviour.SKIP
+    }
+
+    // ...
+
+// end::annotation[]
+
+    private static boolean shouldRetry(KafkaListenerException exception) {
+        return true;
+    }
+}
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.kt
@@ -1,0 +1,39 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler.ConditionalRetryBehaviour
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = "spec.name", value = "RetryProductListenerTest")
+// tag::annotation[]
+@KafkaListener(
+    value = "myGroup",
+    errorStrategy = ErrorStrategy(
+        value = ErrorStrategyValue.RETRY_CONDITIONALLY_ON_ERROR
+    )
+)
+class ConditionalRetryListener :
+    ConditionalRetryBehaviourHandler {
+    override fun conditionalRetryBehaviour(exception: KafkaListenerException): ConditionalRetryBehaviour {
+        return if (shouldRetry(exception)) {
+            ConditionalRetryBehaviour.RETRY
+        } else {
+            ConditionalRetryBehaviour.SKIP
+        }
+    }
+
+    // ...
+
+    // end::annotation[]
+    companion object {
+        private fun shouldRetry(exception: KafkaListenerException): Boolean {
+            return true
+        }
+    }
+}
+
+

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/ConditionalRetryListener.java
@@ -1,0 +1,33 @@
+package io.micronaut.kafka.docs.consumer.errors;
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy;
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler;
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "RetryProductListenerTest")
+// tag::annotation[]
+@KafkaListener(
+    value = "myGroup",
+    errorStrategy = @ErrorStrategy(
+        value = ErrorStrategyValue.RETRY_CONDITIONALLY_ON_ERROR
+    )
+)
+public class ConditionalRetryListener implements ConditionalRetryBehaviourHandler {
+
+    @Override
+    public ConditionalRetryBehaviour conditionalRetryBehaviour(KafkaListenerException exception) {
+        return shouldRetry(exception) ? ConditionalRetryBehaviour.RETRY : ConditionalRetryBehaviour.SKIP;
+    }
+
+    // ...
+
+// end::annotation[]
+
+    private static boolean shouldRetry(KafkaListenerException exception) {
+        return true;
+    }
+}
+


### PR DESCRIPTION
Potential solution for https://github.com/micronaut-projects/micronaut-kafka/issues/947.

Adds `RETRY_CONDITIONALLY_ON_ERROR` and `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR` listener error stratiegies to conditionally retry messages on error.