### PR TITLE
Updated links to Micronaut guide sections

### DIFF
--- a/src/main/docs/guide/kafkaApplications/kafkaHealth.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaHealth.adoc
@@ -1,4 +1,4 @@
-In addition to `http-server-netty`, if the `management` dependency is added, then Micronaut's <<healthEndpoint, Health Endpoint>> can be used to expose the health status of the Kafka consumer application.
+In addition to `http-server-netty`, if the `management` dependency is added, then Micronaut's link:https://docs.micronaut.io/latest/guide/#healthEndpoint[Health Endpoint] can be used to expose the health status of the Kafka consumer application.
 
 For example if Kafka is not available the `/health` endpoint will return:
 
@@ -18,7 +18,7 @@ For example if Kafka is not available the `/health` endpoint will return:
 }
 ----
 
-NOTE: By default, the details visible above are only shown to authenticated users. See the <<healthEndpoint, Health Endpoint>> documentation for how to configure that setting.
+NOTE: By default, the details visible above are only shown to authenticated users. See the link:https://docs.micronaut.io/latest/guide/#healthEndpoint[Health Endpoint] documentation for how to configure that setting.
 
 The following options are available to configure the Kafka Health indicator:
 

--- a/src/main/docs/guide/kafkaClient/kafkaClientConfiguration.adoc
+++ b/src/main/docs/guide/kafkaClient/kafkaClientConfiguration.adoc
@@ -50,7 +50,7 @@ snippet::io.micronaut.kafka.docs.producer.config.ProductClient[tags="imports, cl
 
 When serializing keys and values Micronaut will by default attempt to automatically pick a link:{kafkaapi}/org/apache/kafka/common/serialization/Serializer.html[Serializer] to use. This is done via the api:configuration.kafka.serde.CompositeSerdeRegistry[] bean.
 
-TIP: You can replace the default api:configuration.kafka.serde.SerdeRegistry[] bean with your own implementation by defining a bean that uses `@Replaces(CompositeSerdeRegistry.class)`. See the section on <<replaces, Bean Replacement>>.
+TIP: You can replace the default api:configuration.kafka.serde.SerdeRegistry[] bean with your own implementation by defining a bean that uses `@Replaces(CompositeSerdeRegistry.class)`. See the section on link:https://docs.micronaut.io/latest/guide/#replaces[Bean Replacement].
 
 All common `java.lang` types (`String`, `Integer`, primitives etc.) are supported and for POJOs by default a Jackson based JSON serializer is used.
 

--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -53,7 +53,7 @@ snippet::io.micronaut.kafka.docs.consumer.errors.ConditionalRetryListener[tags =
 
 When a ann:configuration.kafka.annotation.KafkaListener[] does not implement ann:configuration.kafka.retry.ConditionalRetryBehaviourHandler[], the ann:configuration.kafka.exceptions.DefaultConditionalRetryBehaviourHandler[] will be used and all messages that failed processing will be retried.
 
-If you wish to apply the same conditional retry strategy for all of your ann:configuration.kafka.annotation.KafkaListener[] you can define a bean that implements `ConditionalRetryBehaviourHandler` and use Micronaut's <<replaces, Bean Replacement>> feature to replace the default bean: `@Replaces(DefaultConditionalRetryBehaviourHandler.class)`.
+If you wish to apply the same conditional retry strategy for all of your ann:configuration.kafka.annotation.KafkaListener[] you can define a bean that implements `ConditionalRetryBehaviourHandler` and use Micronaut's link:https://docs.micronaut.io/latest/guide/#replaces[Bean Replacement] feature to replace the default bean: `@Replaces(DefaultConditionalRetryBehaviourHandler.class)`.
 
 NOTE: Conditional retry behaviour only applies to `RETRY_CONDITIONALLY_ON_ERROR` and `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR` error strategies.
 
@@ -65,7 +65,7 @@ The following options are available to configure the default Kafka listener exce
 
 include::{includedir}configurationProperties/io.micronaut.configuration.kafka.config.DefaultKafkaListenerExceptionHandlerConfigurationProperties.adoc[]
 
-If you wish to replace this default exception handling with another implementation you can use the Micronaut's <<replaces, Bean Replacement>> feature to define a bean that replaces it: `@Replaces(DefaultKafkaListenerExceptionHandler.class)`.
+If you wish to replace this default exception handling with another implementation you can use the Micronaut's link:https://docs.micronaut.io/latest/guide/#replaces[Bean Replacement] feature to define a bean that replaces it: `@Replaces(DefaultKafkaListenerExceptionHandler.class)`.
 
 You can also define per bean exception handling logic by implementing the api:configuration.kafka.exceptions.KafkaListenerExceptionHandler[] interface in your ann:configuration.kafka.annotation.KafkaListener[] class.
 

--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -67,7 +67,7 @@ snippet::io.micronaut.kafka.docs.consumer.config.ProductListener[tags="imports,c
 
 As mentioned previously when defining `@KafkaListener` methods, Micronaut will attempt to pick an appropriate deserializer for the method signature. This is done via the api:configuration.kafka.serde.CompositeSerdeRegistry[] bean.
 
-TIP: You can replace the default api:configuration.kafka.serde.SerdeRegistry[] bean with your own implementation by defining a bean that uses `@Replaces(CompositeSerdeRegistry.class)`. See the section on <<replaces, Bean Replacement>>.
+TIP: You can replace the default api:configuration.kafka.serde.SerdeRegistry[] bean with your own implementation by defining a bean that uses `@Replaces(CompositeSerdeRegistry.class)`. See the section on link:https://docs.micronaut.io/latest/guide/#replaces[Bean Replacement].
 
 All common `java.lang` types (`String`, `Integer`, primitives etc.) are supported and for POJOs by default a Jackson based JSON deserializer is used.
 

--- a/src/main/docs/guide/kafkaStreams/kafkaStreamHealth.adoc
+++ b/src/main/docs/guide/kafkaStreams/kafkaStreamHealth.adoc
@@ -1,4 +1,4 @@
-In addition to `http-server-netty`, if the `management` dependency is added, then Micronaut's <<healthEndpoint, Health Endpoint>> can be used to expose the health status of the Kafka streams application.
+In addition to `http-server-netty`, if the `management` dependency is added, then Micronaut's link:https://docs.micronaut.io/latest/guide/#healthEndpoint[Health Endpoint] can be used to expose the health status of the Kafka streams application.
 
 For example stream health at the `/health` endpoint will return:
 
@@ -32,7 +32,7 @@ For example stream health at the `/health` endpoint will return:
 }
 ----
 
-NOTE: By default, the details visible above are only shown to authenticated users. See the <<healthEndpoint, Health Endpoint>> documentation for how to configure that setting.
+NOTE: By default, the details visible above are only shown to authenticated users. See the link:https://docs.micronaut.io/latest/guide/#healthEndpoint[Health Endpoint] documentation for how to configure that setting.
 
 If you wish to disable the Kafka streams health check while still using the `management` dependency you can set the property `kafka.health.streams.enabled` to `false` in your application configuration.
 


### PR DESCRIPTION
Current links for "Bean Replacement" and "Health Endpoint" in kafka guide do not work because topics stored in different guide