### PR TITLE
Change offset type from int to long in exception handler

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/exceptions/DefaultKafkaListenerExceptionHandler.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/exceptions/DefaultKafkaListenerExceptionHandler.java
@@ -125,7 +125,7 @@ public class DefaultKafkaListenerExceptionHandler implements KafkaListenerExcept
             if (matcher.find()) {
                 final String topic = matcher.group(1);
                 final int partition = Integer.valueOf(matcher.group(2));
-                final int offset = Integer.valueOf(matcher.group(3));
+                final long offset = Long.valueOf(matcher.group(3));
                 TopicPartition tp = new TopicPartition(topic, partition);
                 LOG.debug("Seeking past unserializable consumer record for partition {}-{} and offset {}", topic, partition, offset);
 


### PR DESCRIPTION
This pull request contains a minor fix to the `DefaultKafkaListenerExceptionHandler` class to improve type safety when handling Kafka offsets.

* Changed the type of the `offset` variable from `int` to `long` in the `seekPastDeserializationError` method to correctly handle large Kafka offsets and prevent potential overflow issues.