### PR TITLE
Ability to selectively disable kafka streams #942 

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/ConfiguredStreamBuilder.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/ConfiguredStreamBuilder.java
@@ -15,12 +15,15 @@
  */
 package io.micronaut.configuration.kafka.streams;
 
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.Named;
 import org.apache.kafka.streams.StreamsBuilder;
 
 import java.time.Duration;
 import java.util.Properties;
+
+import static io.micronaut.configuration.kafka.streams.KafkaStreamsConfiguration.ENABLED_PROPERTY;
 
 /**
  * Extended version of {@link StreamsBuilder} that can be configured.
@@ -55,6 +58,9 @@ public class ConfiguredStreamBuilder extends StreamsBuilder implements Named {
      * @param closeTimeout The time to wait for the stream to shut down
      */
     public ConfiguredStreamBuilder(Properties configuration, String streamName, Duration closeTimeout) {
+        if (configuration.getProperty(ENABLED_PROPERTY, Boolean.TRUE.toString()).equals(Boolean.FALSE.toString())) {
+            throw new DisabledBeanException("Kafka Streams " + streamName + " is disabled");
+        }
         this.configuration.putAll(configuration);
         this.streamName = streamName;
         this.closeTimeout = closeTimeout;

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
@@ -44,6 +44,8 @@ public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfigu
      */
     public static final String PREFIX = "kafka.streams";
 
+    public static final String ENABLED_PROPERTY = "enabled";
+
     /**
      * Construct a new {@link KafkaStreamsConfiguration} for the given defaults.
      *

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
@@ -109,4 +109,12 @@ class KafkaStreamsSpec extends AbstractTestContainersSpec {
         then:
         builder.executed
     }
+
+    void "test kafka streams disabled"() {
+        when:
+        def factory = context.getBean(KafkaStreamsFactory)
+
+        then:
+        factory.getStreams().values().stream().filter(v -> v.name == 'turned-off-streams').findAny().isEmpty()
+    }
 }

--- a/kafka-streams/src/test/resources/application-test.yml
+++ b/kafka-streams/src/test/resources/application-test.yml
@@ -39,3 +39,7 @@ kafka:
       client.id: ${random.uuid}
       application-id: micronaut-kafka-streams-${random.uuid}
       group.id: ${random.uuid}
+    turned-off-streams:
+      enabled: false
+      client.id: ${random.uuid}
+      application-id: micronaut-kafka-streams-${random.uuid}

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -116,8 +116,14 @@ NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="namedStream", indent=0]
 
+.Disabling Kafka Stream
+
+When you want to explicitly disable a specific Kafka Stream, in your configuration you can set `kafka.streams.[STREAM-NAME].enabled` to `false`.
+
 .Configuring Kafka Streams for testing
 When writing a test without starting the actual Kafka server, you can instruct Micronaut not to start Kafka Streams. To do this create a config file suffixed with an environment name, such as `application-test.yml` and set the `kafka.streams.[STREAM-NAME].start-kafka-streams` to `false`.
+
+Take note that `start-kafka-streams` still loads the streams however it does not start it, if you are looking to disable it
 
 
 For example in `application-test.yml`:


### PR DESCRIPTION
Referring to #942 

The aim is to introduce a new `kafka.streams.[STREAM-NAME].enabled` property that when set to `false`, will not load the kafka stream builder hence not setting it up at all