### PR TITLE
Fix Kafka metrics meter cleanup

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -122,20 +122,22 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         }
 
         String meterName = getMetricPrefix() + "." + metric.metricName().name();
-        List<Tag> expectedTags = getTags(metric.metricName());
-        meters.values()
-                .stream()
-                .filter(meter -> meter.getId().getName().equals(meterName))
-                .filter(meter -> meter.getId().getTags().size() == expectedTags.size()
-                        && meter.getId().getTags().containsAll(expectedTags))
-                .toList()
-                .forEach(meter -> {
-                    meterRegistry.remove(meter);
-                    meters.remove(meter.getId());
-                });
+        Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName()));
+        for (var iterator = meters.entrySet().iterator(); iterator.hasNext(); ) {
+            var meterEntry = iterator.next();
+            Meter meter = meterEntry.getValue();
+            if (meter.getId().getName().equals(meterName) && hasExpectedTags(meter.getId().getTags(), expectedTags)) {
+                meterRegistry.remove(meter);
+                iterator.remove();
+            }
+        }
         if (meters.isEmpty()) {
             registeredMeters.remove(meterRegistry, meters);
         }
+    }
+
+    private static boolean hasExpectedTags(List<Tag> meterTags, Set<Tag> expectedTags) {
+        return meterTags.size() == expectedTags.size() && expectedTags.containsAll(meterTags);
     }
 
     private Function<MetricName, List<Tag>> getTagFunction() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -116,19 +116,26 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     private void removeMetric(MeterRegistry meterRegistry, KafkaMetric metric) {
-        meterRegistry.find(getMetricPrefix() + "." + metric.metricName().name())
-                .tags(getTags(metric.metricName()))
-                .meters()
+        Map<Meter.Id, Meter> meters = registeredMeters.get(meterRegistry);
+        if (meters == null || meters.isEmpty()) {
+            return;
+        }
+
+        String meterName = getMetricPrefix() + "." + metric.metricName().name();
+        List<Tag> expectedTags = getTags(metric.metricName());
+        meters.values()
+                .stream()
+                .filter(meter -> meter.getId().getName().equals(meterName))
+                .filter(meter -> meter.getId().getTags().size() == expectedTags.size()
+                        && meter.getId().getTags().containsAll(expectedTags))
+                .toList()
                 .forEach(meter -> {
                     meterRegistry.remove(meter);
-                    Map<Meter.Id, Meter> meters = registeredMeters.get(meterRegistry);
-                    if (meters != null) {
-                        meters.remove(meter.getId());
-                        if (meters.isEmpty()) {
-                            registeredMeters.remove(meterRegistry, meters);
-                        }
-                    }
+                    meters.remove(meter.getId());
                 });
+        if (meters.isEmpty()) {
+            registeredMeters.remove(meterRegistry, meters);
+        }
     }
 
     private Function<MetricName, List<Tag>> getTagFunction() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.kafka.metrics;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 
@@ -46,6 +48,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     public static final String NODE_ID_TAG = "node-id";
 
     private final Collection<MeterRegistry> meterRegistries = new ConcurrentLinkedQueue<>();
+    private final Map<MeterRegistry, Map<Meter.Id, Meter>> registeredMeters = new ConcurrentHashMap<>();
 
     private List<KafkaMetric> metrics;
 
@@ -75,7 +78,9 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
 
     @Override
     public void metricRemoval(KafkaMetric metric) {
-        // no-op (Micrometer doesn't support removal)
+        for (MeterRegistry meterRegistry : meterRegistries) {
+            removeMetric(meterRegistry, metric);
+        }
     }
 
     @Override
@@ -93,6 +98,8 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
             metrics.clear();
             metrics = null;
         }
+        registeredMeters.forEach((meterRegistry, meters) -> meters.values().forEach(meterRegistry::remove));
+        registeredMeters.clear();
         meterRegistries.clear();
     }
 
@@ -102,11 +109,34 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
                 .metric(metric)
                 .tagFunction(getTagFunction())
                 .registry(meterRegistry)
