### PR TITLE
fix: read autoPaused in a synchronized block

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -182,9 +182,11 @@ abstract class ConsumerState {
             LOG.info("Consumer [{}] assignments changed: {} -> {}", info.clientId, assignments, newAssignments);
             assignments = Collections.unmodifiableSet(newAssignments);
         }
-        if (autoPaused) {
-            pause(assignments);
-            kafkaConsumer.pause(assignments);
+        synchronized (this) {
+            if (autoPaused) {
+                pause(assignments);
+                kafkaConsumer.pause(assignments);
+            }
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/micronaut-projects/micronaut-kafka/issues/1124