### PR TITLE
Introduce id for KafkaListener

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,12 +58,20 @@ public @interface KafkaListener {
 
     /**
      * Sets the consumer group id of the Kafka consumer. If not specified the group id is configured
-     * to be the value of {@link io.micronaut.runtime.ApplicationConfiguration#getName()} otherwise
-     * the name of the class is used.
+     * from {@link #id()} when present, otherwise to the value of
+     * {@link io.micronaut.runtime.ApplicationConfiguration#getName()} and finally the name of the class.
      *
      * @return The group id
      */
     String groupId() default "";
+
+    /**
+     * Sets the listener identifier used to resolve consumer configuration from {@code kafka.consumers.*}.
+     * If not specified, the {@link #groupId()} is used.
+     *
+     * @return The listener identifier
+     */
+    String id() default "";
 
     /**
      * A unique string (UUID) can be appended to the group ID.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -40,21 +40,29 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface KafkaListener {
 
     /**
+     * Sets the id of the consumer under which it can be referenced in the application configuration.
+     * If not explicitly set, it defaults to the {@link #groupId()}
+     *
+     * @return The id
+     */
+    @AliasFor(member = "id")
+    String value() default "";
+
+    /**
+     * The same as {@link #value()}.
+     *
+     * @return The id
+     */
+    @AliasFor(member = "value")
+    String id() default "";
+
+    /**
      * Sets the consumer group id of the Kafka consumer. If not specified the group id is configured
      * to be the value of {@link io.micronaut.runtime.ApplicationConfiguration#getName()} otherwise
      * the name of the class is used.
      *
      * @return The group id
      */
-    @AliasFor(member = "groupId")
-    String value() default "";
-
-    /**
-     * The same as {@link #value()}.
-     *
-     * @return The group id
-     */
-    @AliasFor(member = "value")
     String groupId() default "";
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,32 +288,40 @@ class KafkaConsumerProcessor
             return; // No topics to consume
         }
         final Class<?> beanType = beanDefinition.getBeanType();
-        final Optional<String> groupId = consumerAnnotation.stringValue("groupId")
-                .filter(StringUtils::isNotEmpty);
-
+        final Optional<String> listenerId = consumerAnnotation.stringValue("id")
+            .filter(StringUtils::isNotEmpty);
+        final Optional<String> annotationGroupId = consumerAnnotation.stringValue("groupId")
+            .filter(StringUtils::isNotEmpty);
         final String clientId = consumerAnnotation.stringValue("clientId")
                 .filter(StringUtils::isNotEmpty)
                 .orElseGet(() -> applicationConfiguration.getName().map(s -> s + '-' + NameUtils.hyphenate(beanType.getSimpleName())).orElse(null));
         final OffsetStrategy offsetStrategy = consumerAnnotation.enumValue("offsetStrategy", OffsetStrategy.class)
                 .orElse(OffsetStrategy.AUTO);
-        final Optional<String> id =  consumerAnnotation.stringValue("id")
-            .filter(StringUtils::isNotEmpty)
-            .or(() -> groupId);
-
-        final String configId = id.orElseGet(() -> this.groupIdFallback(beanType));
+        final String fallbackGroupId = annotationGroupId
+            .or(() -> listenerId)
+            .orElseGet(() -> this.groupIdFallback(beanType));
+        final String configId = listenerId
+            .or(() -> annotationGroupId)
+            .orElseGet(() -> this.groupIdFallback(beanType));
         final AbstractKafkaConsumerConfiguration<?, ?> consumerConfigurationDefaults = getConsumerConfigurationDefaults(configId);
-
         boolean uniqueGroupIdDeleteOnShutdown = false;
-        String effectiveGroupId = groupId.orElseGet(() -> this.groupIdFallback(beanType));
-
+        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
+        final Properties properties = createConsumerProperties(
+            consumerAnnotation,
+            consumerConfiguration,
+            clientId,
+            fallbackGroupId,
+            annotationGroupId.isPresent(),
+            offsetStrategy
+        );
+        String effectiveGroupId = properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG, fallbackGroupId);
         if (consumerAnnotation.isTrue("uniqueGroupId")) {
             effectiveGroupId = effectiveGroupId + "_" + UUID.randomUUID();
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, effectiveGroupId);
             if (consumerAnnotation.isTrue("uniqueGroupIdDeleteOnShutdown")) {
                 uniqueGroupIdDeleteOnShutdown = true;
             }
         }
-        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
-        final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId,  effectiveGroupId, groupId.isPresent(), offsetStrategy);
         configureDeserializers(method, consumerConfiguration);
         submitConsumerThreads(method, clientId, effectiveGroupId, offsetStrategy, topicAnnotations,
             consumerAnnotation, consumerConfiguration, properties, beanType, uniqueGroupIdDeleteOnShutdown);
