### PR TITLE
make configuration errors on kafka.* properties more explicit

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.kafka.config;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.Toggleable;
 
 import io.micronaut.core.annotation.NonNull;
@@ -81,6 +82,11 @@ public abstract class AbstractKafkaConfiguration<K, V> implements Toggleable {
             return Stream.of("embedded", "consumers", "producers", "streams").noneMatch(key::startsWith);
         }).forEach(entry -> {
             Object value = entry.getValue();
+
+            if (value == null) {
+                throw new ConfigurationException(String.format("Value for property kafka.%s resolved as null", entry.getKey()));
+            }
+
             if (environment.canConvert(entry.getValue().getClass(), String.class)) {
                 Optional<?> converted = environment.convert(entry.getValue(), String.class);
                 if (converted.isPresent()) {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.configuration.kafka.config.KafkaConsumerConfiguration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.EnvironmentPropertySource
 import io.micronaut.context.env.MapPropertySource
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -72,6 +74,22 @@ class KafkaConfigurationSpec extends Specification {
 
         cleanup:
         consumer.close()
+    }
+
+    void "test configure default properties, throw exception when kafka.* property is null"() {
+        when:
+        applicationContext = ApplicationContext.run(
+                ('kafka.' + BOOTSTRAP_SERVERS_CONFIG): "localhost:1111",
+                ('kafka.' + GROUP_ID_CONFIG): null,
+                ('kafka.' + MAX_POLL_RECORDS_CONFIG): "100",
+                ("kafka." + KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+                ("kafka." + VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name
+        )
+
+        then:
+        BeanInstantiationException exception = thrown()
+        exception.getCause().getClass() == ConfigurationException
+        exception.getCause().getMessage() == "Value for property kafka.${GROUP_ID_CONFIG} resolved as null"
     }
 
     void "test override consumer default properties"() {


### PR DESCRIPTION
Currently if there is any `kafka.<property>` configured (mistakingly, cause yaml) as null, then it would be helpful to specify which one is it, right now it just says `NullPointerException`.

This becomes more problematic if there is any user added property like `kafka.custom.users`.

Issue Ref: https://github.com/micronaut-projects/micronaut-kafka/issues/1236