### PR TITLE
Hold kafka consumer startup until resume/wakeup

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * The internal state of the consumer.
@@ -66,7 +67,7 @@ abstract class ConsumerState {
     Set<TopicPartition> assignments;
     private Set<TopicPartition> pausedTopicPartitions;
     private Set<TopicPartition> pauseRequests;
-    private boolean autoPaused;
+    private CountDownLatch startupLatch;
     private boolean pollingStarted;
     private volatile ConsumerCloseState closedState;
 
@@ -81,7 +82,7 @@ abstract class ConsumerState {
         this.kafkaConsumer = consumer;
         this.consumerBean = consumerBean;
         this.subscriptions = Collections.unmodifiableSet(kafkaConsumer.subscription());
-        this.autoPaused = !info.autoStartup;
+        this.startupLatch = info.autoStartup ? null : new CountDownLatch(1);
         this.boundArguments = new HashMap<>(2);
         Optional.ofNullable(info.consumerArg).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
         this.closedState = ConsumerCloseState.NOT_STARTED;
@@ -107,18 +108,25 @@ abstract class ConsumerState {
     }
 
     synchronized void resume() {
-        autoPaused = false;
         pauseRequests = null;
+        if (startupLatch != null) {
+            startupLatch.countDown();
+        }
     }
 
     synchronized void resume(@NonNull Collection<TopicPartition> topicPartitions) {
-        autoPaused = false;
         if (pauseRequests != null) {
             pauseRequests.removeAll(topicPartitions);
+        }
+        if (startupLatch != null) {
+            startupLatch.countDown();
         }
     }
 
     synchronized boolean isPaused(@NonNull Collection<TopicPartition> topicPartitions) {
+        if (startupLatch != null && startupLatch.getCount() > 0) {
+            return true;
+        }
         if (pauseRequests == null || pausedTopicPartitions == null) {
             return false;
         }
@@ -127,6 +135,11 @@ abstract class ConsumerState {
 
     void wakeUp() {
         kafkaConsumer.wakeup();
+        synchronized (this) {
+            if (startupLatch != null) {
+                startupLatch.countDown();
+            }
+        }
     }
 
     void close() {
@@ -149,12 +162,25 @@ abstract class ConsumerState {
 
     void threadPollLoop() {
         try (kafkaConsumer) {
+            holdStartup();
             //noinspection InfiniteLoopStatement
             while (true) { //NOSONAR
                 refreshAssignmentsPollAndProcessRecords();
             }
+        } catch (InterruptedException e) {
+            closedState = ConsumerCloseState.CLOSED;
+            Thread.currentThread().interrupt();
         } catch (WakeupException e) {
             closedState = ConsumerCloseState.CLOSED;
+        }
+    }
+
+    private void holdStartup() throws InterruptedException {
+        if (startupLatch != null) {
+            startupLatch.await();
+            synchronized (this) {
+                startupLatch = null;
+            }
         }
     }
 
@@ -181,12 +207,6 @@ abstract class ConsumerState {
         if (!newAssignments.equals(assignments)) {
             LOG.info("Consumer [{}] assignments changed: {} -> {}", info.clientId, assignments, newAssignments);
             assignments = Collections.unmodifiableSet(newAssignments);
-        }
-        synchronized (this) {
-            if (autoPaused) {
-                pause(assignments);
-                kafkaConsumer.pause(assignments);
-            }
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -22,7 +22,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
-import java.util.HashMap;
+import io.micronaut.core.util.CollectionUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -33,6 +33,7 @@ import reactor.core.publisher.Flux;
 import reactor.util.function.Tuple2;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -71,7 +72,7 @@ final class ConsumerStateBatch extends ConsumerState {
             // By default, seek past the record to continue consumption
             kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
-            resolveWithErrorStrategy(null, currentOffsets, ex);
+            resolveWithErrorStrategy(null, reconstructCurrentOffsetsIfAbsent(currentOffsets, ex), ex);
             // By now, it's been decided whether this record should be retried and the exception may have been handled
             return null;
         }
@@ -145,15 +146,16 @@ final class ConsumerStateBatch extends ConsumerState {
         if (info.errorStrategy.isRetry()) {
             final Set<TopicPartition> partitions = consumerRecords != null ? consumerRecords.partitions() : currentOffsets.keySet();
             if (shouldRetryException(e, consumerRecords, null) && info.retryCount > 0) {
+                Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = reconstructCurrentOffsetsIfAbsent(currentOffsets, consumerRecords);
                 // Check how many retries so far
-                final int currentRetryCount = getCurrentRetryCount(partitions, currentOffsets);
+                final int currentRetryCount = getCurrentRetryCount(partitions, reconstructedOffsets);
                 if (info.retryCount >= currentRetryCount) {
                     // We will retry this batch again next time
                     if (info.shouldHandleAllExceptions) {
                         handleException(e, consumerRecords, null);
                     }
                     // Move back to the previous positions
-                    partitions.forEach(tp -> kafkaConsumer.seek(tp, currentOffsets.get(tp).offset()));
+                    partitions.forEach(tp -> kafkaConsumer.seek(tp, reconstructedOffsets.get(tp).offset()));
                     // Decide how long should we wait to retry this batch again
                     delayRetry(currentRetryCount, partitions);
                     return true;
@@ -177,5 +179,32 @@ final class ConsumerStateBatch extends ConsumerState {
 
     private OffsetAndMetadata getCurrentOffset(TopicPartition tp) {
         return new OffsetAndMetadata(kafkaConsumer.position(tp), null);
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
+        @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets, RecordDeserializationException ex) {
+        // Only after the first poll there are no current offsets, but they can be reconstructed from the exception
+        return CollectionUtils.isEmpty(currentOffsets)
+            ? Map.of(ex.topicPartition(), new OffsetAndMetadata(ex.offset(), null))
+            : currentOffsets;
+    }
+
+    @Nullable
+    private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
+        @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets,
+        @Nullable ConsumerRecords<?, ?> consumerRecords) {
+        // Only after the first poll there are no current offsets, but they can be reconstructed from the fetched records
+        if (CollectionUtils.isEmpty(currentOffsets) && consumerRecords != null) {
+            Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = new HashMap<>();
+            for (ConsumerRecord<?, ?> record : consumerRecords) {
+                TopicPartition tp = new TopicPartition(record.topic(), record.partition());
+                if (!reconstructedOffsets.containsKey(tp)) {
+                    reconstructedOffsets.put(tp, new OffsetAndMetadata(record.offset(), null));
+                }
+            }
+            return reconstructedOffsets;
+        } else {
+            return currentOffsets;
+        }
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaBatchErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaBatchErrorStrategySpec.groovy
@@ -87,9 +87,9 @@ class KafkaBatchErrorStrategySpec extends AbstractEmbeddedServerSpec {
     void "test batch mode with 'retry' error strategy when there are serialization errors"() {
         when: "A record cannot be deserialized"
         MyClient myClient = context.getBean(MyClient)
+        myClient.sendBatch(BATCH_MODE_RETRY_DESER, ['Not an integer'])
         myClient.sendBatchOfNumbers(BATCH_MODE_RETRY_DESER, [111, 222])
         myClient.sendBatchOfNumbers(BATCH_MODE_RETRY_DESER, [333])
-        myClient.sendBatch(BATCH_MODE_RETRY_DESER, ['Not an integer'])
         myClient.sendBatchOfNumbers(BATCH_MODE_RETRY_DESER, [444, 555])
 
         RetryDeserConsumer myConsumer = context.getBean(RetryDeserConsumer)
@@ -97,15 +97,15 @@ class KafkaBatchErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
         then: "The message that threw the exception was eventually left behind"
         conditions.eventually {
-            myConsumer.received == ['111/222', '333', '444/555']
+            myConsumer.received == ['111/222', '333/444', '555']
         }
 
         and: "The retry error strategy was honored"
         myConsumer.exceptions.size() == 2
         myConsumer.exceptions[0].message.startsWith('Error deserializing VALUE')
-        (myConsumer.exceptions[0].cause as RecordDeserializationException).offset() == 3
+        (myConsumer.exceptions[0].cause as RecordDeserializationException).offset() == 0
         myConsumer.exceptions[1].message.startsWith('Error deserializing VALUE')
-        (myConsumer.exceptions[1].cause as RecordDeserializationException).offset() == 3
+        (myConsumer.exceptions[1].cause as RecordDeserializationException).offset() == 0
     }
 
     void "test batch mode with 'retry conditionally' error strategy when there are serialization errors"() {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaPartitionedErrorsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaPartitionedErrorsSpec.groovy
@@ -1,8 +1,6 @@
 package io.micronaut.configuration.kafka.errors
 
-import spock.lang.Ignore
 import spock.lang.Stepwise
-import spock.lang.Retry
 
 @Stepwise
 class KafkaPartitionedErrorsSpec extends KafkaErrorsSpec {


### PR DESCRIPTION
Referring to https://github.com/micronaut-projects/micronaut-kafka/issues/1201

If `autoStartup = false` a consumer is hold until resume/wakeup.