### PR TITLE
Fix Kafka Streams metric naming collisions

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
@@ -19,13 +19,19 @@ import io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporter;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.common.metrics.KafkaMetric;
 
+import java.util.Set;
+
 
 /**
  * Kafka streams specific metrics reporter which prefixes all metrics with kafka-streams.
  */
 public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
 
-    private static final String STREAMS_METRIC_GROUP_PREFIX = "stream-";
+    private static final Set<String> GROUP_PREFIXED_METRIC_GROUPS = Set.of(
+            "stream-processor-node-metrics",
+            "stream-task-metrics",
+            "stream-thread-metrics"
+    );
 
     @Override
     protected String getMetricPrefix() {
@@ -35,7 +41,7 @@ public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
     @Override
     protected String getMetricName(KafkaMetric metric) {
         String group = metric.metricName().group();
-        if (group != null && group.startsWith(STREAMS_METRIC_GROUP_PREFIX)) {
+        if (group != null && GROUP_PREFIXED_METRIC_GROUPS.contains(group)) {
             return group + "." + metric.metricName().name();
         }
         return super.getMetricName(metric);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
@@ -19,13 +19,18 @@ import io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporter;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.common.metrics.KafkaMetric;
 
+import java.util.Set;
+
 
 /**
  * Kafka streams specific metrics reporter which prefixes all metrics with kafka-streams.
  */
 public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
 
-    private static final String STREAMS_GROUP_PREFIX = "stream";
+    private static final Set<String> STREAMS_METRIC_GROUPS = Set.of(
+            "stream-thread-metrics",
+            "stream-task-metrics"
+    );
 
     @Override
     protected String getMetricPrefix() {
@@ -35,7 +40,7 @@ public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
     @Override
     protected String getMetricName(KafkaMetric metric) {
         String group = metric.metricName().group();
-        if (group != null && group.startsWith(STREAMS_GROUP_PREFIX)) {
+        if (group != null && STREAMS_METRIC_GROUPS.contains(group)) {
             return group + "." + metric.metricName().name();
         }
         return super.getMetricName(metric);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.kafka.streams.metrics;
 
 import io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporter;
 import jakarta.annotation.PreDestroy;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
 
 /**
@@ -24,9 +25,20 @@ import jakarta.annotation.PreDestroy;
  */
 public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
 
+    private static final String STREAMS_GROUP_PREFIX = "stream";
+
     @Override
     protected String getMetricPrefix() {
         return "kafka-streams";
+    }
+
+    @Override
+    protected String getMetricName(KafkaMetric metric) {
+        String group = metric.metricName().group();
+        if (group != null && group.startsWith(STREAMS_GROUP_PREFIX)) {
+            return group + "." + metric.metricName().name();
+        }
+        return super.getMetricName(metric);
     }
 
     /**

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporter.java
@@ -19,18 +19,13 @@ import io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporter;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.common.metrics.KafkaMetric;
 
-import java.util.Set;
-
 
 /**
  * Kafka streams specific metrics reporter which prefixes all metrics with kafka-streams.
  */
 public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
 
-    private static final Set<String> STREAMS_METRIC_GROUPS = Set.of(
-            "stream-thread-metrics",
-            "stream-task-metrics"
-    );
+    private static final String STREAMS_METRIC_GROUP_PREFIX = "stream-";
 
     @Override
     protected String getMetricPrefix() {
@@ -40,7 +35,7 @@ public class KafkaStreamsMetricsReporter extends AbstractKafkaMetricsReporter {
     @Override
     protected String getMetricName(KafkaMetric metric) {
         String group = metric.metricName().group();
-        if (group != null && STREAMS_METRIC_GROUPS.contains(group)) {
+        if (group != null && group.startsWith(STREAMS_METRIC_GROUP_PREFIX)) {
             return group + "." + metric.metricName().name();
         }
         return super.getMetricName(metric);

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsDisabledSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsDisabledSpec.groovy
@@ -45,6 +45,8 @@ class KafkaStreamsMetricsDisabledSpec extends AbstractTestContainersSpec {
             def response = Mono.from(httpClient.exchange("/metrics", Map)).block()
             Map result = response.body()
             !result.names.contains("kafka-streams.active-buffer-count")
+            !result.names.contains("kafka-streams.stream-thread-metrics.process-rate")
+            !result.names.contains("kafka-streams.stream-task-metrics.process-rate")
             !result.names.contains("kafka-streams.process-rate")
             !result.names.contains("kafka-streams.alive-stream-threads")
             !result.names.contains("kafka-streams.fetch-rate")

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
@@ -21,6 +21,7 @@ class KafkaStreamsMetricsReporterSpec extends Specification {
                 createMetric("process-rate", "stream-processor-node-metrics", ["processor-node-id": "KSTREAM-SOURCE-0000000000"]),
                 createMetric("process-rate", "stream-thread-metrics", ["thread-id": "StreamThread-1"]),
                 createMetric("process-rate", "stream-task-metrics", ["task-id": "0_0"]),
+                createMetric("alive-stream-threads", "stream-metrics", [:]),
                 createMetric("fetch-rate", "consumer-fetch-manager-metrics", ["client-id": "stream-consumer"])
         ])
 
@@ -28,8 +29,10 @@ class KafkaStreamsMetricsReporterSpec extends Specification {
         registry.find("kafka-streams.stream-processor-node-metrics.process-rate").meter() != null
         registry.find("kafka-streams.stream-thread-metrics.process-rate").meter() != null
         registry.find("kafka-streams.stream-task-metrics.process-rate").meter() != null
+        registry.find("kafka-streams.alive-stream-threads").meter() != null
         registry.find("kafka-streams.fetch-rate").meter() != null
         registry.find("kafka-streams.process-rate").meter() == null
+        registry.find("kafka-streams.stream-metrics.alive-stream-threads").meter() == null
     }
 
     private KafkaMetric createMetric(String name, String group, Map<String, String> tags) {

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
@@ -18,12 +18,14 @@ class KafkaStreamsMetricsReporterSpec extends Specification {
 
         when:
         reporter.init([
+                createMetric("process-rate", "stream-processor-node-metrics", ["processor-node-id": "KSTREAM-SOURCE-0000000000"]),
                 createMetric("process-rate", "stream-thread-metrics", ["thread-id": "StreamThread-1"]),
                 createMetric("process-rate", "stream-task-metrics", ["task-id": "0_0"]),
                 createMetric("fetch-rate", "consumer-fetch-manager-metrics", ["client-id": "stream-consumer"])
         ])
 
         then:
+        registry.find("kafka-streams.stream-processor-node-metrics.process-rate").meter() != null
         registry.find("kafka-streams.stream-thread-metrics.process-rate").meter() != null
         registry.find("kafka-streams.stream-task-metrics.process-rate").meter() != null
         registry.find("kafka-streams.fetch-rate").meter() != null

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsReporterSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.configuration.kafka.streams.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.KafkaMetric
+import org.apache.kafka.common.metrics.MetricConfig
+import org.apache.kafka.common.metrics.stats.Avg
+import org.apache.kafka.common.utils.Time
+import spock.lang.Specification
+
+class KafkaStreamsMetricsReporterSpec extends Specification {
+
+    void "stream metric groups are part of the exported metric name"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def reporter = new KafkaStreamsMetricsReporter()
+        reporter.bindTo(registry)
+
+        when:
+        reporter.init([
+                createMetric("process-rate", "stream-thread-metrics", ["thread-id": "StreamThread-1"]),
+                createMetric("process-rate", "stream-task-metrics", ["task-id": "0_0"]),
+                createMetric("fetch-rate", "consumer-fetch-manager-metrics", ["client-id": "stream-consumer"])
+        ])
+
+        then:
+        registry.find("kafka-streams.stream-thread-metrics.process-rate").meter() != null
+        registry.find("kafka-streams.stream-task-metrics.process-rate").meter() != null
+        registry.find("kafka-streams.fetch-rate").meter() != null
+        registry.find("kafka-streams.process-rate").meter() == null
+    }
+
+    private KafkaMetric createMetric(String name, String group, Map<String, String> tags) {
+        new KafkaMetric(
+                new Object(),
+                new MetricName(name, group, "description", tags),
+                new Avg(),
+                new MetricConfig(),
+                Mock(Time)
+        )
+    }
+}

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsSpec.groovy
@@ -48,7 +48,9 @@ class KafkaStreamsMetricsSpec extends AbstractTestContainersSpec {
             def response = Mono.from(httpClient.exchange("/metrics", Map)).block()
             Map result = response.body()
             result.names.contains("kafka-streams.active-buffer-count")
-            result.names.contains("kafka-streams.process-rate")
+            result.names.contains("kafka-streams.stream-thread-metrics.process-rate")
+            result.names.contains("kafka-streams.stream-task-metrics.process-rate")
+            !result.names.contains("kafka-streams.process-rate")
             result.names.contains("kafka-streams.alive-stream-threads")
             result.names.contains("kafka-streams.fetch-rate")
         }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/metrics/KafkaStreamsMetricsSpec.groovy
@@ -47,10 +47,10 @@ class KafkaStreamsMetricsSpec extends AbstractTestContainersSpec {
         conditions.eventually {
             def response = Mono.from(httpClient.exchange("/metrics", Map)).block()
             Map result = response.body()
-            result.names.contains("kafka-streams.active-buffer-count")
+            result.names.contains("kafka-streams.stream-task-metrics.active-buffer-count")
+            result.names.contains("kafka-streams.stream-processor-node-metrics.process-rate")
             result.names.contains("kafka-streams.stream-thread-metrics.process-rate")
             result.names.contains("kafka-streams.stream-task-metrics.process-rate")
-            !result.names.contains("kafka-streams.process-rate")
             result.names.contains("kafka-streams.alive-stream-threads")
             result.names.contains("kafka-streams.fetch-rate")
         }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -99,10 +99,21 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     private void registerMetric(MeterRegistry meterRegistry, KafkaMetric metric) {
         KafkaMetricMeterTypeBuilder.newBuilder()
                 .prefix(getMetricPrefix())
+                .name(getMetricName(metric))
                 .metric(metric)
                 .tagFunction(getTagFunction())
                 .registry(meterRegistry)
                 .build();
+    }
+
+    /**
+     * Resolve the exported metric name for the supplied Kafka metric.
+     *
+     * @param metric The Kafka metric
+     * @return The metric name to register with Micrometer
+     */
+    protected String getMetricName(KafkaMetric metric) {
+        return metric.metricName().name();
     }
 
     private Function<MetricName, List<Tag>> getTagFunction() {


### PR DESCRIPTION
## Summary
- include Kafka Streams metric groups in exported Micrometer names for stream task and thread metrics
- keep non-stream Kafka metrics on their existing names
- add a focused reporter spec and update existing streams metrics expectations

## Verification
- ./gradlew :micronaut-kafka-streams:test --tests 'io.micronaut.configuration.kafka.streams.metrics.KafkaStreamsMetricsReporterSpec'\n- git diff --cached --check\n- broader Testcontainers-based streams metrics specs require Docker and were not runnable in this environment
 
Resolves #1099