### PR TITLE
Allow reactive consumer methods with error strategy

### DIFF
--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -23,6 +23,8 @@ You can choose one of the error strategies:
 
 NOTE: The error strategies apply only for non-batch messages processing.
 
+NOTE: When using retry error strategies in combination with reactive consumer methods, it is necessary to add the `@Blocking` annotation to the reactive consumer method.
+
 You can also make the number of retries configurable by using `retryCountValue`:
 
 .Dynamically Configuring Retries


### PR DESCRIPTION
Processing of `@KafkaListener` methods is enhanced to allow reactive consumer methods annotated with `@Blocking` to work the same as non-reactive consumer methods in conjunction with retry error strategies.

Resolves #967