@@ -454,8 +462,7 @@ class KafkaConsumerProcessor
 
         if (overrideGroupId) {
             properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-        }
-        else {
+        } else {
             properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -288,27 +288,39 @@ class KafkaConsumerProcessor
             return; // No topics to consume
         }
         final Class<?> beanType = beanDefinition.getBeanType();
-        String groupId = consumerAnnotation.stringValue("groupId")
-                .filter(StringUtils::isNotEmpty)
-                .orElseGet(() -> applicationConfiguration.getName().orElse(beanType.getName()));
+        final Optional<String> groupId = consumerAnnotation.stringValue("groupId")
+                .filter(StringUtils::isNotEmpty);
+
         final String clientId = consumerAnnotation.stringValue("clientId")
                 .filter(StringUtils::isNotEmpty)
                 .orElseGet(() -> applicationConfiguration.getName().map(s -> s + '-' + NameUtils.hyphenate(beanType.getSimpleName())).orElse(null));
         final OffsetStrategy offsetStrategy = consumerAnnotation.enumValue("offsetStrategy", OffsetStrategy.class)
                 .orElse(OffsetStrategy.AUTO);
-        final AbstractKafkaConsumerConfiguration<?, ?> consumerConfigurationDefaults = getConsumerConfigurationDefaults(groupId);
+        final Optional<String> id =  consumerAnnotation.stringValue("id")
+            .filter(StringUtils::isNotEmpty)
+            .or(() -> groupId);
+
+        final String configId = id.orElseGet(() -> this.groupIdFallback(beanType));
+        final AbstractKafkaConsumerConfiguration<?, ?> consumerConfigurationDefaults = getConsumerConfigurationDefaults(configId);
+
         boolean uniqueGroupIdDeleteOnShutdown = false;
+        String effectiveGroupId = groupId.orElseGet(() -> this.groupIdFallback(beanType));
+
         if (consumerAnnotation.isTrue("uniqueGroupId")) {
-            groupId = groupId + "_" + UUID.randomUUID();
+            effectiveGroupId = effectiveGroupId + "_" + UUID.randomUUID();
             if (consumerAnnotation.isTrue("uniqueGroupIdDeleteOnShutdown")) {
                 uniqueGroupIdDeleteOnShutdown = true;
             }
         }
         final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
-        final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
+        final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId,  effectiveGroupId, groupId.isPresent(), offsetStrategy);
         configureDeserializers(method, consumerConfiguration);
-        submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations,
+        submitConsumerThreads(method, clientId, effectiveGroupId, offsetStrategy, topicAnnotations,
             consumerAnnotation, consumerConfiguration, properties, beanType, uniqueGroupIdDeleteOnShutdown);
+    }
+
+    String groupIdFallback(Class<?> beanType) {
+        return applicationConfiguration.getName().orElse(beanType.getName());
     }
 
     @Override
@@ -392,23 +404,23 @@ class KafkaConsumerProcessor
     }
 
     @SuppressWarnings("rawtypes")