-                .build();
+                .build()
+                .ifPresent(meter -> registeredMeters
+                        .computeIfAbsent(meterRegistry, ignored -> new ConcurrentHashMap<>())
+                        .put(meter.getId(), meter));
+    }
+
+    private void removeMetric(MeterRegistry meterRegistry, KafkaMetric metric) {
+        meterRegistry.find(getMetricPrefix() + "." + metric.metricName().name())
+                .tags(getTags(metric.metricName()))
+                .meters()
+                .forEach(meter -> {
+                    meterRegistry.remove(meter);
+                    Map<Meter.Id, Meter> meters = registeredMeters.get(meterRegistry);
+                    if (meters != null) {
+                        meters.remove(meter.getId());
+                        if (meters.isEmpty()) {
+                            registeredMeters.remove(meterRegistry, meters);
+                        }
+                    }
+                });
     }
 
     private Function<MetricName, List<Tag>> getTagFunction() {
-        return metricName -> metricName
+        return this::getTags;
+    }
+
+    private List<Tag> getTags(MetricName metricName) {
+        return metricName
                 .tags()
                 .entrySet()
                 .stream()

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -41,16 +41,13 @@ import java.util.function.Function;
 @Internal
 public class KafkaMetricMeterTypeBuilder {
 
+    private static final KafkaMetricMeterTypeRegistry KAFKA_METRIC_METER_TYPE_REGISTRY = new KafkaMetricMeterTypeRegistry();
+
     private MeterRegistry meterRegistry;
     private String name;
     private Function<MetricName, List<Tag>> tagFunction;
     private KafkaMetric kafkaMetric;
     private String prefix;
-
-    /**
-     * Construct this here instead of using static map in registry to free memory at runtime.
-     */
-    private final KafkaMetricMeterTypeRegistry kafkaMetricMeterTypeRegistry = new KafkaMetricMeterTypeRegistry();
 
     /**
      * Method for creating a new builder class.
@@ -131,11 +128,10 @@ public class KafkaMetricMeterTypeBuilder {
             name = kafkaMetric.metricName().name();
         }
 
-        KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
+        KafkaMetricMeterType kafkaMetricMeterType = KAFKA_METRIC_METER_TYPE_REGISTRY.lookup(this.name);
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
-            final KafkaMetric kafkaMetric = this.kafkaMetric;
-            return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
+            return Optional.of(Gauge.builder(getMetricName(), kafkaMetric, value -> ((Number) value.metricValue()).doubleValue())
                     .tags(tagFunction.apply(kafkaMetric.metricName()))
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -1,0 +1,75 @@
+package io.micronaut.configuration.kafka.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.KafkaMetric
+import org.apache.kafka.common.metrics.MetricConfig
+import org.apache.kafka.common.metrics.stats.Avg
+import org.apache.kafka.common.utils.Time
+import spock.lang.Specification
+
+class AbstractKafkaMetricsReporterSpec extends Specification {
+
+    void "metric removal removes meters from registry"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new TestKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        (0..<10).each { partition ->
+            KafkaMetric metric = createMetric(partition)
+            reporter.metricChange(metric)
+            reporter.metricRemoval(metric)
+        }
+
+        then:
+        meterRegistry.meters.isEmpty()
+    }
+
+    void "close removes registered meters from registry"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new TestKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createMetric(1))
+        reporter.close()
+
+        then:
+        meterRegistry.meters.isEmpty()
+    }
+
+    private static KafkaMetric createMetric(int partition) {
+        new KafkaMetric(
+                new Object(),
+                new MetricName(
+                        "records-lag",
+                        "consumer-fetch-manager-metrics",
+                        "description",
+                        [
+                                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                                (AbstractKafkaMetricsReporter.TOPIC_TAG): "topic-${partition}".toString(),
+                                (ConsumerKafkaMetricsReporter.PARTITION_TAG): Integer.toString(partition),
+                        ]
+                ),
+                new Avg(),
+                new MetricConfig(),
+                Time.SYSTEM
+        )
+    }
+
+    private static final class TestKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
+
+        @Override
+        protected String getMetricPrefix() {
+            return "kafka.test"
+        }
+
+        @Override
+        protected Set<String> getIncludedTags() {
+            [CLIENT_ID_TAG, TOPIC_TAG, ConsumerKafkaMetricsReporter.PARTITION_TAG] as Set
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -41,6 +41,41 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.meters.isEmpty()
     }
 
+    void "metric removal removes meters from all bound registries"() {
+        given:
+        def firstRegistry = new SimpleMeterRegistry()
+        def secondRegistry = new SimpleMeterRegistry()
+        def reporter = new TestKafkaMetricsReporter()
+        reporter.bindTo(firstRegistry)
+        reporter.bindTo(secondRegistry)
+
+        when:
+        def metric = createMetric(1)
+        reporter.metricChange(metric)
+        reporter.metricRemoval(metric)
+
+        then:
+        firstRegistry.meters.isEmpty()
+        secondRegistry.meters.isEmpty()
+    }
+
+    void "close removes registered meters from all bound registries"() {
+        given:
+        def firstRegistry = new SimpleMeterRegistry()
+        def secondRegistry = new SimpleMeterRegistry()
+        def reporter = new TestKafkaMetricsReporter()
+        reporter.bindTo(firstRegistry)
+        reporter.bindTo(secondRegistry)
+
+        when:
+        reporter.metricChange(createMetric(1))
+        reporter.close()
+
+        then:
+        firstRegistry.meters.isEmpty()
+        secondRegistry.meters.isEmpty()
+    }
+
     private static KafkaMetric createMetric(int partition) {
         new KafkaMetric(
                 new Object(),


### PR DESCRIPTION
## Summary
- unregister Micrometer meters when Kafka reports metric removal
- clear tracked meters on reporter close to avoid retaining stale metrics
- reuse the meter type registry and avoid per-meter lambda gauge allocations

## Verification
- ./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporterSpec --tests io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilderSpec
- ./gradlew :micronaut-kafka:test (fails in this environment for Testcontainers-based tests because Docker is unavailable)

Resolves #1123