### PR TITLE
Draft: Alpha version of ConsumerCreationStrategy.

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.kafka.annotation;
 
+import io.micronaut.configuration.kafka.processor.ConsumerCreationStrategy;
 import io.micronaut.context.annotation.*;
 import io.micronaut.messaging.annotation.MessageListener;
 import org.apache.kafka.common.IsolationLevel;
@@ -161,6 +162,15 @@ public @interface KafkaListener {
      * @see KafkaListener#threadsValue()
      */
     int threads() default 1;
+
+    /**
+     * Defines the consumer creation strategy to use when processing @Topic annotations
+     * inside of @KafkaListener annotated classes.
+     *
+     * If ConsumerCreationStrategy.PER_TOPIC is used, a new consumer will be created for method that has a @Topic annotation.
+     * If ConsumerCreationStrategy.PER_CLASS is used, a single consumer will be created for the entire class.
+     */
+    ConsumerCreationStrategy consumerCreationStrategy() default ConsumerCreationStrategy.PER_TOPIC;
 
     /**
      * The timeout to use for calls to {@link org.apache.kafka.clients.consumer.Consumer#poll(java.time.Duration)}.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategy.java
@@ -1,0 +1,17 @@
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Defines the strategy for creating consumers defined inside
+ * of class annotated with @KafkaListener annotation
+ *
+ * @author Vladimir Vrab
+ */
+@Internal
+public enum ConsumerCreationStrategy {
+
+    PER_TOPIC,
+
+    PER_CLASS
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategy.java
@@ -1,17 +1,29 @@
 package io.micronaut.configuration.kafka.processor;
 
-import io.micronaut.core.annotation.Internal;
-
 /**
  * Defines the strategy for creating consumers defined inside
  * of class annotated with @KafkaListener annotation
  *
  * @author Vladimir Vrab
+ * @since 5.9.0
  */
-@Internal
 public enum ConsumerCreationStrategy {
 
+    /**
+     * Creates a separate Kafka consumer for each method
+     * that listens to a different topic.
+     *
+     * <p>This allows parallel consumption across topics, but results in more
+     * consumer instances.</p>
+     */
     PER_TOPIC,
 
+    /**
+     * Creates a single Kafka consumer for the entire class,
+     * regardless of how many methods or topics it listens to.
+     *
+     * <p>This reduces the number of consumer instances, but may serialize
+     * consumption across topics.</p>
+     */
     PER_CLASS
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -31,12 +31,15 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.apache.kafka.clients.consumer.Consumer;
 
 /**
  * Internal consumer info.
@@ -63,7 +66,7 @@ final class ConsumerInfo {
     final boolean isBatch;
     final boolean isBlocking;
     final Duration pollTimeout;
-    @Nullable final Argument<?> consumerArg;
+    final Map<String, Argument<?>> consumerArg;
     @Nullable final Argument<?> ackArg;
     final boolean trackPartitions;
     final boolean shouldSendOffsetsToTransaction;
@@ -94,13 +97,23 @@ final class ConsumerInfo {
         this.isBatch = firstMethod.isTrue(KafkaListener.class, "batch");
         this.isBlocking = firstMethod.hasAnnotation(Blocking.class);
         this.pollTimeout = firstMethod.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
+        this.consumerArg = methods.stream().map(executableMethod -> {
+            var topic = executableMethod.getAnnotation(Topic.class).stringValue().orElseThrow(() -> new MessagingSystemException("Missing @Topic annotation"));
+            var consumerArg = Arrays.stream(executableMethod.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+            return consumerArg != null ? Map.entry(topic, consumerArg) : null;
+        })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (existing, replacement) -> existing,
+                HashMap::new
+            ));
         // problematic
-        // this.consumerArg = Arrays.stream(method.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.consumerArg = null;
         // this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
         this.ackArg = null;
-        // end problematic
         this.trackPartitions = ackArg != null || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
+        // end problematic
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
         this.methods = methods.stream()
             .collect(Collectors.toMap(
@@ -148,6 +161,10 @@ final class ConsumerInfo {
     public Argument<?> seekArg(String topic) {
         var method = methods.get(topic);
         return Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+    }
+
+    public Argument<?> consumerArg(String topic) {
+        return consumerArg.get(topic);
     }
 
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -28,6 +28,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.messaging.Acknowledgement;
 import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import java.util.HashMap;
@@ -54,6 +55,7 @@ final class ConsumerInfo {
     final boolean shouldRedeliver;
     final OffsetStrategy offsetStrategy;
     final ErrorStrategyValue errorStrategy;
+    final ConsumerCreationStrategy consumerCreationStrategy;
     final @Nullable Duration retryDelay;
     final int retryCount;
     final boolean shouldHandleAllExceptions;
@@ -61,13 +63,12 @@ final class ConsumerInfo {
     @Nullable final String producerClientId;
     @Nullable final String producerTransactionalId;
     final boolean isTransactional;
-    final HashMap<String, ExecutableMethod<Object, ?>> methods;
+    final Map<String, ExecutableMethod<Object, ?>> methods;
     final boolean autoStartup;
     final boolean isBatch;
     final boolean isBlocking;
     final Duration pollTimeout;
     final Map<String, Argument<?>> consumerArg;
-    @Nullable final Argument<?> ackArg;
     final boolean trackPartitions;
     final boolean shouldSendOffsetsToTransaction;
 
@@ -94,34 +95,14 @@ final class ConsumerInfo {
         this.isTransactional = producerTransactionalId != null;
         var firstMethod = methods.stream().findFirst().orElseThrow(() -> new MessagingSystemException("No methods found. Every KafkaListener must provide at least one method"));
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
+        this.consumerCreationStrategy = kafkaListener.enumValue("consumerCreationStrategy", ConsumerCreationStrategy.class).orElse(ConsumerCreationStrategy.PER_TOPIC);
         this.isBatch = firstMethod.isTrue(KafkaListener.class, "batch");
         this.isBlocking = firstMethod.hasAnnotation(Blocking.class);
         this.pollTimeout = firstMethod.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
-        this.consumerArg = methods.stream().map(executableMethod -> {
-            var topic = executableMethod.getAnnotation(Topic.class).stringValue().orElseThrow(() -> new MessagingSystemException("Missing @Topic annotation"));
-            var consumerArg = Arrays.stream(executableMethod.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-            return consumerArg != null ? Map.entry(topic, consumerArg) : null;
-        })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                (existing, replacement) -> existing,
-                HashMap::new
-            ));
-        // problematic
-        // this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.ackArg = null;
-        this.trackPartitions = ackArg != null || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
-        // end problematic
+        this.consumerArg = resolveConsumerArg(methods);
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
-        this.methods = methods.stream()
-            .collect(Collectors.toMap(
-                m -> m.getAnnotation(Topic.class).stringValue().orElseThrow(() -> new MessagingSystemException("Missing @Topic annotation")),
-                m -> (ExecutableMethod<Object, ?>) m,
-                (existing, replacement) -> existing,
-                HashMap::new
-            ));
+        this.methods = resolveMethods(methods);
+        this.trackPartitions = anyMethodHasAckArg() || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
         if (shouldSendOffsetsToTransaction) {
             if (!isTransactional || !allMethodsHaveAnnotation(SendTo.class)) {
                 throw new MessagingSystemException("Offset strategy 'SEND_TO_TRANSACTION' can only be used when transaction is enabled and @SendTo is used");
@@ -129,6 +110,61 @@ final class ConsumerInfo {
             if (shouldRedeliver) {
                 throw new MessagingSystemException("Redelivery not supported for transactions in combination with @SendTo");
             }
+        }
+
+        if (consumerCreationStrategy == ConsumerCreationStrategy.PER_CLASS && isBatch) {
+            throw new MessagingSystemException("Batch mode is not yet supported with consumer creation strategy 'PER_CLASS'");
+        }
+    }
+
+    private Map<String, Argument<?>> resolveConsumerArg(
+        List<ExecutableMethod<?, ?>> methods
+    ) {
+        return methods.stream().map(item -> {
+            var keys = item.getAnnotation(Topic.class).getValues().get("value");
+            if (keys == null) {
+                keys = item.getAnnotation(Topic.class).getValues().get("patterns");
+                if (keys == null) {
+                    throw new MessagingSystemException("Missing @Topic annotation");
+                }
+            }
+            var consumerArg = Arrays.stream(item.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+            return consumerArg != null ? Arrays.stream((String[]) keys).map(key -> Map.entry(key, consumerArg)).collect(Collectors.toList()) : null;
+        })
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (existing, replacement) -> existing,
+                HashMap::new
+            ));
+    }
+
+    private Map<String, ExecutableMethod<Object, ?>> resolveMethods(
+        List<ExecutableMethod<?, ?>> methods
+    ) {
+        try {
+            return methods.stream().map(item -> {
+                var keys = item.getAnnotation(Topic.class).getValues().get("value");
+                if (keys == null) {
+                    keys = item.getAnnotation(Topic.class).getValues().get("patterns");
+                    if (keys == null) {
+                        throw new MessagingSystemException("Missing @Topic annotation");
+                    }
+                }
+                return Arrays.stream((String[]) keys).map(key -> Map.entry(key, item)).collect(Collectors.toList());
+            }).flatMap(List::stream).collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> (ExecutableMethod<Object, ?>) entry.getValue()
+            ));
+        } catch (IllegalStateException e) {
+            if (e.getMessage().contains("Duplicate key")) {
+                var className = methods.stream().findFirst().get().getTargetMethod().getDeclaringClass();
+                throw new MessagingSystemException(
+                    "Duplicate topic found in @Topic annotation for " + className + " . Only one topic per listener is allowed.");
+            }
+            throw e;
         }
     }
 
@@ -167,4 +203,12 @@ final class ConsumerInfo {
         return consumerArg.get(topic);
     }
 
+    public Argument<?> ackArg(String topic) {
+        var method = methods.get(topic);
+        return Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+    }
+
+    private boolean anyMethodHasAckArg() {
+        return methods.values().stream().anyMatch(m -> Arrays.stream(m.getArguments()).anyMatch(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())));
+    }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -28,12 +28,10 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ExecutableMethod;
-import io.micronaut.messaging.Acknowledgement;
 import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import java.util.HashMap;
 import java.util.stream.Collectors;
-import org.apache.kafka.clients.consumer.Consumer;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -60,21 +58,15 @@ final class ConsumerInfo {
     @Nullable final String producerClientId;
     @Nullable final String producerTransactionalId;
     final boolean isTransactional;
-    final ExecutableMethod<Object, ?> method;
     final HashMap<String, ExecutableMethod<Object, ?>> methods;
-    final String logMethod;
     final boolean autoStartup;
     final boolean isBatch;
     final boolean isBlocking;
     final Duration pollTimeout;
     @Nullable final Argument<?> consumerArg;
-    @Nullable final Argument<?> seekArg;
     @Nullable final Argument<?> ackArg;
     final boolean trackPartitions;
-    final List<String> sendToTopics;
     final boolean shouldSendOffsetsToTransaction;
-    final boolean returnsOneKafkaMessage;
-    final boolean returnsManyKafkaMessages;
 
     @SuppressWarnings("unchecked")
     ConsumerInfo(
@@ -97,30 +89,19 @@ final class ConsumerInfo {
         this.producerClientId = kafkaListener.stringValue("producerClientId").orElse(null);
         this.producerTransactionalId = kafkaListener.stringValue("producerTransactionalId").filter(StringUtils::isNotEmpty).orElse(null);
         this.isTransactional = producerTransactionalId != null;
-        // TBA: solveable with using method for this
-        this.logMethod = method.getDeclaringType().getSimpleName() + "#" + method.getName();
+        var firstMethod = methods.stream().findFirst().orElseThrow(() -> new MessagingSystemException("No methods found. Every KafkaListener must provide at least one method"));
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
-        this.isBatch = method.isTrue(KafkaListener.class, "batch");
-        this.isBlocking = method.hasAnnotation(Blocking.class);
-        this.pollTimeout = method.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
+        this.isBatch = firstMethod.isTrue(KafkaListener.class, "batch");
+        this.isBlocking = firstMethod.hasAnnotation(Blocking.class);
+        this.pollTimeout = firstMethod.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
         // problematic
-        this.consumerArg = Arrays.stream(method.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.seekArg = Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+        // this.consumerArg = Arrays.stream(method.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+        this.consumerArg = null;
+        // this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+        this.ackArg = null;
         // end problematic
         this.trackPartitions = ackArg != null || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
-
-        // TBA: solveable with using method for this
-        this.sendToTopics = Optional.ofNullable(method.stringValues(SendTo.class)).filter(ArrayUtils::isNotEmpty).stream().flatMap(Arrays::stream).toList();
-
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
-
-        // TBA: solveable with using method for this
-        this.returnsOneKafkaMessage = method.getReturnType().getType().isAssignableFrom(KafkaMessage.class) || method.getReturnType().isAsyncOrReactive() && method.getReturnType().getFirstTypeVariable()
-            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
-        // TBA: solveable with using method for this
-        this.returnsManyKafkaMessages = Iterable.class.isAssignableFrom(method.getReturnType().getType()) && method.getReturnType().getFirstTypeVariable()
-            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
         this.methods = methods.stream()
             .collect(Collectors.toMap(
                 m -> m.getAnnotation(Topic.class).stringValue().orElseThrow(() -> new MessagingSystemException("Missing @Topic annotation")),
@@ -129,7 +110,7 @@ final class ConsumerInfo {
                 HashMap::new
             ));
         if (shouldSendOffsetsToTransaction) {
-            if (!isTransactional || !method.hasAnnotation(SendTo.class)) {
+            if (!isTransactional || !allMethodsHaveAnnotation(SendTo.class)) {
                 throw new MessagingSystemException("Offset strategy 'SEND_TO_TRANSACTION' can only be used when transaction is enabled and @SendTo is used");
             }
             if (shouldRedeliver) {
@@ -137,4 +118,36 @@ final class ConsumerInfo {
             }
         }
     }
+
+    private boolean allMethodsHaveAnnotation(Class<SendTo> sendToClass) {
+        return methods.values().stream().allMatch(m -> m.hasAnnotation(sendToClass));
+    }
+
+    public String logMethod(String topic) {
+        var method = methods.get(topic);
+        return method.getDeclaringType().getSimpleName() + "#" + method.getName();
+    }
+
+    public List<String> sendToTopics(String consumedRecordTopic) {
+        var method = methods.get(consumedRecordTopic);
+        return Optional.ofNullable(method.stringValues(SendTo.class)).filter(ArrayUtils::isNotEmpty).stream().flatMap(Arrays::stream).toList();
+    }
+
+    public boolean returnsOneKafkaMessage(String topic) {
+        var method = methods.get(topic);
+        return method.getReturnType().getType().isAssignableFrom(KafkaMessage.class) || method.getReturnType().isAsyncOrReactive() && method.getReturnType().getFirstTypeVariable()
+            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
+    }
+
+    public boolean returnsManyKafkaMessages(String topic) {
+        var method = methods.get(topic);
+        return Iterable.class.isAssignableFrom(method.getReturnType().getType()) && method.getReturnType().getFirstTypeVariable()
+            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
+    }
+
+    public Argument<?> seekArg(String topic) {
+        var method = methods.get(topic);
+        return Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+    }
+
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -20,6 +20,7 @@ import io.micronaut.configuration.kafka.annotation.ErrorStrategy;
 import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
 import io.micronaut.configuration.kafka.annotation.KafkaListener;
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
+import io.micronaut.configuration.kafka.annotation.Topic;
 import io.micronaut.configuration.kafka.seek.KafkaSeekOperations;
 import io.micronaut.core.annotation.*;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -30,6 +31,8 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.messaging.Acknowledgement;
 import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
+import java.util.HashMap;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.Consumer;
 
 import java.time.Duration;
@@ -58,6 +61,7 @@ final class ConsumerInfo {
     @Nullable final String producerTransactionalId;
     final boolean isTransactional;
     final ExecutableMethod<Object, ?> method;
+    final HashMap<String, ExecutableMethod<Object, ?>> methods;
     final String logMethod;
     final boolean autoStartup;
     final boolean isBatch;
@@ -78,7 +82,7 @@ final class ConsumerInfo {
         String groupId,
         OffsetStrategy offsetStrategy,
         AnnotationValue<KafkaListener> kafkaListener,
-        ExecutableMethod<?, ?> method
+        List<ExecutableMethod<?, ?>> methods
     ) {
         this.clientId = clientId;
         this.groupId = groupId;
@@ -93,23 +97,37 @@ final class ConsumerInfo {
         this.producerClientId = kafkaListener.stringValue("producerClientId").orElse(null);
         this.producerTransactionalId = kafkaListener.stringValue("producerTransactionalId").filter(StringUtils::isNotEmpty).orElse(null);
         this.isTransactional = producerTransactionalId != null;
-        this.method = (ExecutableMethod<Object, ?>) method;
+        // TBA: solveable with using method for this
         this.logMethod = method.getDeclaringType().getSimpleName() + "#" + method.getName();
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
         this.isBatch = method.isTrue(KafkaListener.class, "batch");
         this.isBlocking = method.hasAnnotation(Blocking.class);
         this.pollTimeout = method.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
+        // problematic
         this.consumerArg = Arrays.stream(method.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
         this.seekArg = Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
         this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+        // end problematic
         this.trackPartitions = ackArg != null || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
+
+        // TBA: solveable with using method for this
         this.sendToTopics = Optional.ofNullable(method.stringValues(SendTo.class)).filter(ArrayUtils::isNotEmpty).stream().flatMap(Arrays::stream).toList();
+
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
+
+        // TBA: solveable with using method for this
         this.returnsOneKafkaMessage = method.getReturnType().getType().isAssignableFrom(KafkaMessage.class) || method.getReturnType().isAsyncOrReactive() && method.getReturnType().getFirstTypeVariable()
             .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
+        // TBA: solveable with using method for this
         this.returnsManyKafkaMessages = Iterable.class.isAssignableFrom(method.getReturnType().getType()) && method.getReturnType().getFirstTypeVariable()
             .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
-
+        this.methods = methods.stream()
+            .collect(Collectors.toMap(
+                m -> m.getAnnotation(Topic.class).stringValue().orElseThrow(() -> new MessagingSystemException("Missing @Topic annotation")),
+                m -> (ExecutableMethod<Object, ?>) m,
+                (existing, replacement) -> existing,
+                HashMap::new
+            ));
         if (shouldSendOffsetsToTransaction) {
             if (!isTransactional || !method.hasAnnotation(SendTo.class)) {
                 throw new MessagingSystemException("Offset strategy 'SEND_TO_TRANSACTION' can only be used when transaction is enabled and @SendTo is used");

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -33,6 +33,7 @@ import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -102,9 +103,9 @@ final class ConsumerInfo {
         this.isBatch = firstMethod.isTrue(KafkaListener.class, "batch");
         this.isBlocking = firstMethod.hasAnnotation(Blocking.class);
         this.pollTimeout = firstMethod.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
-        this.consumerArg = resolveConsumerArg(methods);
+        this.methods = resolveToTopicToMethodBinding(methods);
+        this.consumerArg = resolveConsumerArg(this.methods);
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
-        this.methods = resolveMethods(methods);
         this.trackPartitions = anyMethodHasAckArg() || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
         if (shouldSendOffsetsToTransaction) {
             if (!isTransactional || !allMethodsHaveAnnotation(SendTo.class)) {
@@ -120,10 +121,11 @@ final class ConsumerInfo {
         }
     }
 
-    private Map<String, Argument<?>> resolveConsumerArg(
+    @SuppressWarnings("unchecked")
+    private Map<String, ExecutableMethod<Object, ?>> resolveToTopicToMethodBinding(
         List<ExecutableMethod<?, ?>> methods
     ) {
-        return methods.stream().map(item -> {
+        return methods.stream().flatMap(item -> {
             var keys = item.getAnnotation(Topic.class).getValues().get("value");
             if (keys == null) {
                 keys = item.getAnnotation(Topic.class).getValues().get("patterns");
@@ -131,44 +133,19 @@ final class ConsumerInfo {
                     throw new MessagingSystemException("Missing @Topic annotation");
                 }
             }
-            var consumerArg = Arrays.stream(item.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-            return consumerArg != null ? Arrays.stream((String[]) keys).map(key -> Map.entry(key, consumerArg)).collect(Collectors.toList()) : null;
-        })
-            .filter(Objects::nonNull)
-            .flatMap(List::stream)
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                (existing, replacement) -> existing,
-                HashMap::new
-            ));
+            return Arrays.stream((String[]) keys).map(key -> Map.entry(key, item));
+        }).collect(Collectors.toMap(Entry::getKey, item -> (ExecutableMethod<Object, ?>)item.getValue()));
     }
 
-    private Map<String, ExecutableMethod<Object, ?>> resolveMethods(
-        List<ExecutableMethod<?, ?>> methods
+    private Map<String, Argument<?>> resolveConsumerArg(
+        Map<String, ExecutableMethod<Object, ?>> methods
     ) {
-        try {
-            return methods.stream().map(item -> {
-                var keys = item.getAnnotation(Topic.class).getValues().get("value");
-                if (keys == null) {
-                    keys = item.getAnnotation(Topic.class).getValues().get("patterns");
-                    if (keys == null) {
-                        throw new MessagingSystemException("Missing @Topic annotation");
-                    }
-                }
-                return Arrays.stream((String[]) keys).map(key -> Map.entry(key, item)).collect(Collectors.toList());
-            }).flatMap(List::stream).collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> (ExecutableMethod<Object, ?>) entry.getValue()
-            ));
-        } catch (IllegalStateException e) {
-            if (e.getMessage().contains("Duplicate key")) {
-                var className = methods.stream().findFirst().get().getTargetMethod().getDeclaringClass();
-                throw new MessagingSystemException(
-                    "Duplicate topic found in @Topic annotation for " + className + " . Only one topic per listener is allowed.");
-            }
-            throw e;
-        }
+        return methods.entrySet().stream().map(entry -> {
+            var consumerArg = Arrays.stream(entry.getValue().getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+            return consumerArg != null ? Map.entry(entry.getKey(), consumerArg) : null;
+        })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
     private boolean allMethodsHaveAnnotation(Class<SendTo> sendToClass) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -72,6 +72,9 @@ final class ConsumerInfo {
     final boolean trackPartitions;
     final boolean shouldSendOffsetsToTransaction;
 
+    private final Map<String, Argument<?>> seekArgCache = new HashMap<>();
+    private final Map<String, Argument<?>> ackArgCache = new HashMap<>();
+
     @SuppressWarnings("unchecked")
     ConsumerInfo(
         String clientId,
@@ -172,40 +175,53 @@ final class ConsumerInfo {
         return methods.values().stream().allMatch(m -> m.hasAnnotation(sendToClass));
     }
 
-    public String logMethod(String topic) {
+    String logMethod(String topic) {
         var method = methods.get(topic);
         return method.getDeclaringType().getSimpleName() + "#" + method.getName();
     }
 
-    public List<String> sendToTopics(String consumedRecordTopic) {
+    List<String> sendToTopics(String consumedRecordTopic) {
         var method = methods.get(consumedRecordTopic);
         return Optional.ofNullable(method.stringValues(SendTo.class)).filter(ArrayUtils::isNotEmpty).stream().flatMap(Arrays::stream).toList();
     }
 
-    public boolean returnsOneKafkaMessage(String topic) {
+    boolean returnsOneKafkaMessage(String topic) {
         var method = methods.get(topic);
-        return method.getReturnType().getType().isAssignableFrom(KafkaMessage.class) || method.getReturnType().isAsyncOrReactive() && method.getReturnType().getFirstTypeVariable()
-            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
+        var returnType = method.getReturnType();
+        return returnType.getType().isAssignableFrom(KafkaMessage.class) ||
+            (returnType.isAsyncOrReactive() && returnType.getFirstTypeVariable()
+                .map(t -> t.getType().isAssignableFrom(KafkaMessage.class))
+                .orElse(false));
     }
 
-    public boolean returnsManyKafkaMessages(String topic) {
+    boolean returnsManyKafkaMessages(String topic) {
         var method = methods.get(topic);
         return Iterable.class.isAssignableFrom(method.getReturnType().getType()) && method.getReturnType().getFirstTypeVariable()
             .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
     }
 
-    public Argument<?> seekArg(String topic) {
-        var method = methods.get(topic);
-        return Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+    Argument<?> seekArg(String topic) {
+        return seekArgCache.computeIfAbsent(topic, t -> {
+            var method = methods.get(t);
+            return Arrays.stream(method.getArguments())
+                .filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType()))
+                .findFirst()
+                .orElse(null);
+        });
     }
 
-    public Argument<?> consumerArg(String topic) {
+    Argument<?> consumerArg(String topic) {
         return consumerArg.get(topic);
     }
 
-    public Argument<?> ackArg(String topic) {
-        var method = methods.get(topic);
-        return Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
+    Argument<?> ackArg(String topic) {
+        return ackArgCache.computeIfAbsent(topic, t -> {
+            var method = methods.get(t);
+            return Arrays.stream(method.getArguments())
+                .filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType()))
+                .findFirst()
+                .orElse(null);
+        });
     }
 
     private boolean anyMethodHasAckArg() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.ExecutableMethod;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -205,12 +206,6 @@ abstract class ConsumerState {
         if (consumerRecords == null || consumerRecords.isEmpty()) {
             return; // No consumer records to process
         }
-        // Support Kotlin coroutines
-        // TODO 2: Tackle this
-        // if (info.method.isSuspend()) {
-        //     Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
-        //     boundArguments.put(lastArgument, null);
-        // }
         processRecords(consumerRecords, currentOffsets);
         if (failed) {
             return;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -206,7 +206,7 @@ abstract class ConsumerState {
             return; // No consumer records to process
         }
         // Support Kotlin coroutines
-        // TODO: Tackle this
+        // TODO 2: Tackle this
         // if (info.method.isSuspend()) {
         //     Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
         //     boundArguments.put(lastArgument, null);
@@ -384,14 +384,14 @@ abstract class ConsumerState {
     }
 
     private Publisher<RecordMetadata> handleSendToError(Throwable error, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
-        // handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
+        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.methods.get(consumerRecord.topic()) + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
 
         if (!info.shouldRedeliver) {
             return Flux.empty();
         }
 
         return redeliver(consumerRecord)
-            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer : " + error.getMessage(), ex, consumerRecords, consumerRecord));
+            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.methods.get(consumerRecord.topic()) + "]: "+ error.getMessage(), ex, consumerRecords, consumerRecord));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -83,7 +83,6 @@ abstract class ConsumerState {
         this.subscriptions = Collections.unmodifiableSet(kafkaConsumer.subscription());
         this.autoPaused = !info.autoStartup;
         this.boundArguments = new HashMap<>(2);
-        Optional.ofNullable(info.consumerArg).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
         this.closedState = ConsumerCloseState.NOT_STARTED;
         this.topicPartitionRetries = this.info.errorStrategy.isRetry() ? new HashMap<>() : null;
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -207,10 +207,11 @@ abstract class ConsumerState {
             return; // No consumer records to process
         }
         // Support Kotlin coroutines
-        if (info.method.isSuspend()) {
-            Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
-            boundArguments.put(lastArgument, null);
-        }
+        // TODO: Tackle this
+        // if (info.method.isSuspend()) {
+        //     Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
+        //     boundArguments.put(lastArgument, null);
+        // }
         processRecords(consumerRecords, currentOffsets);
         if (failed) {
             return;
@@ -270,17 +271,17 @@ abstract class ConsumerState {
     ) {
         final Flux<RecordMetadata> recordMetadataProducer = publisher
             .flatMap(value -> sendToDestination(value, consumerRecord, consumerRecords));
-
+        var method = info.methods.get(consumerRecord.topic());
         if (isBlocking) {
             List<RecordMetadata> listRecords = recordMetadataProducer.collectList().block();
-            LOG.trace("Method [{}] produced record metadata: {}", info.method, listRecords);
+            LOG.trace("Method [{}] produced record metadata: {}", method, listRecords);
         } else {
-            recordMetadataProducer.subscribe(recordMetadata -> LOG.trace("Method [{}] produced record metadata: {}", info.logMethod, recordMetadata));
+            recordMetadataProducer.subscribe(recordMetadata -> LOG.trace("Method [{}] produced record metadata: {}", method, recordMetadata));
         }
     }
 
     private Publisher<RecordMetadata> sendToDestination(Object value, ConsumerRecord<?, ?> consumerRecord, ConsumerRecords<?, ?> consumerRecords) {
-        if (value == null || info.sendToTopics.isEmpty()) {
+        if (value == null || info.sendToTopics(consumerRecord.topic()).isEmpty()) {
             return Flux.empty();
         }
         final Object key = consumerRecord.key();
@@ -323,8 +324,8 @@ abstract class ConsumerState {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private void sendToDestination(Producer<?, ?> kafkaProducer, Callback callback, Object key, Object value, ConsumerRecord<?, ?> consumerRecord) {
-        for (String destinationTopic : info.sendToTopics) {
-            if (info.returnsManyKafkaMessages) {
+        for (String destinationTopic : info.sendToTopics(consumerRecord.topic())) {
+            if (info.returnsManyKafkaMessages(consumerRecord.topic())) {
                 final Iterable<KafkaMessage> messages = (Iterable<KafkaMessage>) value;
                 for (KafkaMessage message : messages) {
                     final ProducerRecord producerRecord = createFromMessage(destinationTopic, message);
@@ -332,7 +333,7 @@ abstract class ConsumerState {
                 }
             } else {
                 final ProducerRecord producerRecord;
-                if (info.returnsOneKafkaMessage) {
+                if (info.returnsOneKafkaMessage(consumerRecord.topic())) {
                     producerRecord = createFromMessage(destinationTopic, (KafkaMessage) value);
                 } else {
                     producerRecord = new ProducerRecord(destinationTopic, null, key, value, consumerRecord.headers());
@@ -384,14 +385,14 @@ abstract class ConsumerState {
     }
 
     private Publisher<RecordMetadata> handleSendToError(Throwable error, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
-        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
+        // handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
 
         if (!info.shouldRedeliver) {
             return Flux.empty();
         }
 
         return redeliver(consumerRecord)
-            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), ex, consumerRecords, consumerRecord));
+            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer : " + error.getMessage(), ex, consumerRecords, consumerRecord));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
+import io.micronaut.core.type.Argument;
 import java.util.HashMap;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -90,6 +91,11 @@ final class ConsumerStateBatch extends ConsumerState {
             }
             Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
             var method = info.methods.get(topic);
+            // Support Kotlin coroutines
+            if (method.isSuspend()) {
+                Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
+                boundArguments.put(lastArgument, null);
+            }
 
             final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -81,15 +81,13 @@ final class ConsumerStateBatch extends ConsumerState {
     @Override
     protected void processRecords(ConsumerRecords<?, ?> consumerRecords, @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
-            // Bind Acknowledgement argument
-            if (info.ackArg != null) {
-                final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(consumerRecords);
-                boundArguments.put(info.ackArg, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
-            }
-            // TODO: It will not work for batch consumers YET
-            // TODO: Get topic from consumerRecords
-            // TODO: We should get a list of topics? Think about it
             var topic = consumerRecords.partitions().stream().map(TopicPartition::topic).findFirst().orElse(null);
+
+            // Bind Acknowledgement argument
+            if (info.ackArg(topic) != null) {
+                final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(consumerRecords);
+                boundArguments.put(info.ackArg(topic), (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+            }
             Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
             var method = info.methods.get(topic);
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -67,7 +67,7 @@ final class ConsumerStateBatch extends ConsumerState {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
+            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             // By default, seek past the record to continue consumption
             kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
@@ -86,7 +86,11 @@ final class ConsumerStateBatch extends ConsumerState {
                 boundArguments.put(info.ackArg, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
             }
             final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
-            final Object result = batchBinder.bind(info.method, kafkaConsumerProcessor.getBatchBinderRegistry(), consumerRecords).invoke(consumerBean);
+            // TODO: it will not yet work for batch consumers
+            // TODO: get topic from consumerRecords
+            var topic = consumerRecords.partitions().stream().map(TopicPartition::topic).findFirst().orElse(null);
+            var method = info.methods.get(topic);
+            final Object result = batchBinder.bind(method, kafkaConsumerProcessor.getBatchBinderRegistry(), consumerRecords).invoke(consumerBean);
             handleResult(normalizeResult(result), consumerRecords);
             failed = false;
         } catch (Exception e) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -23,6 +23,7 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
 import java.util.HashMap;
+import java.util.Optional;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -85,11 +86,15 @@ final class ConsumerStateBatch extends ConsumerState {
                 final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(consumerRecords);
                 boundArguments.put(info.ackArg, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
             }
-            final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
-            // TODO: it will not yet work for batch consumers
-            // TODO: get topic from consumerRecords
+            // TODO: It will not work for batch consumers YET
+            // TODO: Get topic from consumerRecords
+            // TODO: We should get a list of topics? Think about it
             var topic = consumerRecords.partitions().stream().map(TopicPartition::topic).findFirst().orElse(null);
+            Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
             var method = info.methods.get(topic);
+
+            final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
+
             final Object result = batchBinder.bind(method, kafkaConsumerProcessor.getBatchBinderRegistry(), consumerRecords).invoke(consumerBean);
             handleResult(normalizeResult(result), consumerRecords);
             failed = false;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -85,7 +85,7 @@ final class ConsumerStateSingle extends ConsumerState {
 
             final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg(consumerRecord.topic())).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
             Optional.ofNullable(info.seekArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, seek));
-            Optional.ofNullable(info.ackArg).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
+            Optional.ofNullable(info.ackArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
             Optional.ofNullable(info.consumerArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
             try {
                 process(consumerRecord, consumerRecords);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -58,7 +58,7 @@ final class ConsumerStateSingle extends ConsumerState {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
+            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             // By default, seek past the record to continue consumption
             kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
@@ -75,7 +75,7 @@ final class ConsumerStateSingle extends ConsumerState {
         while (iterator.hasNext()) {
             final ConsumerRecord<?, ?> consumerRecord = iterator.next();
 
-            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod, consumerRecord);
+            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(consumerRecord.topic()), consumerRecord);
 
             if (info.trackPartitions) {
                 final TopicPartition topicPartition = getTopicPartition(consumerRecord);
@@ -83,8 +83,8 @@ final class ConsumerStateSingle extends ConsumerState {
                 currentOffsets.put(topicPartition, offsetAndMetadata);
             }
 
-            final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
-            Optional.ofNullable(info.seekArg).ifPresent(argument -> boundArguments.put(argument, seek));
+            final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg(consumerRecord.topic())).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
+            Optional.ofNullable(info.seekArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, seek));
             Optional.ofNullable(info.ackArg).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
 
             try {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -86,7 +86,7 @@ final class ConsumerStateSingle extends ConsumerState {
             final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg(consumerRecord.topic())).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
             Optional.ofNullable(info.seekArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, seek));
             Optional.ofNullable(info.ackArg).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
-
+            Optional.ofNullable(info.consumerArg(consumerRecord.topic())).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
             try {
                 process(consumerRecord, consumerRecords);
             } catch (Exception e) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -115,7 +115,8 @@ final class ConsumerStateSingle extends ConsumerState {
     private void process(ConsumerRecord<?, ?> consumerRecord,
         ConsumerRecords<?, ?> consumerRecords) {
         final ExecutableBinder<ConsumerRecord<?, ?>> executableBinder = new DefaultExecutableBinder<>(boundArguments);
-        final Object result = executableBinder.bind(info.method, kafkaConsumerProcessor.getBinderRegistry(), consumerRecord).invoke(consumerBean);
+        var method = info.methods.get(consumerRecord.topic());
+        final Object result = executableBinder.bind(method, kafkaConsumerProcessor.getBinderRegistry(), consumerRecord).invoke(consumerBean);
         if (result != null) {
             final boolean isPublisher = Publishers.isConvertibleToPublisher(result);
             final Flux<?> publisher = isPublisher ? kafkaConsumerProcessor.convertPublisher(result) : Flux.just(result);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -25,6 +25,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
+import io.micronaut.core.type.Argument;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
@@ -114,8 +115,13 @@ final class ConsumerStateSingle extends ConsumerState {
 
     private void process(ConsumerRecord<?, ?> consumerRecord,
         ConsumerRecords<?, ?> consumerRecords) {
-        final ExecutableBinder<ConsumerRecord<?, ?>> executableBinder = new DefaultExecutableBinder<>(boundArguments);
         var method = info.methods.get(consumerRecord.topic());
+        // Support Kotlin coroutines
+        if (method.isSuspend()) {
+            Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
+            boundArguments.put(lastArgument, null);
+        }
+        final ExecutableBinder<ConsumerRecord<?, ?>> executableBinder = new DefaultExecutableBinder<>(boundArguments);
         final Object result = executableBinder.bind(method, kafkaConsumerProcessor.getBinderRegistry(), consumerRecord).invoke(consumerBean);
         if (result != null) {
             final boolean isPublisher = Publishers.isConvertibleToPublisher(result);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -521,7 +521,7 @@ class KafkaConsumerProcessor
             }
             setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
-            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, method, methods);
+            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, methods);
             final ConsumerState consumerState = consumerInfo.isBatch ?
                 new ConsumerStateBatch(this, consumerInfo, kafkaConsumer, consumerBean) :
                 new ConsumerStateSingle(this, consumerInfo, kafkaConsumer, consumerBean);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -538,7 +538,6 @@ class KafkaConsumerProcessor
         final boolean hasPatterns = !patterns.isEmpty();
         final String logMethod = LOG.isInfoEnabled() ? logMethod(method) : null;
 
-        // TODO: Only one can be specified (maybe)
         if (!hasTopics && !hasPatterns) {
             throw new MessagingSystemException("Either a topic or a pattern must be specified for method: " + method);
         }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -65,6 +65,7 @@ import io.micronaut.scheduling.TaskScheduler;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import java.util.ArrayList;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.IsolationLevel;
@@ -117,6 +118,7 @@ class KafkaConsumerProcessor
     @SuppressWarnings("rawtypes")
     private final AbstractKafkaConsumerConfiguration defaultConsumerConfiguration;
     private final Map<String, ConsumerState> consumers = new ConcurrentHashMap<>();
+    private List<String> kafkaListenersCreated = new ArrayList<>();
 
     private final ConsumerRecordBinderRegistry binderRegistry;
     private final SerdeRegistry serdeRegistry;
@@ -275,12 +277,18 @@ class KafkaConsumerProcessor
 
     @Override
     public void process(BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
-        List<AnnotationValue<Topic>> topicAnnotations = method.getDeclaredAnnotationValuesByType(Topic.class);
         final AnnotationValue<KafkaListener> consumerAnnotation = method.getAnnotation(KafkaListener.class);
-        if (CollectionUtils.isEmpty(topicAnnotations)) {
-            topicAnnotations = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
+        if (consumerAnnotation == null) {
+            return;
         }
-        if (consumerAnnotation == null || CollectionUtils.isEmpty(topicAnnotations)) {
+        ConsumerCreationStrategy consumerCreationStrategy = consumerAnnotation.enumValue("consumerCreationStrategy", ConsumerCreationStrategy.class)
+            .orElse(ConsumerCreationStrategy.PER_TOPIC);
+        if (consumerCreationStrategy.equals(ConsumerCreationStrategy.PER_CLASS) && kafkaListenersCreated.contains(beanDefinition.getBeanType().getName())) {
+            return; // Listener already created
+        }
+        List<AnnotationValue<Topic>> topicAnnotations = resolveTopicAnnotations(consumerCreationStrategy, method, beanDefinition);
+
+        if (CollectionUtils.isEmpty(topicAnnotations)) {
             return; // No topics to consume
         }
         final Class<?> beanType = beanDefinition.getBeanType();
@@ -300,6 +308,24 @@ class KafkaConsumerProcessor
         final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
         configureDeserializers(method, consumerConfiguration);
         submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations, consumerAnnotation, consumerConfiguration, properties, beanType);
+        kafkaListenersCreated.add(beanType.getName());
+    }
+
+    protected List<AnnotationValue<Topic>> resolveTopicAnnotations(final ConsumerCreationStrategy consumerCreationStrategy,
+                                                                   final ExecutableMethod<?, ?> method,
+                                                                   final BeanDefinition<?> beanDefinition) {
+        List<AnnotationValue<Topic>> topicAnnotations = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
+        if (CollectionUtils.isEmpty(topicAnnotations)) {
+            if (consumerCreationStrategy.equals(ConsumerCreationStrategy.PER_TOPIC)) {
+                topicAnnotations = method.getDeclaredAnnotationValuesByType(Topic.class);
+            } else {
+                topicAnnotations = beanDefinition.getExecutableMethods().stream()
+                    .filter(executableMethod -> executableMethod.hasAnnotation(Topic.class))
+                    .map(m -> m.getAnnotation(Topic.class))
+                    .toList();
+            }
+        }
+        return topicAnnotations;
     }
 
     @Override
@@ -481,36 +507,37 @@ class KafkaConsumerProcessor
                 //noinspection unchecked
                 ca.setKafkaConsumer(kafkaConsumer);
             }
-            topicAnnotations.forEach(a -> setupConsumerSubscription(method, a, consumerBean, kafkaConsumer));
+            setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
             final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, method);
             final ConsumerState consumerState = consumerInfo.isBatch ?
                 new ConsumerStateBatch(this, consumerInfo, kafkaConsumer, consumerBean) :
                 new ConsumerStateSingle(this, consumerInfo, kafkaConsumer, consumerBean);
+
             consumers.put(finalClientId, consumerState);
             executorService.submit(consumerState::threadPollLoop);
         }
     }
 
-    private static void setupConsumerSubscription(ExecutableMethod<?, ?> method, AnnotationValue<Topic> topicAnnotation, Object consumerBean, Consumer<?, ?> kafkaConsumer) {
-        final String[] topicNames = topicAnnotation.stringValues();
-        final String[] patterns = topicAnnotation.stringValues("patterns");
-        final boolean hasTopics = ArrayUtils.isNotEmpty(topicNames);
-        final boolean hasPatterns = ArrayUtils.isNotEmpty(patterns);
+    private static void setupConsumerSubscription(ExecutableMethod<?, ?> method, List<AnnotationValue<Topic>> topicAnnotations, Object consumerBean, Consumer<?, ?> kafkaConsumer) {
+        final List<String> topicNames = topicAnnotations.stream().flatMap(a -> Arrays.stream(a.stringValues())).toList();
+        final List<String> patterns = topicAnnotations.stream().flatMap(a -> Arrays.stream(a.stringValues("patterns"))).toList();
+        final boolean hasTopics = !topicNames.isEmpty();
+        final boolean hasPatterns = !patterns.isEmpty();
         final String logMethod = LOG.isInfoEnabled() ? logMethod(method) : null;
 
+        // TODO: Only one can be specified (maybe)
         if (!hasTopics && !hasPatterns) {
-            throw new MessagingSystemException("Either a topic or a topic must be specified for method: " + method);
+            throw new MessagingSystemException("Either a topic or a pattern must be specified for method: " + method);
         }
 
         final Optional<ConsumerRebalanceListener> listener = getConsumerRebalanceListener(consumerBean, kafkaConsumer);
 
         if (hasTopics) {
-            final List<String> topics = Arrays.asList(topicNames);
             listener.ifPresentOrElse(
-                l -> kafkaConsumer.subscribe(topics, l),
-                () -> kafkaConsumer.subscribe(topics));
-            LOG.info("Kafka listener [{}] subscribed to topics: {}", logMethod, topics);
+                l -> kafkaConsumer.subscribe(topicNames, l),
+                () -> kafkaConsumer.subscribe(topicNames));
+            LOG.info("Kafka listener [{}] subscribed to topics: {}", logMethod, topicNames);
         }
 
         if (hasPatterns) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -308,7 +308,7 @@ class KafkaConsumerProcessor
         final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
         final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
         configureDeserializers(method, consumerConfiguration);
-        submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations, consumerAnnotation, consumerConfiguration, properties, beanType, methods);
+        submitConsumerThreads(method, clientId, groupId, offsetStrategy, consumerCreationStrategy, topicAnnotations, consumerAnnotation, consumerConfiguration, properties, beanType, methods);
         kafkaListenersCreated.add(beanType.getName());
     }
 
@@ -494,6 +494,7 @@ class KafkaConsumerProcessor
                                        final String clientId,
                                        final String groupId,
                                        final OffsetStrategy offsetStrategy,
+                                       final ConsumerCreationStrategy consumerCreationStrategy,
                                        final List<AnnotationValue<Topic>> topicAnnotations,
                                        final AnnotationValue<KafkaListener> consumerAnnotation,
                                        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration,
@@ -519,7 +520,7 @@ class KafkaConsumerProcessor
                 //noinspection unchecked
                 ca.setKafkaConsumer(kafkaConsumer);
             }
-            setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
+            setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer, consumerCreationStrategy);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
             final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, methods);
             final ConsumerState consumerState = consumerInfo.isBatch ?
@@ -531,7 +532,12 @@ class KafkaConsumerProcessor
         }
     }
 
-    private static void setupConsumerSubscription(ExecutableMethod<?, ?> method, List<AnnotationValue<Topic>> topicAnnotations, Object consumerBean, Consumer<?, ?> kafkaConsumer) {
+    private static void setupConsumerSubscription(
+        ExecutableMethod<?, ?> method,
+        List<AnnotationValue<Topic>> topicAnnotations,
+        Object consumerBean,
+        Consumer<?, ?> kafkaConsumer,
+        ConsumerCreationStrategy consumerCreationStrategy) {
         final List<String> topicNames = topicAnnotations.stream().flatMap(a -> Arrays.stream(a.stringValues())).toList();
         final List<String> patterns = topicAnnotations.stream().flatMap(a -> Arrays.stream(a.stringValues("patterns"))).toList();
         final boolean hasTopics = !topicNames.isEmpty();
@@ -552,6 +558,9 @@ class KafkaConsumerProcessor
         }
 
         if (hasPatterns) {
+            if (consumerCreationStrategy.equals(ConsumerCreationStrategy.PER_CLASS)) {
+                throw new MessagingSystemException("Patterns are not supported for ConsumerCreationStrategy.PER_CLASS for method: " + method);
+            }
             try {
                 for (final String pattern : patterns) {
                     final Pattern compiledPattern = Pattern.compile(pattern);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -287,6 +287,7 @@ class KafkaConsumerProcessor
             return; // Listener already created
         }
         List<AnnotationValue<Topic>> topicAnnotations = resolveTopicAnnotations(consumerCreationStrategy, method, beanDefinition);
+        List<ExecutableMethod<?, ?>> methods = resolveMethods(consumerCreationStrategy, method, beanDefinition);
 
         if (CollectionUtils.isEmpty(topicAnnotations)) {
             return; // No topics to consume
@@ -307,8 +308,18 @@ class KafkaConsumerProcessor
         final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
         final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
         configureDeserializers(method, consumerConfiguration);
-        submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations, consumerAnnotation, consumerConfiguration, properties, beanType);
+        submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations, consumerAnnotation, consumerConfiguration, properties, beanType, methods);
         kafkaListenersCreated.add(beanType.getName());
+    }
+
+    protected List<ExecutableMethod<?,?>> resolveMethods(ConsumerCreationStrategy consumerCreationStrategy, ExecutableMethod<?,?> method, BeanDefinition<?> beanDefinition) {
+        if (consumerCreationStrategy.equals(ConsumerCreationStrategy.PER_TOPIC)) {
+            return Collections.singletonList(method);
+        } else {
+            return (List<ExecutableMethod<?, ?>>) (List<?>) beanDefinition.getExecutableMethods().stream()
+                .filter(executableMethod -> executableMethod.hasAnnotation(Topic.class))
+                .toList();
+        }
     }
 
     protected List<AnnotationValue<Topic>> resolveTopicAnnotations(final ConsumerCreationStrategy consumerCreationStrategy,
@@ -487,7 +498,8 @@ class KafkaConsumerProcessor
                                        final AnnotationValue<KafkaListener> consumerAnnotation,
                                        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration,
                                        final Properties properties,
-                                       final Class<?> beanType) {
+                                       final Class<?> beanType,
+                                       final List<ExecutableMethod<?, ?>> methods) {
         final int consumerThreads = consumerAnnotation.intValue("threads").orElse(1);
         for (int i = 0; i < consumerThreads; i++) {
             final String finalClientId;
@@ -509,7 +521,7 @@ class KafkaConsumerProcessor
             }
             setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
-            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, method);
+            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, method, methods);
             final ConsumerState consumerState = consumerInfo.isBatch ?
                 new ConsumerStateBatch(this, consumerInfo, kafkaConsumer, consumerBean) :
                 new ConsumerStateSingle(this, consumerInfo, kafkaConsumer, consumerBean);

--- a/kafka/src/test/resources/logback.xml
+++ b/kafka/src/test/resources/logback.xml
@@ -12,8 +12,8 @@
         <appender-ref ref="STDOUT" />
     </root>
     <logger name="io.micronaut.configuration.kafka.seek" level="INFO"/>
-    <!--<logger name="org.apache.kafka" level="TRACE" />-->
-<!--    <logger name="io.micronaut.context" level="TRACE"/>-->
-    <!--<logger name="io.micronaut.configuration.kafka.processor" level="TRACE"/>-->
+    <logger name="org.apache.kafka" level="TRACE" />
+    <logger name="io.micronaut.context" level="TRACE"/>
+    <logger name="io.micronaut.configuration.kafka.processor" level="TRACE"/>
     <logger name="io.micronaut.configuration.kafka" level="TRACE" />
 </configuration>

--- a/kafka/src/test/resources/logback.xml
+++ b/kafka/src/test/resources/logback.xml
@@ -12,8 +12,8 @@
         <appender-ref ref="STDOUT" />
     </root>
     <logger name="io.micronaut.configuration.kafka.seek" level="INFO"/>
-    <logger name="org.apache.kafka" level="TRACE" />
-    <logger name="io.micronaut.context" level="TRACE"/>
-    <logger name="io.micronaut.configuration.kafka.processor" level="TRACE"/>
+    <!--<logger name="org.apache.kafka" level="TRACE" />-->
+    <!--<logger name="io.micronaut.context" level="TRACE"/>-->
+    <!--<logger name="io.micronaut.configuration.kafka.processor" level="TRACE"/>-->
     <logger name="io.micronaut.configuration.kafka" level="TRACE" />
 </configuration>

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/Boo.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/Boo.java
@@ -1,0 +1,9 @@
+package io.micronaut.kafka.docs.consumer.single;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record Boo(
+    String name
+) {
+}

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/BooFooClient.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/BooFooClient.java
@@ -1,0 +1,16 @@
+package io.micronaut.kafka.docs.consumer.single;
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "ConsumerCreationStrategyTest")
+@KafkaClient()
+public interface BooFooClient {
+
+    @Topic("boo")
+    void sendBoo(Boo boo);
+
+    @Topic("foo")
+    void sendFoo(Foo foo);
+}

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
@@ -29,5 +29,4 @@ public class ConsumerCreationStrategyTest {
             );
         }
     }
-
 }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
@@ -25,7 +25,7 @@ public class ConsumerCreationStrategyTest {
 
             MultiTopicListener listener = ctx.getBean(MultiTopicListener.class);
             await().atMost(10, SECONDS).until(() ->
-                listener.count == 4
+                listener.countBoo == 2 && listener.countFoo == 2
             );
         }
     }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/ConsumerCreationStrategyTest.java
@@ -1,0 +1,33 @@
+package io.micronaut.kafka.docs.consumer.single;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+import io.micronaut.context.ApplicationContext;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ConsumerCreationStrategyTest {
+
+    @Test
+    void itCreatesOneConsumerForMultipleMethodsAnnotatedWithTopicAnnotation() {
+        try (ApplicationContext ctx = ApplicationContext.run(
+            Map.of("kafka.enabled", "true", "spec.name", "ConsumerCreationStrategyTest")
+        )) {
+            Boo boo = new Boo("Boo");
+            Foo foo = new Foo("Foo");
+            BooFooClient client = ctx.getBean(BooFooClient.class);
+
+            client.sendBoo(boo);
+            client.sendBoo(boo);
+            client.sendFoo(foo);
+            client.sendFoo(foo);
+
+            MultiTopicListener listener = ctx.getBean(MultiTopicListener.class);
+            await().atMost(10, SECONDS).until(() ->
+                listener.count == 4
+            );
+        }
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/Foo.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/Foo.java
@@ -1,0 +1,9 @@
+package io.micronaut.kafka.docs.consumer.single;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record Foo(
+    String name
+) {
+}

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -21,13 +21,13 @@ public class MultiTopicListener {
     int countBoo = 0;
     int countFoo = 0;
 
-    @Topic({"boo"})
+    @Topic(value = "boo")
     void processBoo(Boo value) {
         LOG.info("Handling boo: {}", value);
         this.countBoo++;
     }
 
-    @Topic({"foo"})
+    @Topic(value = "foo")
     void processFoo(Foo value) {
         LOG.info("Handling foo: {}", value);
         this.countFoo++;

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -18,17 +18,18 @@ import org.slf4j.Logger;
 public class MultiTopicListener {
     private static final Logger LOG = getLogger(MultiTopicListener.class);
 
-    int count = 0;
+    int countBoo = 0;
+    int countFoo = 0;
 
     @Topic({"boo", "too"})
     void processBoo(String value) {
         LOG.info("Handling boo: {}", value);
-        this.count++;
+        this.countBoo++;
     }
 
     @Topic("foo")
     void processFoo(String value) {
         LOG.info("Handling foo: {}", value);
-        this.count++;
+        this.countFoo++;
     }
 }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -22,15 +22,13 @@ public class MultiTopicListener {
     int countFoo = 0;
 
     @Topic({"boo"})
-    void processBoo(String value) {
+    void processBoo(Boo value) {
         LOG.info("Handling boo: {}", value);
         this.countBoo++;
     }
 
-    // TODO: What about patterns?
-    @Topic(patterns = {"^f.*"})
-    // Testing that ConsumerAware consumer works
-    void processFoo(String value) {
+    @Topic({"foo"})
+    void processFoo(Foo value) {
         LOG.info("Handling foo: {}", value);
         this.countFoo++;
     }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -7,6 +7,7 @@ import io.micronaut.configuration.kafka.annotation.OffsetReset;
 import io.micronaut.configuration.kafka.annotation.Topic;
 import io.micronaut.configuration.kafka.processor.ConsumerCreationStrategy;
 import io.micronaut.context.annotation.Requires;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.slf4j.Logger;
 
 @Requires(property = "spec.name", value = "ConsumerCreationStrategyTest")
@@ -28,7 +29,8 @@ public class MultiTopicListener {
     }
 
     @Topic("foo")
-    void processFoo(String value) {
+    // Testing that ConsumerAware consumer works
+    void processFoo(Consumer consumer, String value) {
         LOG.info("Handling foo: {}", value);
         this.countFoo++;
     }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -7,13 +7,12 @@ import io.micronaut.configuration.kafka.annotation.OffsetReset;
 import io.micronaut.configuration.kafka.annotation.Topic;
 import io.micronaut.configuration.kafka.processor.ConsumerCreationStrategy;
 import io.micronaut.context.annotation.Requires;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.slf4j.Logger;
 
 @Requires(property = "spec.name", value = "ConsumerCreationStrategyTest")
 @KafkaListener(
     value = "myGroup",
-    consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS,
+    consumerCreationStrategy = ConsumerCreationStrategy.PER_TOPIC,
     offsetReset = OffsetReset.EARLIEST
 )
 public class MultiTopicListener {
@@ -22,15 +21,16 @@ public class MultiTopicListener {
     int countBoo = 0;
     int countFoo = 0;
 
-    @Topic({"boo", "too"})
+    @Topic({"boo"})
     void processBoo(String value) {
         LOG.info("Handling boo: {}", value);
         this.countBoo++;
     }
 
-    @Topic("foo")
+    // TODO: What about patterns?
+    @Topic(patterns = {"^f.*"})
     // Testing that ConsumerAware consumer works
-    void processFoo(Consumer consumer, String value) {
+    void processFoo(String value) {
         LOG.info("Handling foo: {}", value);
         this.countFoo++;
     }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/single/MultiTopicListener.java
@@ -1,0 +1,34 @@
+package io.micronaut.kafka.docs.consumer.single;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.OffsetReset;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.configuration.kafka.processor.ConsumerCreationStrategy;
+import io.micronaut.context.annotation.Requires;
+import org.slf4j.Logger;
+
+@Requires(property = "spec.name", value = "ConsumerCreationStrategyTest")
+@KafkaListener(
+    value = "myGroup",
+    consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS,
+    offsetReset = OffsetReset.EARLIEST
+)
+public class MultiTopicListener {
+    private static final Logger LOG = getLogger(MultiTopicListener.class);
+
+    int count = 0;
+
+    @Topic({"boo", "too"})
+    void processBoo(String value) {
+        LOG.info("Handling boo: {}", value);
+        this.count++;
+    }
+
+    @Topic("foo")
+    void processFoo(String value) {
+        LOG.info("Handling foo: {}", value);
+        this.count++;
+    }
+}


### PR DESCRIPTION
In scope:
- Created a new attribute in KafkaListener called consumerCreationStrategy
- Extended KafkaConsumerProcessor::process void to take into consideration that if consumerCreationStrategy is PER_TOPIC, it will resolve all methods annotated with @Topic insideof @KafkaListener class and create only one KafkaListener
- Improved ConsumerInfo class to be able to resolve attributes during runtime based on consumerRecord.topic
- PER_TOPIC strategy with BATCH MODE not supported yet ⚠️ 