-    private AbstractKafkaConsumerConfiguration getConsumerConfigurationDefaults(String groupId) {
-        return findConfigurationBean(groupId)
-            .or(() -> findHyphenatedConsumerConfigurationBean(groupId))
+    private AbstractKafkaConsumerConfiguration getConsumerConfigurationDefaults(String id) {
+        return findConfigurationBean(id)
+            .or(() -> findHyphenatedConsumerConfigurationBean(id))
             .orElse(defaultConsumerConfiguration);
     }
 
     @SuppressWarnings("rawtypes")
-    private Optional<AbstractKafkaConsumerConfiguration> findConfigurationBean(String groupId) {
-        return beanContext.findBean(AbstractKafkaConsumerConfiguration.class, Qualifiers.byName(groupId));
+    private Optional<AbstractKafkaConsumerConfiguration> findConfigurationBean(String id) {
+        return beanContext.findBean(AbstractKafkaConsumerConfiguration.class, Qualifiers.byName(id));
     }
 
     @SuppressWarnings("rawtypes")
-    private Optional<AbstractKafkaConsumerConfiguration> findHyphenatedConsumerConfigurationBean(String groupId) {
-        if (NameUtils.isValidHyphenatedPropertyName(groupId)) {
+    private Optional<AbstractKafkaConsumerConfiguration> findHyphenatedConsumerConfigurationBean(String id) {
+        if (NameUtils.isValidHyphenatedPropertyName(id)) {
             return Optional.empty();
         }
-        return findConfigurationBean(NameUtils.hyphenate(groupId));
+        return findConfigurationBean(NameUtils.hyphenate(id));
     }
 
     @SuppressWarnings("rawtypes")
@@ -416,6 +428,7 @@ class KafkaConsumerProcessor
                                                 final DefaultKafkaConsumerConfiguration consumerConfiguration,
                                                 final String clientId,
                                                 final String groupId,
+                                                final boolean overrideGroupId,
                                                 final OffsetStrategy offsetStrategy) {
         final Properties properties = consumerConfiguration.getConfig();
 
@@ -439,7 +452,12 @@ class KafkaConsumerProcessor
         consumerAnnotation.enumValue("isolation", IsolationLevel.class)
                 .ifPresent(isolation -> properties.putIfAbsent(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation.toString().toLowerCase(Locale.ROOT)));
 
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        if (overrideGroupId) {
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        }
+        else {
+            properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        }
 
         if (clientId != null) {
             properties.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerGroupIdSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerGroupIdSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.configuration.kafka
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class KafkaListenerGroupIdSpec extends Specification {
+
+    @AutoCleanup ApplicationContext applicationContext
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerGroupIdSpec')
+    @KafkaListener(id = "WITH_ID_1", groupId = "GROUP_ID_FALLBACK", autoStartup = false)
+    static class ConsumerWithIdAndGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+        @Topic("foo") void consume(String foo) { }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerGroupIdSpec')
+    @KafkaListener(id = "WITH_ID_2", autoStartup = false)
+    static class ConsumerWithId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+        @Topic("foo") void consume(String foo) { }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerGroupIdSpec')
+    @KafkaListener(groupId = "GROUP_ID_FALLBACK", autoStartup = false)
+    static class ConsumerWithGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+        @Topic("foo") void consume(String foo) { }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerGroupIdSpec')
+    @KafkaListener(autoStartup = false)
+    static class Without implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+        @Topic("foo") void consume(String foo) { }
+    }
+
+    void "test named consumers"() {
+        given:
+        applicationContext = ApplicationContext.run(
+                'spec.name': 'KafkaListenerGroupIdSpec',
+                ('kafka.' + ConsumerConfig.CLIENT_ID_CONFIG): "CLIENT_0",
+                ('kafka.consumers.with-id-1.' + ConsumerConfig.CLIENT_ID_CONFIG): "CLIENT_1",
+                ('kafka.consumers.with-id-1.' + ConsumerConfig.GROUP_ID_CONFIG): "GROUP_ID_CONFIG_1",
+                ('kafka.consumers.with-id-2.' + ConsumerConfig.CLIENT_ID_CONFIG): "CLIENT_2",
+                ('kafka.consumers.with-id-2.' + ConsumerConfig.GROUP_ID_CONFIG): "GROUP_ID_CONFIG_2",
+                ('kafka.consumers.group-id-fallback.' + ConsumerConfig.CLIENT_ID_CONFIG): "CLIENT_3",
+                ('kafka.consumers.group-id-fallback.' + ConsumerConfig.GROUP_ID_CONFIG): "GROUP_ID_CONFIG_3"
+        )
+
+        when:
+        ConsumerWithIdAndGroupId withIdAndGroupId = applicationContext.getBean(ConsumerWithIdAndGroupId)
+
+        then:
+        withIdAndGroupId != null
+        withIdAndGroupId.kafkaConsumer.delegate.clientId == 'CLIENT_1'
+        withIdAndGroupId.kafkaConsumer.delegate.groupId.get() == 'GROUP_ID_FALLBACK'
+
+
+        when:
+        ConsumerWithId withId = applicationContext.getBean(ConsumerWithId)
+
+        then:
+        withId != null
+        withId.kafkaConsumer.delegate.clientId == 'CLIENT_2'
+        withId.kafkaConsumer.delegate.groupId.get() == 'GROUP_ID_CONFIG_2'
+
+
+        when:
+        ConsumerWithGroupId withGroupId = applicationContext.getBean(ConsumerWithGroupId)
+
+        then:
+        withGroupId != null
+        withGroupId.kafkaConsumer.delegate.clientId == 'CLIENT_3'
+        withGroupId.kafkaConsumer.delegate.groupId.get() == 'GROUP_ID_FALLBACK'
+
+
+        when:
+        Without withoutIdAndGroupId = applicationContext.getBean(Without)
+
+        then:
+        withoutIdAndGroupId != null
+        withoutIdAndGroupId.kafkaConsumer.delegate.clientId == 'CLIENT_0'
+        withoutIdAndGroupId.kafkaConsumer.delegate.groupId.get() == Without.name
+
+        cleanup:
+        applicationContext.close()
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.configuration.kafka
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class KafkaListenerIdSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    void "test listener id controls config lookup and group id fallback"() {
+        given:
+        applicationContext = ApplicationContext.run(
+            'spec.name': 'KafkaListenerIdSpec',
+            'micronaut.application.name': 'test-app',
+            ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): 'localhost:1111',
+            ('kafka.consumers.default.' + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+            ('kafka.consumers.default.' + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+            ('kafka.consumers.with-id-and-group.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_1',
+            ('kafka.consumers.with-id.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_2',
+            ('kafka.consumers.group-id-only.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_3',
+            ('kafka.consumers.test-app.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_4'
+        )
+
+        expect:
+        applicationContext.getBean(ConsumerWithIdAndGroupId).kafkaConsumer.groupMetadata().groupId() == 'ANNOTATION_GROUP'
+        applicationContext.getBean(ConsumerWithId).kafkaConsumer.groupMetadata().groupId() == 'CONFIGURED_GROUP_2'
+        applicationContext.getBean(ConsumerWithIdFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'ID_FALLBACK_GROUP'
+        applicationContext.getBean(ConsumerWithGroupId).kafkaConsumer.groupMetadata().groupId() == 'GROUP_ID_ONLY'
+        applicationContext.getBean(ConsumerWithFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'CONFIGURED_GROUP_4'
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'WITH_ID_AND_GROUP', groupId = 'ANNOTATION_GROUP', autoStartup = false)
+    static class ConsumerWithIdAndGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'WITH_ID', autoStartup = false)
+    static class ConsumerWithId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'ID_FALLBACK_GROUP', autoStartup = false)
+    static class ConsumerWithIdFallbackGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(groupId = 'GROUP_ID_ONLY', autoStartup = false)
+    static class ConsumerWithGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(autoStartup = false)
+    static class ConsumerWithFallbackGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+}

--- a/src/main/docs/guide/kafkaListener.adoc
+++ b/src/main/docs/guide/kafkaListener.adoc
@@ -48,6 +48,6 @@ kafka:
               servers: localhost:9098
 ----
 
-Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the . The above example will enable the consumer to create a topic if it doesn't exist for the `default` (`@KafkaListener`) client and set a custom bootstrap server for the `product` client (`@KafkaListener(value = "product")`)
+Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the listener `id`, or `groupId` when `id` is not set. The above example will enable the consumer to create a topic if it doesn't exist for the `default` listener and set a custom bootstrap server for a listener declared with `@KafkaListener(id = "product")`.
 
 TIP: See the guide for https://guides.micronaut.io/latest/testing-micronaut-kafka-listener-using-testcontainers.html[Testing Kafka Listener using Testcontainers with the Micronaut Framework] to learn more.

--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -1,6 +1,6 @@
 === @KafkaListener and Consumer Groups
 
-Kafka consumers created with `@KafkaListener` will by default run within a consumer group that is the value of `micronaut.application.name` unless you explicitly specify a value to the `@KafkaListener` annotation. For example:
+Kafka consumers created with `@KafkaListener` will by default run within a consumer group that is the value of `micronaut.application.name` unless you explicitly specify `groupId` or `value`, or provide an `id` to use as the group fallback. For example:
 
 .Specifying a Consumer Group
 
@@ -16,6 +16,10 @@ The above examples will run the consumer within a consumer group called `myGroup
 In this case, each record will be consumed by one consumer instance of the consumer group.
 
 TIP: You can make the consumer group configurable using a placeholder: `@KafkaListener("${my.consumer.group:myGroup}")`
+
+The `id` member is used to resolve consumer-specific configuration from `kafka.consumers.*`.
+If `id` is not specified, Micronaut falls back to `groupId`.
+If `groupId` is not specified, Micronaut uses `id` as the Kafka consumer group unless `group.id` is already defined in configuration.
 
 To allow the records to be consumed by all the consumer instances (each instance will be part of a unique consumer group), `uniqueGroupId` can be set to `true`:
 
@@ -42,7 +46,7 @@ kafka:
 
 The above example will set the default `session.timeout.ms` that Kafka uses to decide whether a consumer is alive or not and applies it to all created `KafkaConsumer` instances.
 
-You can also provide configuration specific to a consumer group. For example consider the following configuration:
+You can also provide configuration specific to a listener id. For example consider the following configuration:
 
 .Applying Consumer Group Specific config
 [configuration]
@@ -55,7 +59,7 @@ kafka:
                     ms: 30000
 ----
 
-The above configuration will pass properties to only the `@KafkaListener` beans that apply to the consumer group `myGroup`.
+The above configuration will pass properties to only the `@KafkaListener` beans with `id = "myGroup"`, or listeners whose `groupId` is `myGroup` when `id` is not specified.
 
 Finally, the ann:configuration.kafka.annotation.KafkaListener[] annotation itself provides a `properties` member that you can use to set consumer specific properties:
 


### PR DESCRIPTION
Introduce `id` for `@KafkaListener` so consumer configuration can be resolved independently from the Kafka consumer group.

The update also preserves the current fallback behavior by using `groupId` when `id` is not set, and using the configured `group.id` when available before falling back to the listener/application defaults.

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/1179
