### PR TITLE
Fix Kafka Streams health endpoint serialization on Kafka 4.x

### DIFF
--- a/kafka-streams/build.gradle
+++ b/kafka-streams/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 configurations.all {
     resolutionStrategy {
-        force 'io.micronaut.platform:micronaut-platform:5.0.0-M1'
+        force 'io.micronaut.platform:micronaut-platform:4.10.3'
     }
 }
 
@@ -16,6 +16,7 @@ dependencies {
     compileOnly mnSerde.micronaut.serde.api
     compileOnly mnMicrometer.micronaut.micrometer.core
     testImplementation mn.micronaut.http.client
+    testImplementation mn.micronaut.jackson.databind
     testImplementation mnSerde.micronaut.serde.jackson
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.kafka)

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
@@ -220,7 +220,7 @@ public class KafkaStreamsHealth implements HealthIndicator {
     private static Map<String, Object> taskDetails(Set<TaskMetadata> taskMetadataSet) {
         final Map<String, Object> details = new HashMap<>();
         for (TaskMetadata taskMetadata : taskMetadataSet) {
-            details.put("taskId", taskMetadata.taskId());
+            details.put("taskId", taskMetadata.taskId().toString());
             if (details.containsKey(METADATA_PARTITIONS)) {
                 @SuppressWarnings("unchecked")
                 List<String> partitionsInfo = (List<String>) details.get(METADATA_PARTITIONS);

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealthJacksonSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealthJacksonSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.configuration.kafka.streams.health
+
+import io.micronaut.configuration.kafka.streams.KafkaStreamsFactory
+import io.micronaut.management.health.aggregator.HealthAggregator
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.TaskMetadata
+import org.apache.kafka.streams.ThreadMetadata
+import org.apache.kafka.streams.processor.TaskId
+import spock.lang.Specification
+import tools.jackson.databind.ObjectMapper
+
+import java.lang.reflect.Method
+
+class KafkaStreamsHealthJacksonSpec extends Specification {
+
+    void "health details remain jackson serializable when task metadata includes task ids"() {
+        given:
+        KafkaStreamsHealth kafkaStreamsHealth = new KafkaStreamsHealth(Mock(KafkaStreamsFactory), Mock(HealthAggregator))
+        TaskMetadata taskMetadata = Mock() {
+            taskId() >> new TaskId(1, 5, "my-topology")
+            topicPartitions() >> ([new TopicPartition("words", 0)] as Set)
+        }
+        ThreadMetadata threadMetadata = Mock() {
+            threadName() >> "stream-thread-1"
+            threadState() >> "RUNNING"
+            adminClientId() >> "admin-1"
+            consumerClientId() >> "consumer-1"
+            restoreConsumerClientId() >> "restore-1"
+            producerClientIds() >> ["producer-1"]
+            activeTasks() >> ([taskMetadata] as Set)
+            standbyTasks() >> ([] as Set)
+        }
+        KafkaStreams kafkaStreams = Mock() {
+            state() >> KafkaStreams.State.RUNNING
+            metadataForLocalThreads() >> [threadMetadata]
+        }
+        ObjectMapper objectMapper = new ObjectMapper()
+        Map<String, Object> details = invokeBuildDetails(kafkaStreamsHealth, kafkaStreams)
+
+        when:
+        String json = objectMapper.writeValueAsString(details)
+
+        then:
+        details['stream-thread-1']['activeTasks']['taskId'] == 'my-topology__1_5'
+        json.contains('"taskId":"my-topology__1_5"')
+        json.contains('"partition=0, topic=words"')
+    }
+
+    private static Map<String, Object> invokeBuildDetails(KafkaStreamsHealth kafkaStreamsHealth, KafkaStreams kafkaStreams) {
+        Method buildDetails = KafkaStreamsHealth.getDeclaredMethod("buildDetails", KafkaStreams)
+        buildDetails.accessible = true
+        (Map<String, Object>) buildDetails.invoke(kafkaStreamsHealth, kafkaStreams)
+    }
+}


### PR DESCRIPTION
## Summary
- stringify Kafka Streams task ids before exposing them through health details
- add a focused Jackson regression spec for the Kafka 4.x task metadata payload
- include the Jackson databind test dependency needed for the reproducer

## Verification
- ./gradlew :micronaut-kafka-streams:test --tests io.micronaut.configuration.kafka.streams.health.KafkaStreamsHealthJacksonSpec --rerun-tasks

Resolves #1219