### PR TITLE
Support GlobalKTable-only Kafka Streams topologies

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -110,12 +110,13 @@ public class KafkaStreamsFactory implements Closeable {
             ConfiguredStreamBuilder builder,
             KafkaClientSupplier kafkaClientSupplier,
             BeanProvider<KStream<?, ?>> kStreamsProvider,
-            BeanProvider<KTable<?, ?>> kTablesProvider,
-            BeanProvider<GlobalKTable<?, ?>> globalKTablesProvider
+        BeanProvider<KTable<?, ?>> kTablesProvider,
+        BeanProvider<GlobalKTable<?, ?>> globalKTablesProvider
     ) {
         KStream<?, ?>[] kStreams = kStreamsProvider.stream().toArray(KStream[]::new);
-        KTable<?, ?>[] kTables = kTablesProvider.stream().toArray(KTable[]::new);
-        GlobalKTable<?, ?>[] globalKTables = globalKTablesProvider.stream().toArray(GlobalKTable[]::new);
+        // Initialize table topology beans before building the topology.
+        kTablesProvider.stream().count();
+        globalKTablesProvider.stream().count();
         Topology topology = builder.build(builder.getConfiguration());
         TopologyDescription topologyDescription = topology.describe();
         if (topologyDescription.subtopologies().isEmpty() && topologyDescription.globalStores().isEmpty()) {

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -114,7 +114,7 @@ public class KafkaStreamsFactory implements Closeable {
         BeanProvider<GlobalKTable<?, ?>> globalKTablesProvider
     ) {
         KStream<?, ?>[] kStreams = kStreamsProvider.stream().toArray(KStream[]::new);
-        // Initialize table topology beans before building the topology.
+        // count() forces eager resolution before build() without allocating unused arrays.
         kTablesProvider.stream().count();
         globalKTablesProvider.stream().count();
         Topology topology = builder.build(builder.getConfiguration());

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -98,9 +98,9 @@ public class KafkaStreamsFactory implements Closeable {
      * @param name                 The configuration name
      * @param builder              The builder
      * @param kafkaClientSupplier  The kafka client supplier used to create consumers and producers in the streams app
-     * @param kStreams             The KStream definitions
-     * @param kTables              The KTable definitions
-     * @param globalKTables        The GlobalKTable definitions
+     * @param kStreamsProvider     The KStream definitions
+     * @param kTablesProvider      The KTable definitions
+     * @param globalKTablesProvider The GlobalKTable definitions
      * @return The {@link KafkaStreams} bean
      */
     @EachBean(ConfiguredStreamBuilder.class)

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -17,16 +17,21 @@ package io.micronaut.configuration.kafka.streams;
 
 import io.micronaut.configuration.kafka.streams.event.AfterKafkaStreamsStart;
 import io.micronaut.configuration.kafka.streams.event.BeforeKafkaStreamStart;
+import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.*;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
+import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +99,8 @@ public class KafkaStreamsFactory implements Closeable {
      * @param builder              The builder
      * @param kafkaClientSupplier  The kafka client supplier used to create consumers and producers in the streams app
      * @param kStreams             The KStream definitions
+     * @param kTables              The KTable definitions
+     * @param globalKTables        The GlobalKTable definitions
      * @return The {@link KafkaStreams} bean
      */
     @EachBean(ConfiguredStreamBuilder.class)
@@ -102,9 +109,18 @@ public class KafkaStreamsFactory implements Closeable {
             @Parameter String name,
             ConfiguredStreamBuilder builder,
             KafkaClientSupplier kafkaClientSupplier,
-            KStream<?, ?>... kStreams
+            BeanProvider<KStream<?, ?>> kStreamsProvider,
+            BeanProvider<KTable<?, ?>> kTablesProvider,
+            BeanProvider<GlobalKTable<?, ?>> globalKTablesProvider
     ) {
+        KStream<?, ?>[] kStreams = kStreamsProvider.stream().toArray(KStream[]::new);
+        KTable<?, ?>[] kTables = kTablesProvider.stream().toArray(KTable[]::new);
+        GlobalKTable<?, ?>[] globalKTables = globalKTablesProvider.stream().toArray(GlobalKTable[]::new);
         Topology topology = builder.build(builder.getConfiguration());
+        TopologyDescription topologyDescription = topology.describe();
+        if (topologyDescription.subtopologies().isEmpty() && topologyDescription.globalStores().isEmpty()) {
+            throw new DisabledBeanException("No topology components registered for stream builder: " + name);
+        }
         KafkaStreams kafkaStreams = new KafkaStreams(
                 topology,
                 builder.getConfiguration(),
@@ -119,7 +135,7 @@ public class KafkaStreamsFactory implements Closeable {
         }
         streams.put(kafkaStreams, builder);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Initializing Application {} with topology:\n{}", name, topology.describe().toString());
+            LOG.debug("Initializing Application {} with topology:\n{}", name, topologyDescription.toString());
         }
 
         if (startKafkaStreams) {

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/GlobalKTableOnlySpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/GlobalKTableOnlySpec.groovy
@@ -1,0 +1,74 @@
+package io.micronaut.configuration.kafka.streams
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.kstream.GlobalKTable
+import org.apache.kafka.streams.kstream.Materialized
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class GlobalKTableOnlySpec extends AbstractKafkaSpec {
+
+    private static final String UNIQUE_SUFFIX = UUID.randomUUID()
+    private static final String TMP_DIR = System.getProperty('java.io.tmpdir')
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(configuration)
+
+    void "test global ktable only topology is registered"() {
+        when:
+        ConfiguredStreamBuilder builder = context.getBean(ConfiguredStreamBuilder, Qualifiers.byName(GlobalTableOnlyFactory.STREAM_NAME))
+        context.getBean(GlobalKTable, Qualifiers.byName(GlobalTableOnlyFactory.STREAM_NAME))
+        KafkaStreams kafkaStreams = context.getBean(KafkaStreams, Qualifiers.byName(GlobalTableOnlyFactory.STREAM_NAME))
+        String topologyDescription = builder.build(builder.configuration).describe().toString()
+
+        then:
+        kafkaStreams
+        topologyDescription.contains(GlobalTableOnlyFactory.INPUT)
+        topologyDescription.contains(GlobalTableOnlyFactory.STORE)
+    }
+
+    @Override
+    protected Map<String, Object> getConfiguration() {
+        super.getConfiguration() + [
+                'kafka.bootstrap.servers': 'localhost:9092',
+                'kafka.test.initializer.enabled': 'false',
+                'kafka.streams.default.application.id': 'default-' + UNIQUE_SUFFIX,
+                'kafka.streams.default.start-kafka-streams': 'false',
+                'kafka.streams.default.state.dir': TMP_DIR + '/global-ktable-default-' + UNIQUE_SUFFIX,
+                'kafka.streams.my-stream.start-kafka-streams': 'false',
+                'kafka.streams.optimization-on.start-kafka-streams': 'false',
+                'kafka.streams.optimization-off.start-kafka-streams': 'false',
+                'kafka.streams.start-kafka-streams-off.start-kafka-streams': 'false',
+                'kafka.streams.global-table-only.application.id': 'global-table-only-' + UNIQUE_SUFFIX,
+                'kafka.streams.global-table-only.start-kafka-streams': 'false',
+                'kafka.streams.global-table-only.state.dir': TMP_DIR + '/global-ktable-only-' + UNIQUE_SUFFIX
+        ]
+    }
+
+    @Requires(property = "spec.name", value = "GlobalKTableOnlySpec")
+    @Factory
+    static class GlobalTableOnlyFactory {
+        static final String STREAM_NAME = "global-table-only"
+        static final String INPUT = "global-table-only-input"
+        static final String STORE = "global-table-only-store"
+
+        @Singleton
+        @Context
+        @Named(STREAM_NAME)
+        GlobalKTable<String, String> globalTable(@Named(STREAM_NAME) ConfiguredStreamBuilder builder) {
+            builder.configuration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().class.name)
+            builder.configuration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().class.name)
+            builder.globalTable(INPUT, Materialized.as(STORE))
+        }
+    }
+}

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaTestInitializer.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaTestInitializer.java
@@ -6,6 +6,7 @@ import io.micronaut.configuration.kafka.streams.uncaught.CustomUncaughtHandlerSt
 import io.micronaut.configuration.kafka.streams.uncaught.OnErrorStreamFactory;
 import io.micronaut.configuration.kafka.streams.wordcount.WordCountStream;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.context.env.BootstrapPropertySourceLocator;
 import io.micronaut.context.env.Environment;
@@ -26,6 +27,7 @@ import java.util.stream.Stream;
 
 @BootstrapContextCompatible
 @Singleton
+@Requires(property = "kafka.test.initializer.enabled", notEquals = "false", defaultValue = "true")
 public class KafkaTestInitializer implements BootstrapPropertySourceLocator {
 
     private final Map<String, Object> adminProps;

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/optimization/OptimizationStream.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/optimization/OptimizationStream.java
@@ -2,6 +2,7 @@ package io.micronaut.configuration.kafka.streams.optimization;
 
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -14,6 +15,7 @@ import org.apache.kafka.streams.kstream.Materialized;
 import java.util.Properties;
 
 @Factory
+@Requires(property = "spec.name", notEquals = "GlobalKTableOnlySpec")
 public class OptimizationStream {
 
     public static final String STREAM_OPTIMIZATION_ON = "optimization-on";

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/startkafkastreams/StartKafkaStreamsOff.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/startkafkastreams/StartKafkaStreamsOff.java
@@ -2,6 +2,7 @@ package io.micronaut.configuration.kafka.streams.startkafkastreams;
 
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.apache.kafka.common.serialization.Serdes;
@@ -11,6 +12,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import java.util.Properties;
 
 @Factory
+@Requires(property = "spec.name", notEquals = "GlobalKTableOnlySpec")
 public class StartKafkaStreamsOff {
 
     public static final String START_KAFKA_STREAMS_OFF = "start-kafka-streams-off";

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/wordcount/WordCountStream.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/wordcount/WordCountStream.java
@@ -3,6 +3,7 @@ package io.micronaut.configuration.kafka.streams.wordcount;
 // tag::imports[]
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -21,6 +22,7 @@ import java.util.Properties;
 
 // tag::clazz[]
 @Factory
+@Requires(property = "spec.name", notEquals = "GlobalKTableOnlySpec")
 public class WordCountStream {
 
     public static final String STREAM_WORD_COUNT = "word-count";

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -30,7 +30,9 @@ kafka:
 ----
 
 
-You should then define a ann:context.annotation.Factory[] for your streams that defines beans that return a `KStream`. For example to implement the Word Count example from the Kafka Streams documentation:
+You should then define a ann:context.annotation.Factory[] for your streams that defines beans that register topology components against the injected `ConfiguredStreamBuilder`. These beans can return a `KStream`, `KTable`, or `GlobalKTable`, depending on the topology you are building. For example to implement the Word Count example from the Kafka Streams documentation:
+
+NOTE: If a stream topology is composed only of a `KTable` or `GlobalKTable`, make that bean eager (for example with ann:context.annotation.Context[]) so Micronaut initializes the topology before the corresponding `KafkaStreams` bean is resolved.
 
 .Kafka Streams Word Count
 
@@ -110,7 +112,7 @@ You can then inject an `api:configuration.kafka.streams.ConfiguredStreamBuilder[
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="myOtherStream", indent=0]
 
-NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have multiple KStreams defined that share the default configurations like client id, application id, etc. It is advisable when using multiple streams in a single app to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
+NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have multiple topology beans defined that share the default configurations like client id, application id, etc. It is advisable when using multiple streams in a single app to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
 
 .Kafka Streams Word Count
 

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -30,7 +30,7 @@ kafka:
 ----
 
 
-You should then define a ann:context.annotation.Factory[] for your streams that defines beans that register topology components against the injected `ConfiguredStreamBuilder`. These beans can return a `KStream`, `KTable`, or `GlobalKTable`, depending on the topology you are building. For example to implement the Word Count example from the Kafka Streams documentation:
+You should then define an ann:context.annotation.Factory[] for your streams that defines beans that register topology components against the injected `ConfiguredStreamBuilder`. These beans can return a `KStream`, `KTable`, or `GlobalKTable`, depending on the topology you are building. For example to implement the Word Count example from the Kafka Streams documentation:
 
 NOTE: If a stream topology is composed only of a `KTable` or `GlobalKTable`, make that bean eager (for example with ann:context.annotation.Context[]) so Micronaut initializes the topology before the corresponding `KafkaStreams` bean is resolved.
 
@@ -112,7 +112,7 @@ You can then inject an `api:configuration.kafka.streams.ConfiguredStreamBuilder[
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="myOtherStream", indent=0]
 
-NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` you have multiple topology beans defined that share the default configurations like client id, application id, etc. It is advisable when using multiple streams in a single app to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
+NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` and you have multiple topology beans defined, they share the default configurations such as client id and application id. When using multiple streams in a single app, it is advisable to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
 
 .Kafka Streams Word Count
 


### PR DESCRIPTION
## Summary
- support Kafka Streams beans backed by KTable or GlobalKTable topology registrations
- skip empty stream builders and add a focused GlobalKTable-only regression spec
- document the eager initialization requirement for standalone table-only topologies

## Verification
- ./gradlew --no-daemon :micronaut-kafka-streams:test --tests io.micronaut.configuration.kafka.streams.GlobalKTableOnlySpec

Resolves #1119