### PR TITLE
Implement GracefulShutdownCapable in KafkaConsumerProcessor

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -70,6 +71,8 @@ abstract class ConsumerState {
     private CountDownLatch startupLatch;
     private boolean pollingStarted;
     private volatile ConsumerCloseState closedState;
+    private volatile boolean shutdownRequested;
+    private final CompletableFuture<Void> shutdownFuture = new CompletableFuture<>();
 
     protected ConsumerState(
         KafkaConsumerProcessor kafkaConsumerProcessor,
@@ -142,6 +145,18 @@ abstract class ConsumerState {
         }
     }
 
+    void requestShutdown() {
+        shutdownRequested = true;
+    }
+
+    CompletableFuture<Void> getShutdownFuture() {
+        return shutdownFuture;
+    }
+
+    boolean isActive() {
+        return closedState != ConsumerCloseState.CLOSED;
+    }
+
     void close() {
         if (closedState == ConsumerCloseState.POLLING) {
             final Instant start = Instant.now();
@@ -163,15 +178,18 @@ abstract class ConsumerState {
     void threadPollLoop() {
         try (kafkaConsumer) {
             holdStartup();
-            //noinspection InfiniteLoopStatement
-            while (true) { //NOSONAR
+
+            while (!shutdownRequested) {
                 refreshAssignmentsPollAndProcessRecords();
             }
         } catch (InterruptedException e) {
-            closedState = ConsumerCloseState.CLOSED;
+            LOG.debug("Consumer {} interrupted", info.clientId);
             Thread.currentThread().interrupt();
         } catch (WakeupException e) {
+            LOG.debug("Consumer {} woken up", info.clientId);
+        } finally {
             closedState = ConsumerCloseState.CLOSED;
+            shutdownFuture.complete(null);
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -59,6 +59,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.messaging.annotation.MessageBody;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
 import io.micronaut.scheduling.ScheduledExecutorTaskScheduler;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.TaskScheduler;
@@ -85,14 +86,17 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 /**
  * <p>A {@link ExecutableMethodProcessor} that will process all beans annotated with {@link KafkaListener}
@@ -105,7 +109,7 @@ import java.util.regex.PatternSyntaxException;
 @Requires(beans = KafkaDefaultConfiguration.class)
 @Internal
 class KafkaConsumerProcessor
-        implements ExecutableMethodProcessor<Topic>, AutoCloseable, ConsumerRegistry {
+        implements ExecutableMethodProcessor<Topic>, AutoCloseable, ConsumerRegistry, GracefulShutdownCapable {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerProcessor.class);
     private static final ByteArrayDeserializer DEFAULT_KEY_DESERIALIZER = new ByteArrayDeserializer();
@@ -312,14 +316,45 @@ class KafkaConsumerProcessor
     }
 
     @Override
+    public CompletableFuture<Void> shutdownGracefully() {
+        if (consumers.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        consumers.values().forEach(ConsumerState::requestShutdown);
+        consumers.values().forEach(ConsumerState::wakeUp);
+
+        List<CompletableFuture<Void>> shutdownFutures = consumers.values().stream()
+            .map(ConsumerState::getShutdownFuture)
+            .collect(Collectors.toList());
+
+        return CompletableFuture.allOf(shutdownFutures.toArray(new CompletableFuture[0]));
+    }
+
+    @Override
+    public OptionalLong reportActiveTasks() {
+        long activeCount = consumers.values().stream()
+            .filter(ConsumerState::isActive)
+            .count();
+
+        return OptionalLong.of(activeCount);
+    }
+
+    @Override
     @PreDestroy
     public void close() {
         kafkaConsumerGroupManager.getRegisteredClientIdsForDeletion().forEach(clientId -> {
             LOG.info("Already closed consumer client : {}", clientId);
             consumers.remove(clientId);
         });
-        consumers.values().forEach(ConsumerState::wakeUp);
-        consumers.values().forEach(ConsumerState::close);
+
+        consumers.values().forEach(state -> {
+            if (state.isActive()) {
+                state.wakeUp();
+            }
+            state.close();
+        });
+
         consumers.clear();
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
@@ -1,0 +1,105 @@
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.AbstractKafkaContainerSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+import static io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration.EMBEDDED_TOPICS
+
+class KafkaGracefulShutdownSpec extends AbstractKafkaContainerSpec {
+
+    void "graceful shutdown completes promptly with idle consumers"() {
+        given: "a new application context with graceful shutdown enabled"
+        def config = [
+            'kafka.bootstrap.servers': bootstrapServers,
+            'kafka.enabled': 'true',
+            'spec.name': 'KafkaGracefulShutdownIdleSpec',
+            'micronaut.lifecycle.graceful-shutdown.enabled': 'true',
+            'micronaut.lifecycle.graceful-shutdown.grace-period': '30s',
+            (EMBEDDED_TOPICS): ['idle-topic']
+        ]
+        ApplicationContext ctx = ApplicationContext.run(config)
+
+        when: "the context is closed"
+        Instant start = Instant.now()
+        ctx.close()
+        Duration shutdownDuration = Duration.between(start, Instant.now())
+
+        then: "shutdown completes quickly without waiting the full grace period"
+        shutdownDuration.seconds < 5
+    }
+
+    void "graceful shutdown completes in-flight message processing"() {
+        given: "a consumer that takes time to process messages"
+        def config = [
+            'kafka.bootstrap.servers': bootstrapServers,
+            'kafka.enabled': 'true',
+            'spec.name': 'KafkaGracefulShutdownInFlightSpec',
+            'micronaut.lifecycle.graceful-shutdown.enabled': 'true',
+            'micronaut.lifecycle.graceful-shutdown.grace-period': '30s',
+            (EMBEDDED_TOPICS): ['in-flight-products']
+        ]
+        ApplicationContext ctx = ApplicationContext.run(config)
+
+        when: "a message is sent"
+        def client = ctx.getBean(InFlightClient)
+        def consumer = ctx.getBean(InFlightConsumer)
+        client.send("test-product")
+
+        then: "message starts processing"
+        conditions.eventually {
+            consumer.processing.get()
+        }
+
+        when: "shutdown is triggered while processing"
+        Instant start = Instant.now()
+        ctx.close()
+        Duration shutdownDuration = Duration.between(start, Instant.now())
+
+        then: "the message is fully processed"
+        consumer.messageProcessed.get()
+
+        and: "shutdown completes before grace period"
+        shutdownDuration.seconds < 15
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownIdleSpec')
+    @KafkaListener(groupId = "idle-consumer", offsetReset = EARLIEST)
+    static class IdleConsumer {
+        @Topic("idle-topic")
+        void receive(String message) {
+            // Idle consumer - receives no messages during test
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownInFlightSpec')
+    @KafkaListener(groupId = "in-flight-consumer", offsetReset = EARLIEST)
+    static class InFlightConsumer {
+        AtomicBoolean processing = new AtomicBoolean(false)
+        AtomicBoolean messageProcessed = new AtomicBoolean(false)
+
+        @Topic("in-flight-products")
+        void receive(String product) {
+            processing.set(true)
+            try {
+                // Simulate some processing time
+                sleep(2000)
+                messageProcessed.set(true)
+            } finally {
+                processing.set(false)
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownInFlightSpec')
+    @KafkaClient
+    static interface InFlightClient {
+        @Topic("in-flight-products")
+        void send(String product)
+    }
+}


### PR DESCRIPTION
Kafka consumers always time out during graceful shutdown. Update KafkaConsumerProcessor so it implements GracefulShutdownCapable: signal consumers to stop polling and coordinate shutdown within the configured grace period.

Fixes #1278