### PR TITLE
fix: prevent Prometheus tag-key mismatch WARNs in AbstractKafkaMetricsReporter

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -51,7 +51,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        if (!meterRegistries.contains(registry)) {
+        if (\!meterRegistries.contains(registry)) {
             meterRegistries.add(registry);
         }
     }
@@ -81,7 +81,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     @Override
     public void configure(Map<String, ?> configs) {
         Object meterRegistry = configs.get("meter.registry");
-        if (meterRegistry != null) {
+        if (meterRegistry \!= null) {
             meterRegistries.add((MeterRegistry) meterRegistry);
         }
     }
@@ -89,7 +89,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     @PreDestroy
     @Override
     public void close() {
-        if (metrics != null) {
+        if (metrics \!= null) {
             metrics.clear();
             metrics = null;
         }
@@ -97,6 +97,16 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     private void registerMetric(MeterRegistry meterRegistry, KafkaMetric metric) {
+        List<Tag> tags = getTagFunction().apply(metric.metricName());
+        if (tags.isEmpty()) {
+            // Skip metrics that resolve to no tags. Kafka's internal bookkeeping metrics
+            // (e.g. kafka-metrics-count/count from the root Metrics instance) carry no tags,
+            // whereas the same metric name is later registered with tags (e.g. client-id) by
+            // the actual client instance. Registering both the tagless and tagged variants with
+            // Prometheus causes a WARN because Prometheus requires every occurrence of a given
+            // metric name to carry exactly the same set of label (tag) keys.
+            return;
+        }
         KafkaMetricMeterTypeBuilder.newBuilder()
                 .prefix(getMetricPrefix())
                 .metric(metric)
@@ -116,7 +126,16 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     /**
-     * The tags to include in the gauge. Defaults to just the client-id.
+     * The tags to include in the gauge.
+     *
+     * <p>Defaults to {@code client-id} and {@code topic}. {@code node-id} is intentionally
+     * excluded from the base set: Kafka registers certain metrics (e.g. {@code request-total})
+     * both with and without a {@code node-id} tag depending on which internal client instance
+     * performs the registration. Including {@code node-id} here causes some occurrences of a
+     * metric name to carry {@code [client_id, node_id]} while others carry only
+     * {@code [client_id]}, which Prometheus rejects with a tag-key mismatch WARN. Subclasses
+     * that genuinely require per-node breakdown may override this method and add
+     * {@link #NODE_ID_TAG} explicitly.
      *
      * @return The tags to include
      */
@@ -124,7 +143,6 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         HashSet<String> tags = new HashSet<>();
         tags.add(CLIENT_ID_TAG);
         tags.add(TOPIC_TAG);
-        tags.add(NODE_ID_TAG);
         return tags;
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -51,7 +51,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        if (\!meterRegistries.contains(registry)) {
+        if (!meterRegistries.contains(registry)) {
             meterRegistries.add(registry);
         }
     }
@@ -81,7 +81,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     @Override
     public void configure(Map<String, ?> configs) {
         Object meterRegistry = configs.get("meter.registry");
-        if (meterRegistry \!= null) {
+        if (meterRegistry != null) {
             meterRegistries.add((MeterRegistry) meterRegistry);
         }
     }
@@ -89,7 +89,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     @PreDestroy
     @Override
     public void close() {
-        if (metrics \!= null) {
+        if (metrics != null) {
             metrics.clear();
             metrics = null;
         }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.metrics
+
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.KafkaMetric
+import org.apache.kafka.common.metrics.MetricConfig
+import org.apache.kafka.common.metrics.stats.Avg
+import org.apache.kafka.common.utils.Time
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link AbstractKafkaMetricsReporter}.
+ *
+ * Verifies the two guards that prevent Prometheus tag-key mismatch WARNs:
+ *
+ * <ol>
+ *   <li>Metrics that resolve to <em>no</em> tags (Kafka internal bookkeeping metrics) are
+ *       skipped and never registered in the {@link io.micrometer.core.instrument.MeterRegistry}.</li>
+ *   <li>{@code node-id} is excluded from the base {@code getIncludedTags()} set so that metrics
+ *       registered both with and without a {@code node-id} tag always resolve to the same label
+ *       key set ({@code client-id} and/or {@code topic}).</li>
+ * </ol>
+ *
+ * No Kafka broker is required: metrics are constructed directly from
+ * {@link org.apache.kafka.common.metrics.KafkaMetric} with hand-crafted
+ * {@link org.apache.kafka.common.MetricName} instances.
+ */
+class AbstractKafkaMetricsReporterSpec extends Specification {
+
+    // Minimal concrete subclass - only getMetricPrefix() needs an implementation.
+    private AbstractKafkaMetricsReporter reporter() {
+        return new AbstractKafkaMetricsReporter() {
+            @Override
+            protected String getMetricPrefix() { "kafka.test" }
+        }
+    }
+
+    private KafkaMetric metric(String name, String group, Map<String, String> tags) {
+        return new KafkaMetric(
+            new Object(),
+            new MetricName(name, group, "test metric", tags),
+            new Avg(),
+            new MetricConfig(),
+            Mock(Time)
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Guard 1: empty-tag metrics are skipped
+    // -----------------------------------------------------------------------
+
+    def "metric with no tags is not registered in the meter registry"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def reporter = reporter()
+        reporter.configure(["meter.registry": registry])
+
+        when: "a metric whose MetricName carries no tags is processed"
+        def noTagMetric = metric("count", "kafka-metrics-count", [:])
+        reporter.init([noTagMetric])
+
+        then: "the registry stays empty - the tagless metric is silently skipped"
+        registry.meters.isEmpty()
+    }
+
+    def "metricChange with no-tag metric does not register a meter"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def reporter = reporter()
+        reporter.configure(["meter.registry": registry])
+        reporter.init([])
+
+        when:
+        reporter.metricChange(metric("count", "kafka-metrics-count", [:]))
+
+        then:
+        registry.meters.isEmpty()
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path: metric with an included tag IS registered
+    // -----------------------------------------------------------------------
+
+    def "metric with client-id tag is registered"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def reporter = reporter()
+        reporter.configure(["meter.registry": registry])
+
+        when:
+        reporter.init([metric("request-rate", "consumer-metrics", ["client-id": "my-app"])])
+
+        then:
+        registry.meters.size() > 0
+        registry.meters.every { Meter m ->
+            m.id.tags.any { it.key == "client_id" || it.key == "client-id" }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Guard 2: node-id is excluded from the base included-tags set
+    // -----------------------------------------------------------------------
+
+    def "base getIncludedTags does not contain node-id"() {
+        expect:
+        reporter().includedTags.contains(AbstractKafkaMetricsReporter.CLIENT_ID_TAG)
+        reporter().includedTags.contains(AbstractKafkaMetricsReporter.TOPIC_TAG)
+        !reporter().includedTags.contains(AbstractKafkaMetricsReporter.NODE_ID_TAG)
+    }
+
+    def "metric with node-id tag is registered without node-id in the meter tags"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def reporter = reporter()
+        reporter.configure(["meter.registry": registry])
+
+        when: "a metric carrying both client-id and node-id is processed"
+        reporter.init([metric("request-total", "consumer-node-metrics",
+            ["client-id": "my-app", "node-id": "node--1"])])
+
+        then: "a meter IS registered (client-id is included)"
+        registry.meters.size() > 0
+
+        and: "none of the registered meters carry a node-id tag"
+        registry.meters.every { Meter m ->
+            m.id.tags.every { it.key != "node-id" && it.key != "node_id" }
+        }
+    }
+
+    def "two metrics differing only by node-id value produce meters with identical tag keys"() {
+        given: "two request-total metrics - one with node-id node--1, one with node-id node-1"
+        def registry = new SimpleMeterRegistry()
+        def reporter = reporter()
+        reporter.configure(["meter.registry": registry])
+
+        def m1 = metric("request-total", "consumer-node-metrics",
+            ["client-id": "my-app", "node-id": "node--1"])
+        def m2 = metric("request-total", "consumer-node-metrics",
+            ["client-id": "my-app", "node-id": "node-1"])
+
+        when:
+        reporter.init([m1])
+        reporter.metricChange(m2)
+
+        then: "both produce meters, and all meters share the same tag key set (no mismatch)"
+        def tagKeySets = registry.meters.collect { Meter m ->
+            m.id.tags.collect { it.key }.sort() as Set
+        }
+        tagKeySets.toUnique().size() == 1
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -159,9 +159,9 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         reporter.metricChange(m2)
 
         then: "both produce meters, and all meters share the same tag key set (no mismatch)"
-        def tagKeySets = registry.meters.collect { Meter m ->
-            m.id.tags.collect { it.key }.sort() as Set
+        def tagKeyLists = registry.meters.collect { Meter m ->
+            m.id.tags.collect { it.key }.sort()
         }
-        tagKeySets.toUnique().size() == 1
+        tagKeyLists.unique().size() == 1
     }
 }


### PR DESCRIPTION
## Problem

Applications using `micronaut-kafka-streams` together with `micrometer-registry-prometheus` emit a stream of `WARN` log entries at startup whenever Kafka metrics are registered. Two distinct patterns appear:

**Pattern 1 — tagless metric clashes with tagged variant**
```
The meter (MeterId{name='kafka-streams.count', tags=[]}) registration has failed:
Prometheus requires that all meters with the same name have the same set of tag keys.
There is already an existing meter named 'kafka_streams_count' containing tag keys [client_id].
The meter you are attempting to register has keys [].
```

**Pattern 2 — `node-id` tag present on some registrations but not others**
```
The meter (MeterId{name='kafka-streams.request-total',
  tags=[tag(client-id=my-app-admin), tag(node-id=node--1)]}) registration has failed:
Prometheus requires that all meters with the same name have the same set of tag keys.
There is already an existing meter named 'kafka_streams_request_total' containing tag keys [client_id].
The meter you are attempting to register has keys [client_id, node_id].
```

Closes #1225.

## Root cause

Both patterns originate in `AbstractKafkaMetricsReporter`.

### Pattern 1 — no guard for tagless metrics

`registerMetric()` forwards every `KafkaMetric` directly to `KafkaMetricMeterTypeBuilder` without checking whether the resolved tag list is empty. Kafka's root `Metrics` instance registers a bookkeeping metric (`kafka-metrics-count` / `count`) that carries **no tags**. The actual client-scoped instance later registers the same metric name with `[client-id]` tags. Prometheus sees two occurrences of the same metric name with different label key sets and rejects the second registration with a WARN.

### Pattern 2 — `node-id` included in base tag set

`getIncludedTags()` previously returned `{client-id, topic, node-id}`. Kafka registers certain metrics (e.g. `request-total`) via two different internal client paths: one path includes a `node-id` tag; the other does not. Because `node-id` was in the base included-tag set, the two registrations produced tag key sets `[client_id]` and `[client_id, node_id]` for the same metric name — again rejected by Prometheus.

## Changes

### 1. Guard against empty tag lists in `registerMetric()`

Tagless metrics are internal Kafka bookkeeping entries not meaningful to expose in Prometheus. The fix adds an early return when the resolved tag list is empty, eliminating Pattern 1 entirely.

### 2. Remove `NODE_ID_TAG` from base `getIncludedTags()`

The base set now returns only `{client-id, topic}`. `NODE_ID_TAG` is kept as a `public static final` constant so that subclasses that genuinely need per-node breakdown can add it in their own `getIncludedTags()` override. A Javadoc comment on the method explains why it was removed from the base set.

## Affected subclasses

| Class | Module | Impact |
|---|---|---|
| `ProducerKafkaMetricsReporter` | `kafka` | Uses base tags — benefits directly |
| `ConsumerKafkaMetricsReporter` | `kafka` | Overrides `getIncludedTags()` to add `partition` — unaffected by tag change; benefits from empty-tag guard |
| `KafkaStreamsMetricsReporter` | `kafka-streams` | Uses base tags — benefits directly; this is the class that generates both WARN patterns in practice |

## Testing

The existing test suite covers metric registration behaviour. No new test infrastructure is required for the guard change; the `node-id` removal is covered by the existing tag-inclusion tests for each reporter subclass.
