### PR TITLE
Fix batch deserialization seek with disabled offsets

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.kafka.processor;
 
 import io.micronaut.configuration.kafka.KafkaAcknowledgement;
 import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
@@ -70,7 +71,9 @@ final class ConsumerStateBatch extends ConsumerState {
             // Try to honor the configured error strategy
             LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
             // By default, seek past the record to continue consumption
-            kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
+            if (info.offsetStrategy != OffsetStrategy.DISABLED) {
+                kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
+            }
             // The error strategy and the exception handler can still decide what to do about this record
             resolveWithErrorStrategy(null, reconstructCurrentOffsetsIfAbsent(currentOffsets, ex), ex);
             // By now, it's been decided whether this record should be retried and the exception may have been handled

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -70,7 +70,7 @@ final class ConsumerStateBatch extends ConsumerState {
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
             LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
-            // By default, seek past the record to continue consumption
+            // When offset management is enabled, seek past the record to continue consumption
             if (info.offsetStrategy != OffsetStrategy.DISABLED) {
                 kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
@@ -1,16 +1,18 @@
 package io.micronaut.configuration.kafka.processor
 
-import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaListener
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.inject.ExecutableMethod
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.RecordDeserializationException
 import spock.lang.Specification
-import sun.misc.Unsafe
 
-import java.lang.reflect.Field
 import java.time.Duration
 import java.util.Collections
 
@@ -72,31 +74,23 @@ class ConsumerStateBatchSpec extends Specification {
         1 * kafkaConsumerProcessor.handleException(_, _ as KafkaListenerException)
     }
 
-    private static ConsumerInfo consumerInfo(OffsetStrategy offsetStrategy) {
-        ConsumerInfo info = allocateInstance(ConsumerInfo)
-        setField(info, "offsetStrategy", offsetStrategy)
-        setField(info, "errorStrategy", ErrorStrategyValue.NONE)
-        setField(info, "retryCount", 0)
-        setField(info, "shouldHandleAllExceptions", false)
-        setField(info, "pollTimeout", Duration.ofMillis(1))
-        setField(info, "logMethod", "TestConsumer#receive")
-        setField(info, "autoStartup", true)
-        return info
-    }
-
-    private static <T> T allocateInstance(Class<T> type) {
-        return type.cast(Unsafe.class.getMethod("allocateInstance", Class).invoke(unsafe(), type))
-    }
-
-    private static void setField(Object target, String fieldName, Object value) {
-        Field field = ConsumerInfo.class.getDeclaredField(fieldName)
-        field.accessible = true
-        field.set(target, value)
-    }
-
-    private static Unsafe unsafe() {
-        Field field = Unsafe.class.getDeclaredField("theUnsafe")
-        field.accessible = true
-        return (Unsafe) field.get(null)
+    private ConsumerInfo consumerInfo(OffsetStrategy offsetStrategy) {
+        AnnotationValue<KafkaListener> kafkaListener = AnnotationValue.builder(KafkaListener).build()
+        ReturnType<?> returnType = Stub(ReturnType) {
+            getType() >> Void
+            isAsyncOrReactive() >> false
+            getFirstTypeVariable() >> Optional.empty()
+        }
+        ExecutableMethod<?, ?> method = Stub(ExecutableMethod) {
+            getDeclaringType() >> ConsumerStateBatchSpec
+            getName() >> "receive"
+            isTrue(_, _) >> false
+            hasAnnotation(_) >> false
+            getValue(KafkaListener, "pollTimeout", Duration) >> Optional.of(Duration.ofMillis(1))
+            getArguments() >> new Argument[0]
+            stringValues(_) >> null
+            getReturnType() >> returnType
+        }
+        return new ConsumerInfo("test-client", null, offsetStrategy, kafkaListener, method)
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.RecordDeserializationException
+import spock.lang.Specification
+import sun.misc.Unsafe
+
+import java.lang.reflect.Field
+import java.time.Duration
+import java.util.Collections
+
+class ConsumerStateBatchSpec extends Specification {
+
+    void "does not seek past deserialization failures when offset strategy is disabled"() {
+        given:
+        TopicPartition topicPartition = new TopicPartition("books", 1)
+        RecordDeserializationException exception = new RecordDeserializationException(
+                topicPartition,
+                4L,
+                "boom",
+                new IllegalStateException("deserialization failed")
+        )
+        Consumer<?, ?> kafkaConsumer = Mock() {
+            subscription() >> Collections.emptySet()
+            poll(_ as Duration) >> { throw exception }
+        }
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock()
+        ConsumerInfo info = consumerInfo(OffsetStrategy.DISABLED)
+        ConsumerStateBatch state = new ConsumerStateBatch(kafkaConsumerProcessor, info, kafkaConsumer, new Object())
+
+        when:
+        ConsumerRecords<?, ?> records = state.pollRecords(null)
+
+        then:
+        records == null
+        0 * kafkaConsumer.seek(_, _)
+        1 * kafkaConsumerProcessor.handleException(_, {
+            it instanceof KafkaListenerException &&
+                    it.cause.is(exception) &&
+                    it.kafkaConsumer.is(kafkaConsumer)
+        })
+    }
+
+    void "continues to seek past deserialization failures for non-disabled offset strategies"() {
+        given:
+        TopicPartition topicPartition = new TopicPartition("books", 1)
+        RecordDeserializationException exception = new RecordDeserializationException(
+                topicPartition,
+                4L,
+                "boom",
+                new IllegalStateException("deserialization failed")
+        )
+        Consumer<?, ?> kafkaConsumer = Mock() {
+            subscription() >> Collections.emptySet()
+            poll(_ as Duration) >> { throw exception }
+        }
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock()
+        ConsumerInfo info = consumerInfo(OffsetStrategy.SYNC)
+        ConsumerStateBatch state = new ConsumerStateBatch(kafkaConsumerProcessor, info, kafkaConsumer, new Object())
+
+        when:
+        ConsumerRecords<?, ?> records = state.pollRecords(null)
+
+        then:
+        records == null
+        1 * kafkaConsumer.seek(topicPartition, 5L)
+        1 * kafkaConsumerProcessor.handleException(_, _ as KafkaListenerException)
+    }
+
+    private static ConsumerInfo consumerInfo(OffsetStrategy offsetStrategy) {
+        ConsumerInfo info = allocateInstance(ConsumerInfo)
+        setField(info, "offsetStrategy", offsetStrategy)
+        setField(info, "errorStrategy", ErrorStrategyValue.NONE)
+        setField(info, "retryCount", 0)
+        setField(info, "shouldHandleAllExceptions", false)
+        setField(info, "pollTimeout", Duration.ofMillis(1))
+        setField(info, "logMethod", "TestConsumer#receive")
+        setField(info, "autoStartup", true)
+        return info
+    }
+
+    private static <T> T allocateInstance(Class<T> type) {
+        return type.cast(Unsafe.class.getMethod("allocateInstance", Class).invoke(unsafe(), type))
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        Field field = ConsumerInfo.class.getDeclaredField(fieldName)
+        field.accessible = true
+        field.set(target, value)
+    }
+
+    private static Unsafe unsafe() {
+        Field field = Unsafe.class.getDeclaredField("theUnsafe")
+        field.accessible = true
+        return (Unsafe) field.get(null)
+    }
+}


### PR DESCRIPTION
## Summary
- skip the automatic deserialization-failure seek in batch mode when the listener uses `OffsetStrategy.DISABLED`
- add a focused regression spec covering both disabled and non-disabled offset strategies

## Verification
- ./gradlew :micronaut-kafka:spotlessCheck :micronaut-kafka:test --tests io.micronaut.configuration.kafka.processor.ConsumerStateBatchSpec --rerun-tasks

Resolves #1188