### PR TITLE
Add per-class Kafka listener consumer strategy

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.kafka-module.gradle
@@ -34,6 +34,10 @@ test {
 }
 
 ossIndexAudit {
+    if (System.getenv("OSS_INDEX_USERNAME") && System.getenv("OSS_INDEX_PASSWORD")) {
+        username = System.getenv("OSS_INDEX_USERNAME")
+        password = System.getenv("OSS_INDEX_PASSWORD")
+    }
     excludeCoordinates = [
             "org.lz4:lz4-java:1.8.1" // no version patched https://ossindex.sonatype.org/vulnerability/CVE-2025-12183?component-type=maven&component-name=org.lz4%2Flz4-java&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.2
     ]

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+/**
+ * Defines how Kafka consumers are created for listener methods.
+ *
+ * @author Micronaut Framework Team
+ * @since 4.9.0
+ */
+public enum ConsumerCreationStrategy {
+
+    /**
+     * Create one consumer per {@link Topic}-annotated method.
+     */
+    PER_TOPIC,
+
+    /**
+     * Create one consumer for the whole listener class and route records by topic.
+     */
+    PER_CLASS
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategy.java
@@ -18,8 +18,7 @@ package io.micronaut.configuration.kafka.annotation;
 /**
  * Defines how Kafka consumers are created for listener methods.
  *
- * @author Micronaut Framework Team
- * @since 4.9.0
+ * @since 6.0
  */
 public enum ConsumerCreationStrategy {
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -191,6 +191,14 @@ public @interface KafkaListener {
     int threads() default 1;
 
     /**
+     * Defines how consumers are created for multiple {@link Topic} methods within the same listener.
+     *
+     * @return The consumer creation strategy
+     * @since 4.9.0
+     */
+    ConsumerCreationStrategy consumerCreationStrategy() default ConsumerCreationStrategy.PER_TOPIC;
+
+    /**
      * The timeout to use for calls to {@link org.apache.kafka.clients.consumer.Consumer#poll(java.time.Duration)}.
      *
      * @return The timeout. Defaults to 100ms

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,11 +126,11 @@ final class ConsumerInfo {
         this.producerTransactionalId = kafkaListener.stringValue("producerTransactionalId").filter(StringUtils::isNotEmpty).orElse(null);
         this.isTransactional = producerTransactionalId != null;
         this.cooperativeStickyAssignmentStrategy = OffsetCommitExceptionLogger.isCooperativeStickyAssignor(properties.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
-        java.util.ArrayList<ExecutableMethod<Object, ?>> listenerMethods = new java.util.ArrayList<>(methods.size());
+        java.util.ArrayList<ExecutableMethod<Object, ?>> resolvedListenerMethods = new java.util.ArrayList<>(methods.size());
         for (ExecutableMethod<?, ?> executableMethod : methods) {
-            listenerMethods.add((ExecutableMethod<Object, ?>) executableMethod);
+            resolvedListenerMethods.add((ExecutableMethod<Object, ?>) executableMethod);
         }
-        this.listenerMethods = List.copyOf(listenerMethods);
+        this.listenerMethods = List.copyOf(resolvedListenerMethods);
         this.method = this.listenerMethods.get(0);
         this.patternMethods = resolveTopicMethods(this.listenerMethods);
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
@@ -140,7 +140,7 @@ final class ConsumerInfo {
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
 
         if (shouldSendOffsetsToTransaction) {
-            if (!isTransactional || !listenerMethods.stream().allMatch(executableMethod -> executableMethod.hasAnnotation(SendTo.class))) {
+            if (!this.listenerMethods.stream().allMatch(executableMethod -> executableMethod.hasAnnotation(SendTo.class)) || !isTransactional) {
                 throw new MessagingSystemException("Offset strategy 'SEND_TO_TRANSACTION' can only be used when transaction is enabled and @SendTo is used");
             }
             if (shouldRedeliver) {
@@ -153,7 +153,8 @@ final class ConsumerInfo {
         return listenerMethods.size() > 1;
     }
 
-    ExecutableMethod<Object, ?> method(String topic) {
+    @SuppressWarnings("java:S1452")
+    ExecutableMethod<Object, ?> methodForTopic(String topic) {
         if (topicMethods.isEmpty() && patternMethods.isEmpty()) {
             return method;
         }
@@ -161,16 +162,16 @@ final class ConsumerInfo {
     }
 
     String logMethod(String topic) {
-        ExecutableMethod<Object, ?> executableMethod = method(topic);
+        ExecutableMethod<Object, ?> executableMethod = methodForTopic(topic);
         return executableMethod.getDeclaringType().getSimpleName() + "#" + executableMethod.getName();
     }
 
     boolean isBlocking(String topic) {
-        return method(topic).hasAnnotation(Blocking.class);
+        return methodForTopic(topic).hasAnnotation(Blocking.class);
     }
 
     List<String> sendToTopics(String topic) {
-        return sendToTopicsCache.computeIfAbsent(method(topic), executableMethod ->
+        return sendToTopicsCache.computeIfAbsent(methodForTopic(topic), executableMethod ->
             Optional.ofNullable(executableMethod.stringValues(SendTo.class))
                 .filter(ArrayUtils::isNotEmpty)
                 .stream()
@@ -180,7 +181,7 @@ final class ConsumerInfo {
     }
 
     boolean returnsOneKafkaMessage(String topic) {
-        return returnsOneKafkaMessageCache.computeIfAbsent(method(topic), executableMethod -> {
+        return returnsOneKafkaMessageCache.computeIfAbsent(methodForTopic(topic), executableMethod -> {
             var returnType = executableMethod.getReturnType();
             return returnType.getType().isAssignableFrom(KafkaMessage.class) ||
                 (returnType.isAsyncOrReactive() && returnType.getFirstTypeVariable()
@@ -190,7 +191,7 @@ final class ConsumerInfo {
     }
 
     boolean returnsManyKafkaMessages(String topic) {
-        return returnsManyKafkaMessagesCache.computeIfAbsent(method(topic), executableMethod -> {
+        return returnsManyKafkaMessagesCache.computeIfAbsent(methodForTopic(topic), executableMethod -> {
             var returnType = executableMethod.getReturnType();
             return Iterable.class.isAssignableFrom(returnType.getType()) &&
                 returnType.getFirstTypeVariable().map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
@@ -198,8 +199,9 @@ final class ConsumerInfo {
     }
 
     @Nullable
+    @SuppressWarnings("java:S1452")
     Argument<?> consumerArg(String topic) {
-        return consumerArgCache.computeIfAbsent(method(topic), executableMethod ->
+        return consumerArgCache.computeIfAbsent(methodForTopic(topic), executableMethod ->
             Arrays.stream(executableMethod.getArguments())
                 .filter(arg -> Consumer.class.isAssignableFrom(arg.getType()))
                 .findFirst()
@@ -207,8 +209,9 @@ final class ConsumerInfo {
     }
 
     @Nullable
+    @SuppressWarnings("java:S1452")
     Argument<?> seekArg(String topic) {
-        return seekArgCache.computeIfAbsent(method(topic), executableMethod ->
+        return seekArgCache.computeIfAbsent(methodForTopic(topic), executableMethod ->
             Arrays.stream(executableMethod.getArguments())
                 .filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType()))
                 .findFirst()
@@ -216,8 +219,9 @@ final class ConsumerInfo {
     }
 
     @Nullable
+    @SuppressWarnings("java:S1452")
     Argument<?> ackArg(String topic) {
-        return ackArgCache.computeIfAbsent(method(topic), executableMethod ->
+        return ackArgCache.computeIfAbsent(methodForTopic(topic), executableMethod ->
             Arrays.stream(executableMethod.getArguments())
                 .filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType()))
                 .findFirst()
@@ -232,28 +236,13 @@ final class ConsumerInfo {
     private List<PatternMethod> resolveTopicMethods(List<ExecutableMethod<Object, ?>> methods) {
         List<PatternMethod> patterns = new java.util.ArrayList<>();
         for (ExecutableMethod<Object, ?> executableMethod : methods) {
-            for (AnnotationValue<Topic> topicAnnotation : topicAnnotations(executableMethod)) {
-                for (String topic : topicAnnotation.stringValues()) {
-                    ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
-                    if (previous != null && previous != executableMethod) {
-                        throw new MessagingSystemException("Duplicate topic [" + topic + "] found for listener [" + executableMethod.getDeclaringType().getName() + ']');
-                    }
-                }
-                for (String pattern : topicAnnotation.stringValues("patterns")) {
-                    try {
-                        patterns.add(new PatternMethod(Pattern.compile(pattern), executableMethod));
-                    } catch (PatternSyntaxException e) {
-                        throw new MessagingSystemException("Invalid @Topic pattern [" + pattern + "] for listener method [" + executableMethod.getDeclaringType().getName() + "#" + executableMethod.getName() + "]: " + e.getMessage(), e);
-                    }
-                }
-            }
+            registerTopicMethods(patterns, executableMethod);
         }
         return List.copyOf(patterns);
     }
 
     private static List<AnnotationValue<Topic>> topicAnnotations(ExecutableMethod<Object, ?> executableMethod) {
-        List<AnnotationValue<Topic>> topicAnnotations = executableMethod.getDeclaredAnnotationValuesByType(Topic.class);
-        return topicAnnotations == null ? List.of() : topicAnnotations;
+        return executableMethod.getDeclaredAnnotationValuesByType(Topic.class);
     }
 
     private ExecutableMethod<Object, ?> resolveMethod(String topic) {
@@ -277,6 +266,32 @@ final class ConsumerInfo {
             return method;
         }
         throw new MessagingSystemException("No @Topic method found for consumed topic [" + topic + "] in listener [" + method.getDeclaringType().getName() + "]");
+    }
+
+    private void registerTopicMethods(List<PatternMethod> patterns, ExecutableMethod<Object, ?> executableMethod) {
+        for (AnnotationValue<Topic> topicAnnotation : topicAnnotations(executableMethod)) {
+            registerDirectTopics(executableMethod, topicAnnotation);
+            registerPatterns(patterns, executableMethod, topicAnnotation);
+        }
+    }
+
+    private void registerDirectTopics(ExecutableMethod<Object, ?> executableMethod, AnnotationValue<Topic> topicAnnotation) {
+        for (String topic : topicAnnotation.stringValues()) {
+            ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
+            if (previous != null && previous != executableMethod) {
+                throw new MessagingSystemException("Duplicate topic [" + topic + "] found for listener [" + executableMethod.getDeclaringType().getName() + ']');
+            }
+        }
+    }
+
+    private static void registerPatterns(List<PatternMethod> patterns, ExecutableMethod<Object, ?> executableMethod, AnnotationValue<Topic> topicAnnotation) {
+        for (String pattern : topicAnnotation.stringValues("patterns")) {
+            try {
+                patterns.add(new PatternMethod(Pattern.compile(pattern), executableMethod));
+            } catch (PatternSyntaxException e) {
+                throw new MessagingSystemException("Invalid @Topic pattern [" + pattern + "] for listener method [" + executableMethod.getDeclaringType().getName() + "#" + executableMethod.getName() + "]: " + e.getMessage(), e);
+            }
+        }
     }
 
     private record PatternMethod(Pattern pattern, ExecutableMethod<Object, ?> method) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -20,9 +20,13 @@ import io.micronaut.configuration.kafka.annotation.ErrorStrategy;
 import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
 import io.micronaut.configuration.kafka.annotation.KafkaListener;
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
+import io.micronaut.configuration.kafka.annotation.Topic;
 import io.micronaut.configuration.kafka.exceptions.OffsetCommitExceptionLogger;
 import io.micronaut.configuration.kafka.seek.KafkaSeekOperations;
-import io.micronaut.core.annotation.*;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Blocking;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
@@ -31,14 +35,19 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.messaging.Acknowledgement;
 import io.micronaut.messaging.annotation.SendTo;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Internal consumer info.
@@ -54,7 +63,7 @@ final class ConsumerInfo {
     final OffsetStrategy offsetStrategy;
     final ErrorStrategyValue errorStrategy;
     @Nullable final String dlq;
-    final @Nullable Duration retryDelay;
+    @Nullable final Duration retryDelay;
     final int retryCount;
     final boolean shouldHandleAllExceptions;
     final List<Class<? extends Throwable>> exceptionTypes;
@@ -62,20 +71,43 @@ final class ConsumerInfo {
     @Nullable final String producerTransactionalId;
     final boolean isTransactional;
     final ExecutableMethod<Object, ?> method;
-    final String logMethod;
     final boolean autoStartup;
     final boolean isBatch;
-    final boolean isBlocking;
     final Duration pollTimeout;
-    @Nullable final Argument<?> consumerArg;
-    @Nullable final Argument<?> seekArg;
-    @Nullable final Argument<?> ackArg;
     final boolean trackPartitions;
-    final List<String> sendToTopics;
     final boolean shouldSendOffsetsToTransaction;
-    final boolean returnsOneKafkaMessage;
-    final boolean returnsManyKafkaMessages;
     final boolean cooperativeStickyAssignmentStrategy;
+    private final List<ExecutableMethod<Object, ?>> listenerMethods;
+    private final Map<String, ExecutableMethod<Object, ?>> topicMethods = new HashMap<>();
+    private final List<PatternMethod> patternMethods;
+    private final Map<String, ExecutableMethod<Object, ?>> resolvedMethods = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, Optional<Argument<?>>> consumerArgCache = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, Optional<Argument<?>>> seekArgCache = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, Optional<Argument<?>>> ackArgCache = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, List<String>> sendToTopicsCache = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, Boolean> returnsOneKafkaMessageCache = new ConcurrentHashMap<>();
+    private final Map<ExecutableMethod<Object, ?>, Boolean> returnsManyKafkaMessagesCache = new ConcurrentHashMap<>();
+
+    ConsumerInfo(
+        String clientId,
+        String groupId,
+        OffsetStrategy offsetStrategy,
+        AnnotationValue<KafkaListener> kafkaListener,
+        Properties properties,
+        ExecutableMethod<?, ?> method
+    ) {
+        this(clientId, groupId, offsetStrategy, kafkaListener, properties, List.of(method));
+    }
+
+    ConsumerInfo(
+        String clientId,
+        String groupId,
+        OffsetStrategy offsetStrategy,
+        AnnotationValue<KafkaListener> kafkaListener,
+        List<ExecutableMethod<?, ?>> methods
+    ) {
+        this(clientId, groupId, offsetStrategy, kafkaListener, new Properties(), methods);
+    }
 
     @SuppressWarnings("unchecked")
     ConsumerInfo(
@@ -84,7 +116,7 @@ final class ConsumerInfo {
         OffsetStrategy offsetStrategy,
         AnnotationValue<KafkaListener> kafkaListener,
         Properties properties,
-        ExecutableMethod<?, ?> method
+        List<ExecutableMethod<?, ?>> methods
     ) {
         this.clientId = clientId;
         this.groupId = groupId;
@@ -103,31 +135,151 @@ final class ConsumerInfo {
         this.producerClientId = kafkaListener.stringValue("producerClientId").orElse(null);
         this.producerTransactionalId = kafkaListener.stringValue("producerTransactionalId").filter(StringUtils::isNotEmpty).orElse(null);
         this.isTransactional = producerTransactionalId != null;
-        this.method = (ExecutableMethod<Object, ?>) method;
-        this.logMethod = method.getDeclaringType().getSimpleName() + "#" + method.getName();
+        this.cooperativeStickyAssignmentStrategy = OffsetCommitExceptionLogger.isCooperativeStickyAssignor(properties.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
+        java.util.ArrayList<ExecutableMethod<Object, ?>> listenerMethods = new java.util.ArrayList<>(methods.size());
+        for (ExecutableMethod<?, ?> executableMethod : methods) {
+            listenerMethods.add((ExecutableMethod<Object, ?>) executableMethod);
+        }
+        this.listenerMethods = List.copyOf(listenerMethods);
+        this.method = this.listenerMethods.get(0);
+        this.patternMethods = resolveTopicMethods(this.listenerMethods);
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
         this.isBatch = method.isTrue(KafkaListener.class, "batch");
-        this.isBlocking = method.hasAnnotation(Blocking.class);
         this.pollTimeout = method.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
-        this.consumerArg = Arrays.stream(method.getArguments()).filter(arg -> Consumer.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.seekArg = Arrays.stream(method.getArguments()).filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.ackArg = Arrays.stream(method.getArguments()).filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())).findFirst().orElse(null);
-        this.trackPartitions = ackArg != null || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
-        this.sendToTopics = Optional.ofNullable(method.stringValues(SendTo.class)).filter(ArrayUtils::isNotEmpty).stream().flatMap(Arrays::stream).toList();
+        this.trackPartitions = anyMethodHasAckArg() || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
-        this.returnsOneKafkaMessage = method.getReturnType().getType().isAssignableFrom(KafkaMessage.class) || method.getReturnType().isAsyncOrReactive() && method.getReturnType().getFirstTypeVariable()
-            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
-        this.returnsManyKafkaMessages = Iterable.class.isAssignableFrom(method.getReturnType().getType()) && method.getReturnType().getFirstTypeVariable()
-            .map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
-        this.cooperativeStickyAssignmentStrategy = OffsetCommitExceptionLogger.isCooperativeStickyAssignor(properties.get(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG));
 
         if (shouldSendOffsetsToTransaction) {
-            if (!isTransactional || !method.hasAnnotation(SendTo.class)) {
+            if (!isTransactional || !listenerMethods.stream().allMatch(executableMethod -> executableMethod.hasAnnotation(SendTo.class))) {
                 throw new MessagingSystemException("Offset strategy 'SEND_TO_TRANSACTION' can only be used when transaction is enabled and @SendTo is used");
             }
             if (shouldRedeliver) {
                 throw new MessagingSystemException("Redelivery not supported for transactions in combination with @SendTo");
             }
         }
+    }
+
+    ExecutableMethod<Object, ?> method(String topic) {
+        if (topicMethods.isEmpty() && patternMethods.isEmpty()) {
+            return method;
+        }
+        return resolvedMethods.computeIfAbsent(topic, this::resolveMethod);
+    }
+
+    String logMethod(String topic) {
+        ExecutableMethod<Object, ?> executableMethod = method(topic);
+        return executableMethod.getDeclaringType().getSimpleName() + "#" + executableMethod.getName();
+    }
+
+    boolean isBlocking(String topic) {
+        return method(topic).hasAnnotation(Blocking.class);
+    }
+
+    List<String> sendToTopics(String topic) {
+        return sendToTopicsCache.computeIfAbsent(method(topic), executableMethod ->
+            Optional.ofNullable(executableMethod.stringValues(SendTo.class))
+                .filter(ArrayUtils::isNotEmpty)
+                .stream()
+                .flatMap(Arrays::stream)
+                .toList()
+        );
+    }
+
+    boolean returnsOneKafkaMessage(String topic) {
+        return returnsOneKafkaMessageCache.computeIfAbsent(method(topic), executableMethod -> {
+            var returnType = executableMethod.getReturnType();
+            return returnType.getType().isAssignableFrom(KafkaMessage.class) ||
+                (returnType.isAsyncOrReactive() && returnType.getFirstTypeVariable()
+                    .map(t -> t.getType().isAssignableFrom(KafkaMessage.class))
+                    .orElse(false));
+        });
+    }
+
+    boolean returnsManyKafkaMessages(String topic) {
+        return returnsManyKafkaMessagesCache.computeIfAbsent(method(topic), executableMethod -> {
+            var returnType = executableMethod.getReturnType();
+            return Iterable.class.isAssignableFrom(returnType.getType()) &&
+                returnType.getFirstTypeVariable().map(t -> t.getType().isAssignableFrom(KafkaMessage.class)).orElse(false);
+        });
+    }
+
+    @Nullable
+    Argument<?> consumerArg(String topic) {
+        return consumerArgCache.computeIfAbsent(method(topic), executableMethod ->
+            Arrays.stream(executableMethod.getArguments())
+                .filter(arg -> Consumer.class.isAssignableFrom(arg.getType()))
+                .findFirst()
+        ).orElse(null);
+    }
+
+    @Nullable
+    Argument<?> seekArg(String topic) {
+        return seekArgCache.computeIfAbsent(method(topic), executableMethod ->
+            Arrays.stream(executableMethod.getArguments())
+                .filter(arg -> KafkaSeekOperations.class.isAssignableFrom(arg.getType()))
+                .findFirst()
+        ).orElse(null);
+    }
+
+    @Nullable
+    Argument<?> ackArg(String topic) {
+        return ackArgCache.computeIfAbsent(method(topic), executableMethod ->
+            Arrays.stream(executableMethod.getArguments())
+                .filter(arg -> Acknowledgement.class.isAssignableFrom(arg.getType()))
+                .findFirst()
+        ).orElse(null);
+    }
+
+    private boolean anyMethodHasAckArg() {
+        return listenerMethods.stream()
+            .anyMatch(executableMethod -> Arrays.stream(executableMethod.getArguments()).anyMatch(arg -> Acknowledgement.class.isAssignableFrom(arg.getType())));
+    }
+
+    private List<PatternMethod> resolveTopicMethods(List<ExecutableMethod<Object, ?>> methods) {
+        List<PatternMethod> patterns = new java.util.ArrayList<>();
+        for (ExecutableMethod<Object, ?> executableMethod : methods) {
+            for (AnnotationValue<Topic> topicAnnotation : executableMethod.getDeclaredAnnotationValuesByType(Topic.class)) {
+                for (String topic : topicAnnotation.stringValues()) {
+                    ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
+                    if (previous != null && previous != executableMethod) {
+                        throw new MessagingSystemException("Duplicate topic [" + topic + "] found for listener [" + executableMethod.getDeclaringType().getName() + ']');
+                    }
+                }
+                for (String pattern : topicAnnotation.stringValues("patterns")) {
+                    try {
+                        patterns.add(new PatternMethod(Pattern.compile(pattern), executableMethod));
+                    } catch (PatternSyntaxException e) {
+                        throw new MessagingSystemException("Invalid @Topic pattern [" + pattern + "] for listener method [" + executableMethod.getDeclaringType().getName() + "#" + executableMethod.getName() + "]: " + e.getMessage(), e);
+                    }
+                }
+            }
+        }
+        return List.copyOf(patterns);
+    }
+
+    private ExecutableMethod<Object, ?> resolveMethod(String topic) {
+        ExecutableMethod<Object, ?> executableMethod = topicMethods.get(topic);
+        if (executableMethod != null) {
+            return executableMethod;
+        }
+        ExecutableMethod<Object, ?> matchedMethod = null;
+        for (PatternMethod patternMethod : patternMethods) {
+            if (patternMethod.pattern.matcher(topic).matches()) {
+                if (matchedMethod != null && matchedMethod != patternMethod.method) {
+                    throw new MessagingSystemException("Multiple @Topic patterns matched consumed topic [" + topic + "] for listener [" + method.getDeclaringType().getName() + ']');
+                }
+                matchedMethod = patternMethod.method;
+            }
+        }
+        if (matchedMethod != null) {
+            return matchedMethod;
+        }
+        if (listenerMethods.size() == 1) {
+            return method;
+        }
+        throw new MessagingSystemException("No @Topic method found for consumed topic [" + topic + "] in listener [" + method.getDeclaringType().getName() + "]");
+    }
+
+    private record PatternMethod(Pattern pattern, ExecutableMethod<Object, ?> method) {
     }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -99,16 +99,6 @@ final class ConsumerInfo {
         this(clientId, groupId, offsetStrategy, kafkaListener, properties, List.of(method));
     }
 
-    ConsumerInfo(
-        String clientId,
-        String groupId,
-        OffsetStrategy offsetStrategy,
-        AnnotationValue<KafkaListener> kafkaListener,
-        List<ExecutableMethod<?, ?>> methods
-    ) {
-        this(clientId, groupId, offsetStrategy, kafkaListener, new Properties(), methods);
-    }
-
     @SuppressWarnings("unchecked")
     ConsumerInfo(
         String clientId,
@@ -157,6 +147,10 @@ final class ConsumerInfo {
                 throw new MessagingSystemException("Redelivery not supported for transactions in combination with @SendTo");
             }
         }
+    }
+
+    boolean routesByTopic() {
+        return listenerMethods.size() > 1;
     }
 
     ExecutableMethod<Object, ?> method(String topic) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -238,7 +238,11 @@ final class ConsumerInfo {
     private List<PatternMethod> resolveTopicMethods(List<ExecutableMethod<Object, ?>> methods) {
         List<PatternMethod> patterns = new java.util.ArrayList<>();
         for (ExecutableMethod<Object, ?> executableMethod : methods) {
-            for (AnnotationValue<Topic> topicAnnotation : executableMethod.getDeclaredAnnotationValuesByType(Topic.class)) {
+            List<AnnotationValue<Topic>> topicAnnotations = executableMethod.getDeclaredAnnotationValuesByType(Topic.class);
+            if (topicAnnotations == null) {
+                continue;
+            }
+            for (AnnotationValue<Topic> topicAnnotation : topicAnnotations) {
                 for (String topic : topicAnnotation.stringValues()) {
                     ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
                     if (previous != null && previous != executableMethod) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -238,11 +238,7 @@ final class ConsumerInfo {
     private List<PatternMethod> resolveTopicMethods(List<ExecutableMethod<Object, ?>> methods) {
         List<PatternMethod> patterns = new java.util.ArrayList<>();
         for (ExecutableMethod<Object, ?> executableMethod : methods) {
-            List<AnnotationValue<Topic>> topicAnnotations = executableMethod.getDeclaredAnnotationValuesByType(Topic.class);
-            if (topicAnnotations == null) {
-                continue;
-            }
-            for (AnnotationValue<Topic> topicAnnotation : topicAnnotations) {
+            for (AnnotationValue<Topic> topicAnnotation : topicAnnotations(executableMethod)) {
                 for (String topic : topicAnnotation.stringValues()) {
                     ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
                     if (previous != null && previous != executableMethod) {
@@ -259,6 +255,11 @@ final class ConsumerInfo {
             }
         }
         return List.copyOf(patterns);
+    }
+
+    private static List<AnnotationValue<Topic>> topicAnnotations(ExecutableMethod<Object, ?> executableMethod) {
+        List<AnnotationValue<Topic>> topicAnnotations = executableMethod.getDeclaredAnnotationValuesByType(Topic.class);
+        return topicAnnotations == null ? List.of() : topicAnnotations;
     }
 
     private ExecutableMethod<Object, ?> resolveMethod(String topic) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -331,9 +331,13 @@ abstract class ConsumerState {
 
         if (isBlocking) {
             List<RecordMetadata> listRecords = recordMetadataProducer.collectList().block();
-            LOG.trace("Method [{}] produced record metadata: {}", info.logMethod(topic), listRecords);
-        } else {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Method [{}] produced record metadata: {}", info.logMethod(topic), listRecords);
+            }
+        } else if (LOG.isTraceEnabled()) {
             recordMetadataProducer.subscribe(recordMetadata -> LOG.trace("Method [{}] produced record metadata: {}", info.logMethod(topic), recordMetadata));
+        } else {
+            recordMetadataProducer.subscribe();
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -454,14 +454,14 @@ abstract class ConsumerState {
     }
 
     private Publisher<RecordMetadata> handleSendToError(String topic, Throwable error, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
-        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method(topic) + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
+        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.methodForTopic(topic) + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
 
         if (!info.shouldRedeliver) {
             return Flux.empty();
         }
 
         return redeliver(consumerRecord)
-            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method(topic) + "]: " + error.getMessage(), ex, consumerRecords, consumerRecord));
+            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.methodForTopic(topic) + "]: " + error.getMessage(), ex, consumerRecords, consumerRecord));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -100,7 +100,6 @@ abstract class ConsumerState {
         this.subscriptions = Collections.unmodifiableSet(kafkaConsumer.subscription());
         this.startupLatch = info.autoStartup ? null : new CountDownLatch(1);
         this.boundArguments = new HashMap<>(2);
-        Optional.ofNullable(info.consumerArg).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
         this.closedState = ConsumerCloseState.NOT_STARTED;
         this.closedLatch = new CountDownLatch(1);
         this.topicPartitionRetries = this.info.errorStrategy.isRetry() ? new HashMap<>() : null;
@@ -258,11 +257,6 @@ abstract class ConsumerState {
         if (consumerRecords == null || consumerRecords.isEmpty()) {
             return; // No consumer records to process
         }
-        // Support Kotlin coroutines
-        if (info.method.isSuspend()) {
-            Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
-            boundArguments.put(lastArgument, null);
-        }
         processRecords(consumerRecords, currentOffsets);
         if (failed) {
             return;
@@ -328,22 +322,23 @@ abstract class ConsumerState {
     protected void handleResultFlux(
         ConsumerRecords<?, ?> consumerRecords,
         ConsumerRecord<?, ?> consumerRecord,
+        String topic,
         Flux<?> publisher,
         boolean isBlocking
     ) {
         final Flux<RecordMetadata> recordMetadataProducer = publisher
-            .flatMap(value -> sendToDestination(value, consumerRecord, consumerRecords));
+            .flatMap(value -> sendToDestination(topic, value, consumerRecord, consumerRecords));
 
         if (isBlocking) {
             List<RecordMetadata> listRecords = recordMetadataProducer.collectList().block();
-            LOG.trace("Method [{}] produced record metadata: {}", info.method, listRecords);
+            LOG.trace("Method [{}] produced record metadata: {}", info.logMethod(topic), listRecords);
         } else {
-            recordMetadataProducer.subscribe(recordMetadata -> LOG.trace("Method [{}] produced record metadata: {}", info.logMethod, recordMetadata));
+            recordMetadataProducer.subscribe(recordMetadata -> LOG.trace("Method [{}] produced record metadata: {}", info.logMethod(topic), recordMetadata));
         }
     }
 
-    private Publisher<RecordMetadata> sendToDestination(Object value, ConsumerRecord<?, ?> consumerRecord, ConsumerRecords<?, ?> consumerRecords) {
-        if (value == null || info.sendToTopics.isEmpty()) {
+    private Publisher<RecordMetadata> sendToDestination(String topic, Object value, ConsumerRecord<?, ?> consumerRecord, ConsumerRecords<?, ?> consumerRecords) {
+        if (value == null || info.sendToTopics(topic).isEmpty()) {
             return Flux.empty();
         }
         final Object key = consumerRecord.key();
@@ -362,16 +357,24 @@ abstract class ConsumerState {
                 value.getClass()
             );
         }
-        Flux<RecordMetadata> result = Flux.create(emitter -> sendToDestination(emitter, kafkaProducer, key, value, consumerRecord, consumerRecords));
-        return result.onErrorResume(error -> handleSendToError(error, consumerRecords, consumerRecord));
+        Flux<RecordMetadata> result = Flux.create(emitter -> sendToDestination(emitter, kafkaProducer, topic, key, value, consumerRecord, consumerRecords));
+        return result.onErrorResume(error -> handleSendToError(topic, error, consumerRecords, consumerRecord));
     }
 
-    private void sendToDestination(FluxSink<RecordMetadata> emitter, Producer<?, ?> kafkaProducer, Object key, Object value, ConsumerRecord<?, ?> consumerRecord, ConsumerRecords<?, ?> consumerRecords) {
+    private void sendToDestination(
+        FluxSink<RecordMetadata> emitter,
+        Producer<?, ?> kafkaProducer,
+        String topic,
+        Object key,
+        Object value,
+        ConsumerRecord<?, ?> consumerRecord,
+        ConsumerRecords<?, ?> consumerRecords
+    ) {
         try {
             if (info.shouldSendOffsetsToTransaction) {
                 beginTransaction(kafkaProducer);
             }
-            sendToDestination(kafkaProducer, new FluxCallback(emitter), key, value, consumerRecord);
+            sendToDestination(kafkaProducer, new FluxCallback(emitter), topic, key, value, consumerRecord);
             if (info.shouldSendOffsetsToTransaction) {
                 endTransaction(kafkaProducer, consumerRecords);
             }
@@ -385,9 +388,9 @@ abstract class ConsumerState {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void sendToDestination(Producer<?, ?> kafkaProducer, Callback callback, Object key, Object value, ConsumerRecord<?, ?> consumerRecord) {
-        for (String destinationTopic : info.sendToTopics) {
-            if (info.returnsManyKafkaMessages) {
+    private void sendToDestination(Producer<?, ?> kafkaProducer, Callback callback, String topic, Object key, Object value, ConsumerRecord<?, ?> consumerRecord) {
+        for (String destinationTopic : info.sendToTopics(topic)) {
+            if (info.returnsManyKafkaMessages(topic)) {
                 final Iterable<KafkaMessage> messages = (Iterable<KafkaMessage>) value;
                 for (KafkaMessage message : messages) {
                     final ProducerRecord producerRecord = createFromMessage(destinationTopic, message);
@@ -395,7 +398,7 @@ abstract class ConsumerState {
                 }
             } else {
                 final ProducerRecord producerRecord;
-                if (info.returnsOneKafkaMessage) {
+                if (info.returnsOneKafkaMessage(topic)) {
                     producerRecord = createFromMessage(destinationTopic, (KafkaMessage) value);
                 } else {
                     producerRecord = new ProducerRecord(destinationTopic, null, key, value, consumerRecord.headers());
@@ -446,15 +449,15 @@ abstract class ConsumerState {
         }
     }
 
-    private Publisher<RecordMetadata> handleSendToError(Throwable error, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
-        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
+    private Publisher<RecordMetadata> handleSendToError(String topic, Throwable error, ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord) {
+        handleException("Error occurred processing record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method(topic) + "]: " + error.getMessage(), error, consumerRecords, consumerRecord);
 
         if (!info.shouldRedeliver) {
             return Flux.empty();
         }
 
         return redeliver(consumerRecord)
-            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method + "]: " + error.getMessage(), ex, consumerRecords, consumerRecord));
+            .doOnError(ex -> handleException("Redelivery failed for record [" + consumerRecord + "] with Kafka reactive consumer [" + info.method(topic) + "]: " + error.getMessage(), ex, consumerRecords, consumerRecord));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import reactor.util.function.Tuple2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ final class ConsumerStateBatch extends ConsumerState {
         try {
             for (ConsumerRecords<?, ?> topicRecords : recordsByTopic(consumerRecords)) {
                 final String topic = topicRecords.partitions().stream().findFirst().map(TopicPartition::topic).orElseThrow();
-                final ExecutableMethod<Object, ?> method = info.method(topic);
+                final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
                 Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
                     final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(topicRecords);
                     boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
@@ -254,7 +255,7 @@ final class ConsumerStateBatch extends ConsumerState {
         }
         java.util.List<ConsumerRecords<?, ?>> splitRecords = new ArrayList<>(byTopic.size());
         for (Map<TopicPartition, java.util.List<ConsumerRecord<?, ?>>> topicRecords : byTopic.values()) {
-            splitRecords.add(new ConsumerRecords<>((Map) topicRecords));
+            splitRecords.add(new ConsumerRecords<>((Map) topicRecords, Collections.emptyMap()));
         }
         return splitRecords;
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -19,24 +19,29 @@ import io.micronaut.configuration.kafka.KafkaAcknowledgement;
 import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.ExecutableMethod;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.util.function.Tuple2;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,19 +70,14 @@ final class ConsumerStateBatch extends ConsumerState {
     @Override
     protected ConsumerRecords<?, ?> pollRecords(
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        // Deserialization errors can happen while polling
         try {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
-            // Try to honor the configured error strategy
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
-            // When offset management is enabled, seek past the record to continue consumption
+            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             if (info.offsetStrategy != OffsetStrategy.DISABLED) {
                 kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             }
-            // The error strategy and the exception handler can still decide what to do about this record
             resolveWithErrorStrategy(null, reconstructCurrentOffsetsIfAbsent(currentOffsets, ex), makeConsumerRecord(ex), ex);
-            // By now, it's been decided whether this record should be retried and the exception may have been handled
             return null;
         }
     }
@@ -85,14 +85,22 @@ final class ConsumerStateBatch extends ConsumerState {
     @Override
     protected void processRecords(ConsumerRecords<?, ?> consumerRecords, @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
-            // Bind Acknowledgement argument
-            if (info.ackArg != null) {
-                final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(consumerRecords);
-                boundArguments.put(info.ackArg, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+            for (ConsumerRecords<?, ?> topicRecords : splitByTopic(consumerRecords)) {
+                final String topic = topicRecords.partitions().stream().findFirst().map(TopicPartition::topic).orElseThrow();
+                final ExecutableMethod<Object, ?> method = info.method(topic);
+                Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
+                    final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(topicRecords);
+                    boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+                });
+                Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
+                if (method.isSuspend()) {
+                    Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
+                    boundArguments.put(lastArgument, null);
+                }
+                final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
+                final Object result = batchBinder.bind(method, kafkaConsumerProcessor.getBatchBinderRegistry(), topicRecords).invoke(consumerBean);
+                handleResult(normalizeResult(result), topicRecords, topic);
             }
-            final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
-            final Object result = batchBinder.bind(info.method, kafkaConsumerProcessor.getBatchBinderRegistry(), consumerRecords).invoke(consumerBean);
-            handleResult(normalizeResult(result), consumerRecords);
             failed = false;
         } catch (Exception e) {
             failed = resolveWithErrorStrategy(consumerRecords, currentOffsets, null, e);
@@ -117,13 +125,11 @@ final class ConsumerStateBatch extends ConsumerState {
         return result;
     }
 
-    private void handleResult(Object result, ConsumerRecords<?, ?> consumerRecords) {
+    private void handleResult(Object result, ConsumerRecords<?, ?> consumerRecords, String topic) {
         if (result != null) {
             final boolean isPublisher = Publishers.isConvertibleToPublisher(result);
-            final boolean isBlocking = info.isBlocking || !isPublisher;
-            // Flux of tuples (consumer record / result)
+            final boolean isBlocking = info.isBlocking(topic) || !isPublisher;
             final Flux<? extends Tuple2<?, ? extends ConsumerRecord<?, ?>>> resultRecordFlux;
-            // Flux of results
             final Flux<?> resultFlux;
             if (result instanceof Iterable<?> iterable) {
                 resultFlux = Flux.fromIterable(iterable);
@@ -132,10 +138,8 @@ final class ConsumerStateBatch extends ConsumerState {
             } else {
                 resultFlux = Flux.just(result);
             }
-            // Zip result flux with consumer records
             resultRecordFlux = resultFlux.zipWithIterable(consumerRecords)
-                .doOnNext(x -> handleResultFlux(consumerRecords, x.getT2(), Flux.just(x.getT1()), isBlocking));
-            // Block on the zipped flux or subscribe if non-blocking
+                .doOnNext(x -> handleResultFlux(consumerRecords, x.getT2(), topic, Flux.just(x.getT1()), isBlocking));
             if (isBlocking) {
                 resultRecordFlux.blockLast();
             } else {
@@ -145,37 +149,34 @@ final class ConsumerStateBatch extends ConsumerState {
     }
 
     @SuppressWarnings("java:S1874") // ErrorStrategyValue.NONE is deprecated
-    private boolean resolveWithErrorStrategy(@Nullable ConsumerRecords<?, ?> consumerRecords,
-        Map<TopicPartition, OffsetAndMetadata> currentOffsets, @Nullable ConsumerRecord<?, ?> consumerRecord, Throwable e) {
+    private boolean resolveWithErrorStrategy(
+        @Nullable ConsumerRecords<?, ?> consumerRecords,
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets,
+        @Nullable ConsumerRecord<?, ?> consumerRecord,
+        Throwable e
+    ) {
         if (info.errorStrategy.isRetry()) {
             final Set<TopicPartition> partitions = consumerRecords != null ? consumerRecords.partitions() : currentOffsets.keySet();
             if (shouldRetryException(e, consumerRecords, null) && info.retryCount > 0) {
                 Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = reconstructCurrentOffsetsIfAbsent(currentOffsets, consumerRecords);
-                // Check how many retries so far
                 final int currentRetryCount = getCurrentRetryCount(partitions, reconstructedOffsets);
                 if (info.retryCount >= currentRetryCount) {
-                    // We will retry this batch again next time
                     if (info.shouldHandleAllExceptions) {
                         handleException(e, consumerRecords, null);
                     }
-                    // Move back to the previous positions
                     partitions.forEach(tp -> kafkaConsumer.seek(tp, reconstructedOffsets.get(tp).offset()));
-                    // Decide how long should we wait to retry this batch again
                     delayRetry(currentRetryCount, partitions);
                     return true;
                 }
             }
-            // We will NOT retry this batch anymore
             partitions.forEach(topicPartitionRetries::remove);
         }
-        // Skip the failing batch of records
         publishToDlq(e, consumerRecords, consumerRecord);
         handleException(e, consumerRecords, consumerRecord);
         return info.errorStrategy == ErrorStrategyValue.NONE;
     }
 
-    private int getCurrentRetryCount(Set<TopicPartition> partitions,
-        @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+    private int getCurrentRetryCount(Set<TopicPartition> partitions, @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         return partitions.stream()
             .map(tp -> {
                 OffsetAndMetadata offsetAndMetadata = currentOffsets.get(tp);
@@ -191,8 +192,9 @@ final class ConsumerStateBatch extends ConsumerState {
     }
 
     private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
-        @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets, RecordDeserializationException ex) {
-        // Current offsets can be missing after the first poll if assignments changed while records were being fetched.
+        @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets,
+        RecordDeserializationException ex
+    ) {
         if (CollectionUtils.isEmpty(currentOffsets)) {
             return Map.of(ex.topicPartition(), new OffsetAndMetadata(ex.offset(), null));
         }
@@ -207,8 +209,8 @@ final class ConsumerStateBatch extends ConsumerState {
     @Nullable
     private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets,
-        @Nullable ConsumerRecords<?, ?> consumerRecords) {
-        // Current offsets can be missing for some partitions if assignments changed while records were being fetched.
+        @Nullable ConsumerRecords<?, ?> consumerRecords
+    ) {
         if (consumerRecords == null) {
             return currentOffsets;
         }
@@ -229,5 +231,22 @@ final class ConsumerStateBatch extends ConsumerState {
     private static ConsumerRecord<?, ?> makeConsumerRecord(RecordDeserializationException ex) {
         final TopicPartition tp = ex.topicPartition();
         return new ConsumerRecord<>(tp.topic(), tp.partition(), ex.offset(), null, null);
+    }
+
+    private static java.util.List<ConsumerRecords<?, ?>> splitByTopic(ConsumerRecords<?, ?> consumerRecords) {
+        if (consumerRecords.partitions().stream().map(TopicPartition::topic).distinct().count() <= 1) {
+            return java.util.List.of(consumerRecords);
+        }
+        Map<String, Map<TopicPartition, java.util.List<ConsumerRecord<?, ?>>>> byTopic = new LinkedHashMap<>();
+        for (ConsumerRecord<?, ?> consumerRecord : consumerRecords) {
+            byTopic.computeIfAbsent(consumerRecord.topic(), ignored -> new LinkedHashMap<>())
+                .computeIfAbsent(new TopicPartition(consumerRecord.topic(), consumerRecord.partition()), ignored -> new ArrayList<>())
+                .add(consumerRecord);
+        }
+        java.util.List<ConsumerRecords<?, ?>> splitRecords = new ArrayList<>(byTopic.size());
+        for (Map<TopicPartition, java.util.List<ConsumerRecord<?, ?>>> topicRecords : byTopic.values()) {
+            splitRecords.add(new ConsumerRecords<>((Map) topicRecords));
+        }
+        return splitRecords;
     }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -73,7 +73,9 @@ final class ConsumerStateBatch extends ConsumerState {
         try {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
+            }
             if (info.offsetStrategy != OffsetStrategy.DISABLED) {
                 kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             }
@@ -85,7 +87,7 @@ final class ConsumerStateBatch extends ConsumerState {
     @Override
     protected void processRecords(ConsumerRecords<?, ?> consumerRecords, @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
-            for (ConsumerRecords<?, ?> topicRecords : splitByTopic(consumerRecords)) {
+            for (ConsumerRecords<?, ?> topicRecords : recordsByTopic(consumerRecords)) {
                 final String topic = topicRecords.partitions().stream().findFirst().map(TopicPartition::topic).orElseThrow();
                 final ExecutableMethod<Object, ?> method = info.method(topic);
                 Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
@@ -231,6 +233,13 @@ final class ConsumerStateBatch extends ConsumerState {
     private static ConsumerRecord<?, ?> makeConsumerRecord(RecordDeserializationException ex) {
         final TopicPartition tp = ex.topicPartition();
         return new ConsumerRecord<>(tp.topic(), tp.partition(), ex.offset(), null, null);
+    }
+
+    private java.util.List<ConsumerRecords<?, ?>> recordsByTopic(ConsumerRecords<?, ?> consumerRecords) {
+        if (!info.routesByTopic()) {
+            return java.util.List.of(consumerRecords);
+        }
+        return splitByTopic(consumerRecords);
     }
 
     private static java.util.List<ConsumerRecords<?, ?>> splitByTopic(ConsumerRecords<?, ?> consumerRecords) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -160,7 +160,7 @@ final class ConsumerStateSingle extends ConsumerState {
     private void process(ConsumerRecord<?, ?> consumerRecord,
         ConsumerRecords<?, ?> consumerRecords) {
         final String topic = consumerRecord.topic();
-        final ExecutableMethod<Object, ?> method = info.method(topic);
+        final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
         if (method.isSuspend()) {
             Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
             boundArguments.put(lastArgument, null);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -26,6 +26,8 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.ExecutableBinder;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.ExecutableMethod;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
@@ -59,7 +61,7 @@ final class ConsumerStateSingle extends ConsumerState {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod, ex);
+            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             // By default, seek past the record to continue consumption
             kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
@@ -75,8 +77,9 @@ final class ConsumerStateSingle extends ConsumerState {
         final Iterator<? extends ConsumerRecord<?, ?>> iterator = consumerRecords.iterator();
         while (iterator.hasNext()) {
             final ConsumerRecord<?, ?> consumerRecord = iterator.next();
+            final String topic = consumerRecord.topic();
 
-            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod, consumerRecord);
+            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
 
             if (info.trackPartitions) {
                 final TopicPartition topicPartition = getTopicPartition(consumerRecord);
@@ -84,9 +87,10 @@ final class ConsumerStateSingle extends ConsumerState {
                 currentOffsets.put(topicPartition, offsetAndMetadata);
             }
 
-            final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
-            Optional.ofNullable(info.seekArg).ifPresent(argument -> boundArguments.put(argument, seek));
-            Optional.ofNullable(info.ackArg).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
+            final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg(topic)).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
+            Optional.ofNullable(info.seekArg(topic)).ifPresent(argument -> boundArguments.put(argument, seek));
+            Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
+            Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
 
             try {
                 process(consumerRecord, consumerRecords);
@@ -115,12 +119,18 @@ final class ConsumerStateSingle extends ConsumerState {
 
     private void process(ConsumerRecord<?, ?> consumerRecord,
         ConsumerRecords<?, ?> consumerRecords) {
+        final String topic = consumerRecord.topic();
+        final ExecutableMethod<Object, ?> method = info.method(topic);
+        if (method.isSuspend()) {
+            Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
+            boundArguments.put(lastArgument, null);
+        }
         final ExecutableBinder<ConsumerRecord<?, ?>> executableBinder = new DefaultExecutableBinder<>(boundArguments);
-        final Object result = executableBinder.bind(info.method, kafkaConsumerProcessor.getBinderRegistry(), consumerRecord).invoke(consumerBean);
+        final Object result = executableBinder.bind(method, kafkaConsumerProcessor.getBinderRegistry(), consumerRecord).invoke(consumerBean);
         if (result != null) {
             final boolean isPublisher = Publishers.isConvertibleToPublisher(result);
             final Flux<?> publisher = isPublisher ? kafkaConsumerProcessor.convertPublisher(result) : Flux.just(result);
-            handleResultFlux(consumerRecords, consumerRecord, publisher, isPublisher || info.isBlocking);
+            handleResultFlux(consumerRecords, consumerRecord, topic, publisher, isPublisher || info.isBlocking(topic));
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -61,7 +61,9 @@ final class ConsumerStateSingle extends ConsumerState {
             return kafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
-            LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
+            }
             // By default, seek past the record to continue consumption
             kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
@@ -79,7 +81,9 @@ final class ConsumerStateSingle extends ConsumerState {
             final ConsumerRecord<?, ?> consumerRecord = iterator.next();
             final String topic = consumerRecord.topic();
 
-            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
+            }
 
             updateCurrentOffsets(consumerRecord, currentOffsets);
             final KafkaSeekOperations seek = bindRecordArguments(topic, currentOffsets);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -81,43 +81,76 @@ final class ConsumerStateSingle extends ConsumerState {
 
             LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
 
-            if (info.trackPartitions) {
-                final TopicPartition topicPartition = getTopicPartition(consumerRecord);
-                final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(consumerRecord.offset() + 1, null);
-                currentOffsets.put(topicPartition, offsetAndMetadata);
+            updateCurrentOffsets(consumerRecord, currentOffsets);
+            final KafkaSeekOperations seek = bindRecordArguments(topic, currentOffsets);
+
+            if (processRecord(consumerRecord, consumerRecords, iterator)) {
+                return;
             }
 
-            final Argument seekArgument = info.seekArg(topic);
-            final KafkaSeekOperations seek = seekArgument == null ? null : KafkaSeekOperations.newInstance();
-            if (seekArgument != null) {
-                boundArguments.put(seekArgument, seek);
-            }
-            Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
-            Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
-
-            try {
-                process(consumerRecord, consumerRecords);
-            } catch (Exception e) {
-                if (resolveWithErrorStrategy(consumerRecords, consumerRecord, e)) {
-                    resetTheFollowingPartitions(consumerRecord, iterator);
-                    failed = true;
-                    return;
-                }
-            }
-
-            if (info.offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
-                commitSync(consumerRecords, consumerRecord, currentOffsets);
-            } else if (info.offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-                kafkaConsumer.commitAsync(currentOffsets, this::resolveCommitCallback);
-            }
-
-            if (seek != null) {
-                // Performs seek operations that were deferred by the user
-                final KafkaSeeker seeker = KafkaSeeker.newInstance(kafkaConsumer);
-                seek.forEach(seeker::perform);
-            }
+            commitOffsets(consumerRecords, consumerRecord, currentOffsets);
+            performDeferredSeek(seek);
         }
         failed = false;
+    }
+
+    private void updateCurrentOffsets(ConsumerRecord<?, ?> consumerRecord,
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        if (!info.trackPartitions) {
+            return;
+        }
+        final TopicPartition topicPartition = getTopicPartition(consumerRecord);
+        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(consumerRecord.offset() + 1, null);
+        currentOffsets.put(topicPartition, offsetAndMetadata);
+    }
+
+    @Nullable
+    private KafkaSeekOperations bindRecordArguments(String topic,
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        final Argument<?> seekArgument = info.seekArg(topic);
+        final KafkaSeekOperations seek = seekArgument == null ? null : KafkaSeekOperations.newInstance();
+        if (seekArgument != null) {
+            boundArguments.put(seekArgument, seek);
+        }
+        Optional.ofNullable(info.ackArg(topic))
+            .ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
+        Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
+        return seek;
+    }
+
+    private boolean processRecord(ConsumerRecord<?, ?> consumerRecord,
+        ConsumerRecords<?, ?> consumerRecords,
+        Iterator<? extends ConsumerRecord<?, ?>> iterator) {
+        try {
+            process(consumerRecord, consumerRecords);
+            return false;
+        } catch (Exception e) {
+            if (!resolveWithErrorStrategy(consumerRecords, consumerRecord, e)) {
+                return false;
+            }
+            resetTheFollowingPartitions(consumerRecord, iterator);
+            failed = true;
+            return true;
+        }
+    }
+
+    private void commitOffsets(ConsumerRecords<?, ?> consumerRecords,
+        ConsumerRecord<?, ?> consumerRecord,
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        if (info.offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
+            commitSync(consumerRecords, consumerRecord, currentOffsets);
+        } else if (info.offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
+            kafkaConsumer.commitAsync(currentOffsets, this::resolveCommitCallback);
+        }
+    }
+
+    private void performDeferredSeek(@Nullable KafkaSeekOperations seek) {
+        if (seek == null) {
+            return;
+        }
+        // Performs seek operations that were deferred by the user
+        final KafkaSeeker seeker = KafkaSeeker.newInstance(kafkaConsumer);
+        seek.forEach(seeker::perform);
     }
 
     private void process(ConsumerRecord<?, ?> consumerRecord,

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -87,8 +87,11 @@ final class ConsumerStateSingle extends ConsumerState {
                 currentOffsets.put(topicPartition, offsetAndMetadata);
             }
 
-            final KafkaSeekOperations seek = Optional.ofNullable(info.seekArg(topic)).map(x -> KafkaSeekOperations.newInstance()).orElse(null);
-            Optional.ofNullable(info.seekArg(topic)).ifPresent(argument -> boundArguments.put(argument, seek));
+            final Argument seekArgument = info.seekArg(topic);
+            final KafkaSeekOperations seek = seekArgument == null ? null : KafkaSeekOperations.newInstance();
+            if (seekArgument != null) {
+                boundArguments.put(seekArgument, seek);
+            }
             Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
             Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,6 @@ import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
@@ -439,7 +438,7 @@ class KafkaConsumerProcessor
             final List<ExecutableMethod<?, ?>> methods = beanDefinition.getExecutableMethods().stream()
                 .filter(executableMethod -> !CollectionUtils.isEmpty(executableMethod.getDeclaredAnnotationValuesByType(Topic.class)))
                 .<ExecutableMethod<?, ?>>map(executableMethod -> executableMethod)
-                .collect(java.util.stream.Collectors.toList());
+                .toList();
             if (CollectionUtils.isNotEmpty(methods)) {
                 return methods;
             }
@@ -742,7 +741,7 @@ class KafkaConsumerProcessor
                 .filter(KafkaConsumerProcessor::isConsumerRecord)
                 .flatMap(b -> b.getTypeVariable("K")))
             .map(argument -> (Deserializer<Object>) serdeRegistry.pickDeserializer(argument));
-        return deserializer.orElseGet(() -> (Deserializer<Object>) (Deserializer) DEFAULT_KEY_DESERIALIZER);
+        return deserializer.orElseGet(KafkaConsumerProcessor::defaultKeyDeserializer);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -752,12 +751,22 @@ class KafkaConsumerProcessor
             .flatMap(b -> b.getTypeVariable("V"))
             .or(() -> body)
             .map(argument -> (Deserializer<Object>) serdeRegistry.pickDeserializer(argument));
-        return deserializer.orElseGet(() -> (Deserializer<Object>) (Deserializer) DEFAULT_VALUE_DESERIALIZER);
+        return deserializer.orElseGet(KafkaConsumerProcessor::defaultValueDeserializer);
     }
 
     private static boolean isConsumerRecord(@NonNull Argument<?> body) {
         return ConsumerRecord.class.isAssignableFrom(body.getType()) ||
             ConsumerRecords.class.isAssignableFrom(body.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Deserializer<Object> defaultKeyDeserializer() {
+        return (Deserializer<Object>) (Deserializer<?>) DEFAULT_KEY_DESERIALIZER;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Deserializer<Object> defaultValueDeserializer() {
+        return (Deserializer<Object>) (Deserializer<?>) DEFAULT_VALUE_DESERIALIZER;
     }
 
     private static Argument<?> getComponentType(final Argument<?> argument) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -453,16 +453,16 @@ class KafkaConsumerProcessor
         ConsumerCreationStrategy consumerCreationStrategy,
         List<ExecutableMethod<?, ?>> methods
     ) {
-        final List<AnnotationValue<Topic>> beanTopics = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
-        if (CollectionUtils.isNotEmpty(beanTopics)) {
-            return beanTopics;
-        }
         if (consumerCreationStrategy == ConsumerCreationStrategy.PER_CLASS && methods.size() > 1) {
             return methods.stream()
                 .flatMap(executableMethod -> executableMethod.getDeclaredAnnotationValuesByType(Topic.class).stream())
                 .toList();
         }
-        return method.getDeclaredAnnotationValuesByType(Topic.class);
+        final List<AnnotationValue<Topic>> methodTopics = method.getDeclaredAnnotationValuesByType(Topic.class);
+        if (CollectionUtils.isNotEmpty(methodTopics)) {
+            return methodTopics;
+        }
+        return beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
     }
 
     @SuppressWarnings("rawtypes")

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -20,6 +20,7 @@ import io.micronaut.configuration.kafka.ConsumerRegistry;
 import io.micronaut.configuration.kafka.ConsumerSeekAware;
 import io.micronaut.configuration.kafka.ProducerRegistry;
 import io.micronaut.configuration.kafka.TransactionalProducerRegistry;
+import io.micronaut.configuration.kafka.annotation.ConsumerCreationStrategy;
 import io.micronaut.configuration.kafka.annotation.KafkaKey;
 import io.micronaut.configuration.kafka.annotation.KafkaListener;
 import io.micronaut.configuration.kafka.annotation.OffsetReset;
@@ -73,6 +74,7 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -83,6 +85,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,6 +125,7 @@ class KafkaConsumerProcessor
     @SuppressWarnings("rawtypes")
     private final AbstractKafkaConsumerConfiguration defaultConsumerConfiguration;
     private final Map<String, ConsumerState> consumers = new ConcurrentHashMap<>();
+    private final Set<Class<?>> perClassConsumers = ConcurrentHashMap.newKeySet();
 
     private final ConsumerRecordBinderRegistry binderRegistry;
     private final SerdeRegistry serdeRegistry;
@@ -283,15 +287,23 @@ class KafkaConsumerProcessor
 
     @Override
     public <B> void process(BeanDefinition<B> beanDefinition, ExecutableMethod<B, ?> method) {
-        List<AnnotationValue<Topic>> topicAnnotations = method.getDeclaredAnnotationValuesByType(Topic.class);
         final AnnotationValue<KafkaListener> consumerAnnotation = method.getAnnotation(KafkaListener.class);
-        if (CollectionUtils.isEmpty(topicAnnotations)) {
-            topicAnnotations = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
+        if (consumerAnnotation == null) {
+            return;
         }
-        if (consumerAnnotation == null || CollectionUtils.isEmpty(topicAnnotations)) {
+
+        final ConsumerCreationStrategy consumerCreationStrategy = consumerAnnotation.enumValue("consumerCreationStrategy", ConsumerCreationStrategy.class)
+            .orElse(ConsumerCreationStrategy.PER_TOPIC);
+        final Class<?> beanType = beanDefinition.getBeanType();
+        if (consumerCreationStrategy == ConsumerCreationStrategy.PER_CLASS && !perClassConsumers.add(beanType)) {
+            return;
+        }
+
+        final List<ExecutableMethod<?, ?>> methods = resolveConsumerMethods(beanDefinition, method, consumerCreationStrategy);
+        final List<AnnotationValue<Topic>> topicAnnotations = resolveTopicAnnotations(beanDefinition, method, consumerCreationStrategy, methods);
+        if (CollectionUtils.isEmpty(topicAnnotations)) {
             return; // No topics to consume
         }
-        final Class<?> beanType = beanDefinition.getBeanType();
         String groupId = consumerAnnotation.stringValue("groupId")
                 .filter(StringUtils::isNotEmpty)
                 .orElseGet(() -> applicationConfiguration.getName().orElse(beanType.getName()));
@@ -310,9 +322,10 @@ class KafkaConsumerProcessor
         }
         final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
         final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
-        configureDeserializers(method, consumerConfiguration);
-        submitConsumerThreads(method, clientId, groupId, offsetStrategy, topicAnnotations,
-            consumerAnnotation, consumerConfiguration, properties, beanType, uniqueGroupIdDeleteOnShutdown);
+        final ExecutableMethod<?, ?> primaryMethod = methods.get(0);
+        configureDeserializers(methods, consumerConfiguration);
+        submitConsumerThreads(primaryMethod, clientId, groupId, offsetStrategy, topicAnnotations,
+            consumerAnnotation, consumerConfiguration, properties, beanType, methods, uniqueGroupIdDeleteOnShutdown);
     }
 
     @Override
@@ -416,6 +429,42 @@ class KafkaConsumerProcessor
         return batchBinderRegistry;
     }
 
+    private static List<ExecutableMethod<?, ?>> resolveConsumerMethods(
+        BeanDefinition<?> beanDefinition,
+        ExecutableMethod<?, ?> method,
+        ConsumerCreationStrategy consumerCreationStrategy
+    ) {
+        if (consumerCreationStrategy == ConsumerCreationStrategy.PER_CLASS &&
+            CollectionUtils.isEmpty(beanDefinition.getDeclaredAnnotationValuesByType(Topic.class))) {
+            final List<ExecutableMethod<?, ?>> methods = beanDefinition.getExecutableMethods().stream()
+                .filter(executableMethod -> !CollectionUtils.isEmpty(executableMethod.getDeclaredAnnotationValuesByType(Topic.class)))
+                .<ExecutableMethod<?, ?>>map(executableMethod -> executableMethod)
+                .collect(java.util.stream.Collectors.toList());
+            if (CollectionUtils.isNotEmpty(methods)) {
+                return methods;
+            }
+        }
+        return Collections.singletonList(method);
+    }
+
+    private static List<AnnotationValue<Topic>> resolveTopicAnnotations(
+        BeanDefinition<?> beanDefinition,
+        ExecutableMethod<?, ?> method,
+        ConsumerCreationStrategy consumerCreationStrategy,
+        List<ExecutableMethod<?, ?>> methods
+    ) {
+        final List<AnnotationValue<Topic>> beanTopics = beanDefinition.getDeclaredAnnotationValuesByType(Topic.class);
+        if (CollectionUtils.isNotEmpty(beanTopics)) {
+            return beanTopics;
+        }
+        if (consumerCreationStrategy == ConsumerCreationStrategy.PER_CLASS && methods.size() > 1) {
+            return methods.stream()
+                .flatMap(executableMethod -> executableMethod.getDeclaredAnnotationValuesByType(Topic.class).stream())
+                .toList();
+        }
+        return method.getDeclaredAnnotationValuesByType(Topic.class);
+    }
+
     @SuppressWarnings("rawtypes")
     private AbstractKafkaConsumerConfiguration getConsumerConfigurationDefaults(String groupId) {
         return findConfigurationBean(groupId)
@@ -500,6 +549,7 @@ class KafkaConsumerProcessor
                                        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration,
                                        final Properties properties,
                                        final Class<?> beanType,
+                                       final List<ExecutableMethod<?, ?>> methods,
                                        boolean uniqueGroupIdDeleteOnShutdown) {
         final int consumerThreads = consumerAnnotation.intValue("threads").orElse(1);
         for (int i = 0; i < consumerThreads; i++) {
@@ -520,9 +570,9 @@ class KafkaConsumerProcessor
                 //noinspection unchecked
                 ca.setKafkaConsumer(kafkaConsumer);
             }
-            topicAnnotations.forEach(a -> setupConsumerSubscription(method, a, consumerBean, kafkaConsumer));
+            setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
-            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, properties, method);
+            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, properties, methods);
             final ConsumerState consumerState = consumerInfo.isBatch ?
                 new ConsumerStateBatch(this, consumerInfo, kafkaConsumer, consumerBean) :
                 new ConsumerStateSingle(this, consumerInfo, kafkaConsumer, consumerBean);
@@ -536,40 +586,60 @@ class KafkaConsumerProcessor
         }
     }
 
-    private static void setupConsumerSubscription(ExecutableMethod<?, ?> method, AnnotationValue<Topic> topicAnnotation, Object consumerBean, Consumer<?, ?> kafkaConsumer) {
-        final String[] topicNames = topicAnnotation.stringValues();
-        final String[] patterns = topicAnnotation.stringValues("patterns");
-        final boolean hasTopics = ArrayUtils.isNotEmpty(topicNames);
-        final boolean hasPatterns = ArrayUtils.isNotEmpty(patterns);
+    private static void setupConsumerSubscription(
+        ExecutableMethod<?, ?> method,
+        List<AnnotationValue<Topic>> topicAnnotations,
+        Object consumerBean,
+        Consumer<?, ?> kafkaConsumer
+    ) {
+        final List<String> topicNames = topicAnnotations.stream()
+            .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues()))
+            .collect(java.util.stream.Collectors.collectingAndThen(
+                java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+                List::copyOf
+            ));
+        final List<String> patterns = topicAnnotations.stream()
+            .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues("patterns")))
+            .collect(java.util.stream.Collectors.collectingAndThen(
+                java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+                List::copyOf
+            ));
+        final boolean hasTopics = !topicNames.isEmpty();
+        final boolean hasPatterns = !patterns.isEmpty();
         final String logMethod = LOG.isInfoEnabled() ? logMethod(method) : null;
 
         if (!hasTopics && !hasPatterns) {
-            throw new MessagingSystemException("Either a topic or a topic must be specified for method: " + method);
+            throw new MessagingSystemException("Either topics or topic patterns must be specified for method: " + method);
         }
 
         final Optional<ConsumerRebalanceListener> listener = getConsumerRebalanceListener(consumerBean, kafkaConsumer);
 
-        if (hasTopics) {
-            final List<String> topics = Arrays.asList(topicNames);
-            listener.ifPresentOrElse(
-                l -> kafkaConsumer.subscribe(topics, l),
-                () -> kafkaConsumer.subscribe(topics));
-            LOG.info("Kafka listener [{}] subscribed to topics: {}", logMethod, topics);
-        }
-
         if (hasPatterns) {
             try {
-                for (final String pattern : patterns) {
-                    final Pattern compiledPattern = Pattern.compile(pattern);
-                    listener.ifPresentOrElse(
-                        l -> kafkaConsumer.subscribe(compiledPattern, l),
-                        () -> kafkaConsumer.subscribe(compiledPattern));
-                    LOG.info("Kafka listener [{}] subscribed to topics pattern: {}", logMethod, pattern);
-                }
+                final Pattern compiledPattern = compileTopicPattern(topicNames, patterns);
+                listener.ifPresentOrElse(
+                    l -> kafkaConsumer.subscribe(compiledPattern, l),
+                    () -> kafkaConsumer.subscribe(compiledPattern));
+                LOG.info("Kafka listener [{}] subscribed to topics: {} and topic patterns: {}", logMethod, topicNames, patterns);
             } catch (PatternSyntaxException e) {
                 throw new MessagingSystemException("Invalid topic pattern [" + e.getPattern() + "] for method [" + method + "]: " + e.getMessage(), e);
             }
+            return;
         }
+
+        listener.ifPresentOrElse(
+            l -> kafkaConsumer.subscribe(topicNames, l),
+            () -> kafkaConsumer.subscribe(topicNames));
+        LOG.info("Kafka listener [{}] subscribed to topics: {}", logMethod, topicNames);
+    }
+
+    private static Pattern compileTopicPattern(List<String> topicNames, List<String> patterns) {
+        final String joinedPattern = java.util.stream.Stream.concat(
+                topicNames.stream().map(Pattern::quote),
+                patterns.stream().map(pattern -> "(?:" + pattern + ')')
+            )
+            .collect(java.util.stream.Collectors.joining("|"));
+        return Pattern.compile(joinedPattern);
     }
 
     private static Optional<ConsumerRebalanceListener> getConsumerRebalanceListener(Object consumerBean, Consumer<?, ?> kafkaConsumer) {
@@ -611,6 +681,20 @@ class KafkaConsumerProcessor
         return argument.equals(lastArgumentValue);
     }
 
+    private void configureDeserializers(final List<ExecutableMethod<?, ?>> methods, final DefaultKafkaConsumerConfiguration<?, ?> config) {
+        if (methods.size() == 1) {
+            configureDeserializers(methods.get(0), config);
+            return;
+        }
+        if (!config.getConfig().containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG) && config.getKeyDeserializer().isEmpty()) {
+            config.setKeyDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, true), "key"));
+        }
+        if (!config.getConfig().containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG) && config.getValueDeserializer().isEmpty()) {
+            config.setValueDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, false), "value"));
+        }
+        debugDeserializationConfiguration(methods.get(0), config);
+    }
+
     private void configureDeserializers(final ExecutableMethod<?, ?> method, final DefaultKafkaConsumerConfiguration<?, ?> config) {
         final boolean batch = method.isTrue(KafkaListener.class, "batch");
         final Argument<?> bodyArgument = findBodyArgument(batch, method);
@@ -620,18 +704,24 @@ class KafkaConsumerProcessor
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    private TopicRouter<Deserializer<Object>> buildDeserializerRouter(List<ExecutableMethod<?, ?>> methods, boolean key) {
+        TopicRouter<Deserializer<Object>> router = new TopicRouter<>();
+        for (ExecutableMethod<?, ?> method : methods) {
+            final boolean batch = method.isTrue(KafkaListener.class, "batch");
+            final Argument<?> bodyArgument = findBodyArgument(batch, method);
+            final Deserializer<Object> deserializer = key ? resolveKeyDeserializer(bodyArgument, method) : resolveValueDeserializer(bodyArgument);
+            for (AnnotationValue<Topic> topicAnnotation : method.getDeclaredAnnotationValuesByType(Topic.class)) {
+                router.register(topicAnnotation.stringValues(), topicAnnotation.stringValues("patterns"), deserializer, logMethod(method));
+            }
+        }
+        return router;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void configureKeyDeserializer(Argument<?> bodyArgument, ExecutableMethod<?, ?> method, DefaultKafkaConsumerConfiguration config) {
         if (!config.getConfig().containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG) && config.getKeyDeserializer().isEmpty()) {
             // figure out the Key deserializer
-            Arrays.stream(method.getArguments())
-                .filter(arg -> arg.isAnnotationPresent(KafkaKey.class))
-                .findFirst()
-                .or(() -> Optional.ofNullable(bodyArgument)
-                    .filter(KafkaConsumerProcessor::isConsumerRecord)
-                    .flatMap(b -> b.getTypeVariable("K")))
-                .map(serdeRegistry::pickDeserializer)
-                .ifPresentOrElse(config::setKeyDeserializer,
-                    () -> config.setKeyDeserializer(DEFAULT_KEY_DESERIALIZER));
+            config.setKeyDeserializer(resolveKeyDeserializer(bodyArgument, method));
         }
     }
 
@@ -639,14 +729,30 @@ class KafkaConsumerProcessor
     private void configureValueDeserializer(Argument<?> bodyArgument, DefaultKafkaConsumerConfiguration config) {
         if (!config.getConfig().containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG) && config.getValueDeserializer().isEmpty()) {
             // figure out the Value deserializer
-            final Optional<Argument<?>> body = Optional.ofNullable(bodyArgument);
-            body.filter(KafkaConsumerProcessor::isConsumerRecord)
-                .flatMap(b -> b.getTypeVariable("V"))
-                .or(() -> body)
-                .map(serdeRegistry::pickDeserializer)
-                .ifPresentOrElse(config::setValueDeserializer,
-                    () -> config.setValueDeserializer(DEFAULT_VALUE_DESERIALIZER));
+            config.setValueDeserializer(resolveValueDeserializer(bodyArgument));
         }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Deserializer<Object> resolveKeyDeserializer(Argument<?> bodyArgument, ExecutableMethod<?, ?> method) {
+        Optional<Deserializer<Object>> deserializer = Arrays.stream(method.getArguments())
+            .filter(arg -> arg.isAnnotationPresent(KafkaKey.class))
+            .findFirst()
+            .or(() -> Optional.ofNullable(bodyArgument)
+                .filter(KafkaConsumerProcessor::isConsumerRecord)
+                .flatMap(b -> b.getTypeVariable("K")))
+            .map(argument -> (Deserializer<Object>) serdeRegistry.pickDeserializer(argument));
+        return deserializer.orElseGet(() -> (Deserializer<Object>) (Deserializer) DEFAULT_KEY_DESERIALIZER);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Deserializer<Object> resolveValueDeserializer(Argument<?> bodyArgument) {
+        final Optional<Argument<?>> body = Optional.ofNullable(bodyArgument);
+        Optional<Deserializer<Object>> deserializer = body.filter(KafkaConsumerProcessor::isConsumerRecord)
+            .flatMap(b -> b.getTypeVariable("V"))
+            .or(() -> body)
+            .map(argument -> (Deserializer<Object>) serdeRegistry.pickDeserializer(argument));
+        return deserializer.orElseGet(() -> (Deserializer<Object>) (Deserializer) DEFAULT_VALUE_DESERIALIZER);
     }
 
     private static boolean isConsumerRecord(@NonNull Argument<?> body) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicAwareDeserializer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicAwareDeserializer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.core.annotation.Internal;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Delegates deserialization based on the topic being consumed.
+ *
+ * @author Micronaut Framework Team
+ * @since 6.0.0
+ */
+@Internal
+final class TopicAwareDeserializer implements Deserializer<Object> {
+
+    private final TopicRouter<? extends Deserializer<?>> router;
+    private final String kind;
+
+    TopicAwareDeserializer(TopicRouter<? extends Deserializer<?>> router, String kind) {
+        this.router = router;
+        this.kind = kind;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        for (Deserializer<?> deserializer : uniqueDelegates()) {
+            deserializer.configure(configs, isKey);
+        }
+    }
+
+    @Override
+    public Object deserialize(String topic, byte[] data) {
+        return router.resolve(topic, kind + " deserializer").deserialize(topic, data);
+    }
+
+    @Override
+    public Object deserialize(String topic, Headers headers, byte[] data) {
+        return router.resolve(topic, kind + " deserializer").deserialize(topic, headers, data);
+    }
+
+    @Override
+    public void close() {
+        for (Deserializer<?> deserializer : uniqueDelegates()) {
+            deserializer.close();
+        }
+    }
+
+    private Set<Deserializer<?>> uniqueDelegates() {
+        Set<Deserializer<?>> delegates = Collections.newSetFromMap(new IdentityHashMap<>());
+        delegates.addAll(router.values());
+        return delegates;
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicRouter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicRouter.java
@@ -59,36 +59,13 @@ final class TopicRouter<T> {
     T resolve(String topic, String purpose) {
         T direct = directRoutes.get(topic);
         if (direct != null) {
-            List<String> patternMatches = new ArrayList<>(2);
-            for (Route<T> route : routes) {
-                if (!route.matchesPattern(topic)) {
-                    continue;
-                }
-                if (route.value() != direct) {
-                    patternMatches.add(route.source());
-                }
-            }
-            if (!patternMatches.isEmpty()) {
-                throw new MessagingSystemException("Topic [" + topic + "] has a direct " + purpose + " route and also matches pattern " + purpose + " routes: " + String.join(", ", patternMatches));
+            List<String> conflictingPatterns = findConflictingPatterns(topic, direct);
+            if (!conflictingPatterns.isEmpty()) {
+                throw new MessagingSystemException("Topic [" + topic + "] has a direct " + purpose + " route and also matches pattern " + purpose + " routes: " + String.join(", ", conflictingPatterns));
             }
             return direct;
         }
-        T resolved = null;
-        List<String> matches = new ArrayList<>(2);
-        for (Route<T> route : routes) {
-            if (!route.matchesPattern(topic)) {
-                continue;
-            }
-            matches.add(route.source());
-            if (resolved != null && resolved != route.value()) {
-                throw new MessagingSystemException("Topic [" + topic + "] matches multiple " + purpose + " routes: " + String.join(", ", matches));
-            }
-            resolved = route.value();
-        }
-        if (resolved == null) {
-            throw new MessagingSystemException("No " + purpose + " route found for topic [" + topic + "]");
-        }
-        return resolved;
+        return resolvePatternRoute(topic, purpose);
     }
 
     Collection<String> topics() {
@@ -117,6 +94,35 @@ final class TopicRouter<T> {
 
     List<Route<T>> routes() {
         return Collections.unmodifiableList(routes);
+    }
+
+    private List<String> findConflictingPatterns(String topic, T direct) {
+        List<String> conflictingPatterns = new ArrayList<>(2);
+        for (Route<T> route : routes) {
+            if (route.matchesPattern(topic) && route.value() != direct) {
+                conflictingPatterns.add(route.source());
+            }
+        }
+        return conflictingPatterns;
+    }
+
+    private T resolvePatternRoute(String topic, String purpose) {
+        T resolved = null;
+        List<String> matches = new ArrayList<>(2);
+        for (Route<T> route : routes) {
+            if (!route.matchesPattern(topic)) {
+                continue;
+            }
+            matches.add(route.source());
+            if (resolved != null && resolved != route.value()) {
+                throw new MessagingSystemException("Topic [" + topic + "] matches multiple " + purpose + " routes: " + String.join(", ", matches));
+            }
+            resolved = route.value();
+        }
+        if (resolved == null) {
+            throw new MessagingSystemException("No " + purpose + " route found for topic [" + topic + "]");
+        }
+        return resolved;
     }
 
     record Route<T>(List<String> topics, List<String> patternStrings, List<Pattern> patterns, T value, String source) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicRouter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/TopicRouter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.messaging.exceptions.MessagingSystemException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Resolves values by topic name or topic pattern.
+ *
+ * @param <T> The routed value type
+ * @author Micronaut Framework Team
+ * @since 6.0.0
+ */
+@Internal
+final class TopicRouter<T> {
+
+    private final Map<String, T> directRoutes = new LinkedHashMap<>();
+    private final List<Route<T>> routes = new ArrayList<>();
+
+    void register(String[] topics, String[] patterns, T value, String source) {
+        try {
+            Route<T> route = new Route<>(topics, patterns, value, source);
+            for (String topic : route.topics()) {
+                T existing = directRoutes.putIfAbsent(topic, value);
+                if (existing != null && existing != value) {
+                    throw new MessagingSystemException("Topic [" + topic + "] is already mapped to a different route");
+                }
+            }
+            routes.add(route);
+        } catch (PatternSyntaxException e) {
+            throw new MessagingSystemException("Invalid topic pattern [" + e.getPattern() + "] for [" + source + "]: " + e.getMessage(), e);
+        }
+    }
+
+    T resolve(String topic, String purpose) {
+        T direct = directRoutes.get(topic);
+        if (direct != null) {
+            List<String> patternMatches = new ArrayList<>(2);
+            for (Route<T> route : routes) {
+                if (!route.matchesPattern(topic)) {
+                    continue;
+                }
+                if (route.value() != direct) {
+                    patternMatches.add(route.source());
+                }
+            }
+            if (!patternMatches.isEmpty()) {
+                throw new MessagingSystemException("Topic [" + topic + "] has a direct " + purpose + " route and also matches pattern " + purpose + " routes: " + String.join(", ", patternMatches));
+            }
+            return direct;
+        }
+        T resolved = null;
+        List<String> matches = new ArrayList<>(2);
+        for (Route<T> route : routes) {
+            if (!route.matchesPattern(topic)) {
+                continue;
+            }
+            matches.add(route.source());
+            if (resolved != null && resolved != route.value()) {
+                throw new MessagingSystemException("Topic [" + topic + "] matches multiple " + purpose + " routes: " + String.join(", ", matches));
+            }
+            resolved = route.value();
+        }
+        if (resolved == null) {
+            throw new MessagingSystemException("No " + purpose + " route found for topic [" + topic + "]");
+        }
+        return resolved;
+    }
+
+    Collection<String> topics() {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(directRoutes.keySet()));
+    }
+
+    Collection<String> patterns() {
+        LinkedHashSet<String> patterns = new LinkedHashSet<>();
+        for (Route<T> route : routes) {
+            patterns.addAll(route.patternStrings());
+        }
+        return Collections.unmodifiableSet(patterns);
+    }
+
+    boolean hasPatterns() {
+        return routes.stream().anyMatch(Route::hasPatterns);
+    }
+
+    Collection<T> values() {
+        LinkedHashSet<T> values = new LinkedHashSet<>();
+        for (Route<T> route : routes) {
+            values.add(route.value());
+        }
+        return Collections.unmodifiableSet(values);
+    }
+
+    List<Route<T>> routes() {
+        return Collections.unmodifiableList(routes);
+    }
+
+    record Route<T>(List<String> topics, List<String> patternStrings, List<Pattern> patterns, T value, String source) {
+        Route(String[] topics, String[] patterns, T value, String source) {
+            this(List.of(topics), List.of(patterns), compile(patterns), value, source);
+        }
+
+        boolean hasPatterns() {
+            return !patterns.isEmpty();
+        }
+
+        boolean matchesPattern(String topic) {
+            for (Pattern pattern : patterns) {
+                if (pattern.matcher(topic).matches()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static List<Pattern> compile(String[] patterns) {
+            List<Pattern> compiled = new ArrayList<>(patterns.length);
+            for (String pattern : patterns) {
+                compiled.add(Pattern.compile(pattern));
+            }
+            return compiled;
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/ConsumerCreationStrategySpec.groovy
@@ -1,0 +1,126 @@
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.AbstractKafkaContainerSpec
+import io.micronaut.configuration.kafka.ConsumerRegistry
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.annotation.MessageBody
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+
+class ConsumerCreationStrategySpec extends AbstractKafkaContainerSpec {
+
+    static final String FOO_TOPIC = 'ConsumerCreationStrategySpec-foo'
+    static final String BAR_TOPIC = 'ConsumerCreationStrategySpec-bar'
+    static final String BATCH_FOO_TOPIC = 'ConsumerCreationStrategySpec-batch-foo'
+    static final String BATCH_BAR_TOPIC = 'ConsumerCreationStrategySpec-batch-bar'
+
+    void 'test PER_CLASS creates one consumer and routes records by topic'() {
+        given:
+        ConsumerRegistry registry = context.getBean(ConsumerRegistry)
+        MultiTopicClient client = context.getBean(MultiTopicClient)
+        MultiTopicListener listener = context.getBean(MultiTopicListener)
+
+        when:
+        client.sendFoo('one')
+        client.sendFoo('two')
+        client.sendBar('three')
+
+        then:
+        conditions.eventually {
+            listener.fooValues == ['one', 'two']
+            listener.barValues == ['three']
+        }
+
+        and:
+        registry.consumerIds.findAll { it.startsWith('multi-topic-listener') }.size() == 1
+        registry.getConsumerSubscription('multi-topic-listener') == [FOO_TOPIC, BAR_TOPIC] as Set
+    }
+
+    void 'test PER_CLASS batch listener routes each topic to the matching method'() {
+        given:
+        ConsumerRegistry registry = context.getBean(ConsumerRegistry)
+        MultiTopicBatchClient client = context.getBean(MultiTopicBatchClient)
+        MultiTopicBatchListener listener = context.getBean(MultiTopicBatchListener)
+
+        when:
+        client.sendFoo(['one', 'two'])
+        client.sendBar(['three', 'four'])
+
+        then:
+        conditions.eventually {
+            listener.fooValues == ['one', 'two']
+            listener.barValues == ['three', 'four']
+        }
+
+        and:
+        registry.consumerIds.findAll { it.startsWith('multi-topic-batch-listener') }.size() == 1
+        registry.getConsumerSubscription('multi-topic-batch-listener') == [BATCH_FOO_TOPIC, BATCH_BAR_TOPIC] as Set
+    }
+
+    @Requires(property = 'spec.name', value = 'ConsumerCreationStrategySpec')
+    @KafkaClient
+    static interface MultiTopicClient {
+
+        @Topic(FOO_TOPIC)
+        void sendFoo(@MessageBody String body)
+
+        @Topic(BAR_TOPIC)
+        void sendBar(@MessageBody String body)
+    }
+
+    @Requires(property = 'spec.name', value = 'ConsumerCreationStrategySpec')
+    @KafkaListener(
+        clientId = 'multi-topic-listener',
+        consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS,
+        offsetReset = EARLIEST
+    )
+    static class MultiTopicListener {
+        List<String> fooValues = new CopyOnWriteArrayList<>()
+        List<String> barValues = new CopyOnWriteArrayList<>()
+
+        @Topic(FOO_TOPIC)
+        void receiveFoo(String body) {
+            fooValues.add(body)
+        }
+
+        @Topic(BAR_TOPIC)
+        void receiveBar(String body) {
+            barValues.add(body)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ConsumerCreationStrategySpec')
+    @KafkaClient(batch = true)
+    static interface MultiTopicBatchClient {
+
+        @Topic(BATCH_FOO_TOPIC)
+        void sendFoo(List<String> body)
+
+        @Topic(BATCH_BAR_TOPIC)
+        void sendBar(List<String> body)
+    }
+
+    @Requires(property = 'spec.name', value = 'ConsumerCreationStrategySpec')
+    @KafkaListener(
+        batch = true,
+        clientId = 'multi-topic-batch-listener',
+        consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS,
+        offsetReset = EARLIEST
+    )
+    static class MultiTopicBatchListener {
+        List<String> fooValues = new CopyOnWriteArrayList<>()
+        List<String> barValues = new CopyOnWriteArrayList<>()
+
+        @Topic(BATCH_FOO_TOPIC)
+        void receiveFoo(List<String> body) {
+            fooValues.addAll(body)
+        }
+
+        @Topic(BATCH_BAR_TOPIC)
+        void receiveBar(List<String> body) {
+            barValues.addAll(body)
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategyStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategyStateSpec.groovy
@@ -15,6 +15,8 @@ import org.apache.kafka.common.TopicPartition
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.util.Properties
+
 class ConsumerCreationStrategyStateSpec extends Specification {
 
     @Shared
@@ -71,6 +73,29 @@ class ConsumerCreationStrategyStateSpec extends Specification {
         listener.barValues == ['five', 'six']
     }
 
+    void 'batch state keeps single-method multi-topic listeners as one callback per poll'() {
+        given:
+        def listener = new TestBatchMultiTopicListener()
+        def processor = Stub(KafkaConsumerProcessor) {
+            getBatchBinderRegistry() >> batchBinderRegistry
+        }
+        def kafkaConsumer = Stub(Consumer) {
+            subscription() >> ([] as Set)
+        }
+        def state = new ConsumerStateBatch(processor, consumerInfo(TestBatchMultiTopicListener), kafkaConsumer, listener)
+        def records = consumerRecords(
+            foo: ['one'],
+            bar: ['two']
+        )
+
+        when:
+        state.processRecords(records, [:] as Map<TopicPartition, OffsetAndMetadata>)
+
+        then:
+        listener.invocations == 1
+        listener.values == ['one', 'two']
+    }
+
     private ConsumerInfo consumerInfo(Class<?> beanType) {
         def definitionType = Class.forName("${beanType.packageName}.\$${beanType.simpleName}\$Definition")
         def beanDefinition = ((BeanDefinitionReference<?>) definitionType.getDeclaredConstructor().newInstance()).load()
@@ -82,6 +107,7 @@ class ConsumerCreationStrategyStateSpec extends Specification {
             'test-group',
             OffsetStrategy.AUTO,
             methods[0].getAnnotation(KafkaListener),
+            new Properties(),
             methods
         )
     }
@@ -90,9 +116,11 @@ class ConsumerCreationStrategyStateSpec extends Specification {
         Map<TopicPartition, List<ConsumerRecord<String, String>>> records = [:]
         valuesByTopic.each { topic, values ->
             def topicPartition = new TopicPartition(topic, 0)
-            records[topicPartition] = values.indexed().collect { index, value ->
-                new ConsumerRecord<>(topic, 0, index as long, null, value)
+            List<ConsumerRecord<String, String>> topicRecords = []
+            for (int index = 0; index < values.size(); index++) {
+                topicRecords.add(new ConsumerRecord<>(topic, 0, index as long, null, values.get(index)))
             }
+            records[topicPartition] = topicRecords
         }
         new ConsumerRecords<>(records)
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategyStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategyStateSpec.groovy
@@ -1,0 +1,99 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry
+import io.micronaut.configuration.kafka.bind.batch.BatchConsumerRecordsBinderRegistry
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.inject.BeanDefinitionReference
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ConsumerCreationStrategyStateSpec extends Specification {
+
+    @Shared
+    ConsumerRecordBinderRegistry binderRegistry = new ConsumerRecordBinderRegistry(ConversionService.SHARED)
+
+    @Shared
+    BatchConsumerRecordsBinderRegistry batchBinderRegistry = new BatchConsumerRecordsBinderRegistry(binderRegistry, ConversionService.SHARED)
+
+    void 'single state routes each topic to the matching method'() {
+        given:
+        def listener = new TestPerClassMultiTopicListener()
+        def processor = Stub(KafkaConsumerProcessor) {
+            getBinderRegistry() >> binderRegistry
+        }
+        def kafkaConsumer = Stub(Consumer) {
+            subscription() >> ([] as Set)
+        }
+        def state = new ConsumerStateSingle(processor, consumerInfo(TestPerClassMultiTopicListener), kafkaConsumer, listener)
+        def records = consumerRecords(
+            foo: ['one'],
+            foo2: ['two'],
+            bar: ['three']
+        )
+
+        when:
+        state.processRecords(records, [:] as Map<TopicPartition, OffsetAndMetadata>)
+
+        then:
+        listener.fooValues == ['one', 'two']
+        listener.barValues == ['three']
+    }
+
+    void 'batch state routes each topic to the matching method'() {
+        given:
+        def listener = new TestPerClassMultiTopicBatchListener()
+        def processor = Stub(KafkaConsumerProcessor) {
+            getBatchBinderRegistry() >> batchBinderRegistry
+        }
+        def kafkaConsumer = Stub(Consumer) {
+            subscription() >> ([] as Set)
+        }
+        def state = new ConsumerStateBatch(processor, consumerInfo(TestPerClassMultiTopicBatchListener), kafkaConsumer, listener)
+        def records = consumerRecords(
+            foo: ['one', 'two'],
+            foo2: ['three', 'four'],
+            bar: ['five', 'six']
+        )
+
+        when:
+        state.processRecords(records, [:] as Map<TopicPartition, OffsetAndMetadata>)
+
+        then:
+        listener.fooValues == ['one', 'two', 'three', 'four']
+        listener.barValues == ['five', 'six']
+    }
+
+    private ConsumerInfo consumerInfo(Class<?> beanType) {
+        def definitionType = Class.forName("${beanType.packageName}.\$${beanType.simpleName}\$Definition")
+        def beanDefinition = ((BeanDefinitionReference<?>) definitionType.getDeclaredConstructor().newInstance()).load()
+        def methods = beanDefinition.executableMethods.findAll {
+            !it.getDeclaredAnnotationValuesByType(Topic).isEmpty()
+        }
+        new ConsumerInfo(
+            'test-client',
+            'test-group',
+            OffsetStrategy.AUTO,
+            methods[0].getAnnotation(KafkaListener),
+            methods
+        )
+    }
+
+    private static ConsumerRecords<String, String> consumerRecords(Map<String, List<String>> valuesByTopic) {
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> records = [:]
+        valuesByTopic.each { topic, values ->
+            def topicPartition = new TopicPartition(topic, 0)
+            records[topicPartition] = values.indexed().collect { index, value ->
+                new ConsumerRecord<>(topic, 0, index as long, null, value)
+            }
+        }
+        new ConsumerRecords<>(records)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
@@ -150,6 +150,7 @@ class ConsumerCreationStrategySupportSpec extends Specification {
             'test-group',
             OffsetStrategy.AUTO,
             methods[0].getAnnotation(KafkaListener),
+            new Properties(),
             methods
         )
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.configuration.kafka.processor
 
+import io.micronaut.configuration.kafka.annotation.ConsumerCreationStrategy
 import io.micronaut.configuration.kafka.annotation.KafkaListener
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy
 import io.micronaut.configuration.kafka.annotation.Topic
@@ -54,6 +55,18 @@ class ConsumerCreationStrategySupportSpec extends Specification {
                 !it.matcher('baz').matches()
         })
         0 * _
+    }
+
+    void 'method topics override class topics for per-topic listeners'() {
+        given:
+        def beanDefinition = loadBeanDefinition(MethodTopicOverridesClassTopicListener)
+        def method = beanDefinition.executableMethods.find { it.name == 'receive' }
+
+        when:
+        def topicAnnotations = invokeResolveTopicAnnotations(beanDefinition, method, [method])
+
+        then:
+        topicAnnotations*.stringValues().flatten() == ['method-topic']
     }
 
     void 'topic aware deserializer delegates by topic'() {
@@ -128,8 +141,7 @@ class ConsumerCreationStrategySupportSpec extends Specification {
     }
 
     private ConsumerInfo consumerInfo(Class<?> beanType) {
-        def definitionType = Class.forName("${beanType.packageName}.\$${beanType.simpleName}\$Definition")
-        def beanDefinition = ((BeanDefinitionReference<?>) definitionType.getDeclaredConstructor().newInstance()).load()
+        def beanDefinition = loadBeanDefinition(beanType)
         def methods = beanDefinition.executableMethods.findAll {
             !it.getDeclaredAnnotationValuesByType(Topic).isEmpty()
         }
@@ -138,6 +150,37 @@ class ConsumerCreationStrategySupportSpec extends Specification {
             'test-group',
             OffsetStrategy.AUTO,
             methods[0].getAnnotation(KafkaListener),
+            methods
+        )
+    }
+
+    private def loadBeanDefinition(Class<?> beanType) {
+        loadBeanDefinitionReference(beanType).load()
+    }
+
+    private BeanDefinitionReference<?> loadBeanDefinitionReference(Class<?> beanType) {
+        def definitionType = Class.forName("${beanType.packageName}.\$${beanType.simpleName}\$Definition")
+        return (BeanDefinitionReference<?>) definitionType.getDeclaredConstructor().newInstance()
+    }
+
+    private List<AnnotationValue<Topic>> invokeResolveTopicAnnotations(
+        def beanDefinition,
+        ExecutableMethod<?, ?> method,
+        List<ExecutableMethod<?, ?>> methods
+    ) {
+        Method reflectedMethod = KafkaConsumerProcessor.getDeclaredMethod(
+            'resolveTopicAnnotations',
+            io.micronaut.inject.BeanDefinition,
+            ExecutableMethod,
+            ConsumerCreationStrategy,
+            List
+        )
+        reflectedMethod.accessible = true
+        return (List<AnnotationValue<Topic>>) reflectedMethod.invoke(
+            null,
+            beanDefinition,
+            method,
+            ConsumerCreationStrategy.PER_TOPIC,
             methods
         )
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerCreationStrategySupportSpec.groovy
@@ -1,0 +1,144 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.messaging.exceptions.MessagingSystemException
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.common.serialization.Deserializer
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
+class ConsumerCreationStrategySupportSpec extends Specification {
+
+    void 'setupConsumerSubscription subscribes once with all topics'() {
+        given:
+        Consumer consumer = Mock()
+        ExecutableMethod<?, ?> executableMethod = mockExecutableMethod()
+        List<AnnotationValue<Topic>> topicAnnotations = [
+            AnnotationValue.builder(Topic).member('value', ['foo'] as String[]).build(),
+            AnnotationValue.builder(Topic).member('value', ['bar'] as String[]).build()
+        ]
+
+        when:
+        invokeSetupConsumerSubscription(executableMethod, topicAnnotations, new Object(), consumer)
+
+        then:
+        1 * consumer.subscribe(['foo', 'bar'])
+        0 * _
+    }
+
+    void 'setupConsumerSubscription combines topic names and patterns into one pattern subscription'() {
+        given:
+        Consumer consumer = Mock()
+        ExecutableMethod<?, ?> executableMethod = mockExecutableMethod()
+        List<AnnotationValue<Topic>> topicAnnotations = [
+            AnnotationValue.builder(Topic).member('value', ['foo'] as String[]).build(),
+            AnnotationValue.builder(Topic).member('patterns', ['bar-.*'] as String[]).build()
+        ]
+
+        when:
+        invokeSetupConsumerSubscription(executableMethod, topicAnnotations, new Object(), consumer)
+
+        then:
+        1 * consumer.subscribe({
+            it instanceof Pattern &&
+                it.matcher('foo').matches() &&
+                it.matcher('bar-1').matches() &&
+                !it.matcher('baz').matches()
+        })
+        0 * _
+    }
+
+    void 'topic aware deserializer delegates by topic'() {
+        given:
+        Deserializer fooDeserializer = Mock()
+        Deserializer barDeserializer = Mock()
+        TopicRouter<Deserializer<?>> router = new TopicRouter<>()
+        router.register(['foo'] as String[], [] as String[], fooDeserializer, 'FooListener#receive')
+        router.register(['bar'] as String[], [] as String[], barDeserializer, 'BarListener#receive')
+        TopicAwareDeserializer deserializer = new TopicAwareDeserializer(router, 'value')
+
+        when:
+        def fooResult = deserializer.deserialize('foo', 'one'.bytes)
+        def barResult = deserializer.deserialize('bar', 'two'.bytes)
+
+        then:
+        fooResult == 'foo'
+        barResult == 'bar'
+        1 * fooDeserializer.deserialize('foo', 'one'.bytes) >> 'foo'
+        1 * barDeserializer.deserialize('bar', 'two'.bytes) >> 'bar'
+        0 * _
+    }
+
+    void 'topic router rejects overlapping direct and pattern routes with different values'() {
+        given:
+        TopicRouter<Deserializer<?>> router = new TopicRouter<>()
+        router.register(['foo'] as String[], [] as String[], Mock(Deserializer), 'FooListener#receive')
+        router.register([] as String[], ['foo'] as String[], Mock(Deserializer), 'PatternListener#receive')
+
+        when:
+        router.resolve('foo', 'deserializer')
+
+        then:
+        def e = thrown(MessagingSystemException)
+        e.message.contains('direct deserializer route')
+        e.message.contains('PatternListener#receive')
+    }
+
+    void 'consumer info wraps invalid topic patterns with messaging system exception'() {
+        when:
+        consumerInfo(InvalidPatternPerClassListener)
+
+        then:
+        def e = thrown(MessagingSystemException)
+        e.message.contains('Invalid @Topic pattern [[foo]')
+        e.message.contains('InvalidPatternPerClassListener#receive')
+        e.cause instanceof PatternSyntaxException
+    }
+
+    private ExecutableMethod<?, ?> mockExecutableMethod() {
+        Stub(ExecutableMethod) {
+            getDeclaringType() >> ConsumerCreationStrategySupportSpec
+            getName() >> 'receive'
+        }
+    }
+
+    private void invokeSetupConsumerSubscription(
+        ExecutableMethod<?, ?> method,
+        List<AnnotationValue<Topic>> topicAnnotations,
+        Object consumerBean,
+        Consumer<?, ?> consumer
+    ) {
+        Method reflectedMethod = KafkaConsumerProcessor.getDeclaredMethod(
+            'setupConsumerSubscription',
+            ExecutableMethod,
+            List,
+            Object,
+            Consumer
+        )
+        reflectedMethod.accessible = true
+        reflectedMethod.invoke(null, method, topicAnnotations, consumerBean, consumer)
+    }
+
+    private ConsumerInfo consumerInfo(Class<?> beanType) {
+        def definitionType = Class.forName("${beanType.packageName}.\$${beanType.simpleName}\$Definition")
+        def beanDefinition = ((BeanDefinitionReference<?>) definitionType.getDeclaredConstructor().newInstance()).load()
+        def methods = beanDefinition.executableMethods.findAll {
+            !it.getDeclaredAnnotationValuesByType(Topic).isEmpty()
+        }
+        new ConsumerInfo(
+            'test-client',
+            'test-group',
+            OffsetStrategy.AUTO,
+            methods[0].getAnnotation(KafkaListener),
+            methods
+        )
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
@@ -339,6 +339,8 @@ class ConsumerStateSingleSpec extends Specification {
                         return Argument.ZERO_ARGUMENTS
                     case "stringValues":
                         return [] as String[]
+                    case "getDeclaredAnnotationValuesByType":
+                        return []
                     case "getReturnType":
                         return returnType
                     default:
@@ -427,6 +429,8 @@ class ConsumerStateSingleSpec extends Specification {
                         return Argument.ZERO_ARGUMENTS
                     case 'stringValues':
                         return [] as String[]
+                    case 'getDeclaredAnnotationValuesByType':
+                        return []
                     case 'getReturnType':
                         return returnType
                     case 'invoke':

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/InvalidPatternPerClassListener.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/InvalidPatternPerClassListener.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.ConsumerCreationStrategy
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = 'spec.name', value = 'ConsumerCreationStrategySupportSpec')
+@KafkaListener(consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS)
+class InvalidPatternPerClassListener {
+    @Topic(patterns = ['[foo'])
+    void receive(String value) {
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/MethodTopicOverridesClassTopicListener.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/MethodTopicOverridesClassTopicListener.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = 'spec.name', value = 'ConsumerCreationStrategySupportSpec')
+@KafkaListener
+@Topic('bean-topic')
+class MethodTopicOverridesClassTopicListener {
+    @Topic('method-topic')
+    void receive(String value) {
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestBatchMultiTopicListener.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestBatchMultiTopicListener.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+
+@KafkaListener(batch = true)
+class TestBatchMultiTopicListener {
+    int invocations
+    List<String> values = []
+
+    @Topic(['foo', 'bar'])
+    void receive(List<String> value) {
+        invocations++
+        values.addAll(value)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestPerClassMultiTopicBatchListener.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestPerClassMultiTopicBatchListener.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.ConsumerCreationStrategy
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(property = 'spec.name', value = 'ConsumerCreationStrategyStateSpec')
+@Singleton
+@KafkaListener(batch = true, consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS)
+class TestPerClassMultiTopicBatchListener {
+    List<String> fooValues = []
+    List<String> barValues = []
+
+    @Topic(['foo', 'foo2'])
+    void receiveFoo(List<String> value) {
+        fooValues.addAll(value)
+    }
+
+    @Topic('bar')
+    void receiveBar(List<String> value) {
+        barValues.addAll(value)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestPerClassMultiTopicListener.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/TestPerClassMultiTopicListener.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.ConsumerCreationStrategy
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(property = 'spec.name', value = 'ConsumerCreationStrategyStateSpec')
+@Singleton
+@KafkaListener(consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS)
+class TestPerClassMultiTopicListener {
+    List<String> fooValues = []
+    List<String> barValues = []
+
+    @Topic(['foo', 'foo2'])
+    void receiveFoo(String value) {
+        fooValues << value
+    }
+
+    @Topic('bar')
+    void receiveBar(String value) {
+        barValues << value
+    }
+}

--- a/src/main/docs/guide/kafkaListener/kafkaListenerMethods.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerMethods.adoc
@@ -22,6 +22,8 @@ You can also specify one or many regular expressions to listen for:
 
 snippet::io.micronaut.kafka.docs.consumer.topics.ProductListener[tags=patternTopics, indent=0]
 
+By default, Micronaut creates one Kafka consumer per `@Topic`-annotated listener method, even when multiple methods live in the same ann:configuration.kafka.annotation.KafkaListener[] class. To create a single consumer for the whole listener and route records to methods by topic, set `consumerCreationStrategy = ConsumerCreationStrategy.PER_CLASS` on ann:configuration.kafka.annotation.KafkaListener[].
+
 == Handling Multiple Payload Types on One Topic
 
 Kafka does not route records by `@MessageBody` type. If a topic intentionally carries multiple event types, prefer a single listener method that consumes a common supertype and branches on the concrete payload in application code.


### PR DESCRIPTION
## Summary
- add `consumerCreationStrategy` to `@KafkaListener` to support one consumer per listener class
- route per-class listener records, send-to behavior, and deserializers by consumed topic
- document the default one-consumer-per-`@Topic` behavior and cover the new routing with focused specs

## Verification
- `./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.processor.ConsumerCreationStrategySupportSpec --tests io.micronaut.configuration.kafka.processor.ConsumerCreationStrategyStateSpec`
- `./gradlew :micronaut-kafka:spotlessCheck`

Supersedes #1142.
Resolves #1138
