### PR TITLE
Reduce memory usage by not capturing this through mutable Builder ins…

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -134,7 +134,8 @@ public class KafkaMetricMeterTypeBuilder {
         KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
-                return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
+            final KafkaMetric kafkaMetric = this.kafkaMetric;
+            return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())


### PR DESCRIPTION
Reduce memory usage by not capturing the builder instance from a lambda. The builder instance field is mutable so the whole builder is retained.
Possibly related to https://github.com/micronaut-projects/micronaut-kafka/issues/1123