### PR TITLE
Fix multi-topic listener retry partition resets

### DIFF
--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractTestContainersSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractTestContainersSpec.groovy
@@ -55,9 +55,10 @@ abstract class AbstractTestContainersSpec extends AbstractEmbeddedServerSpec {
 
     static def purgeLocalStreamsState(final StreamsConfig streamsConfiguration) throws IOException {
         final String tmpDir = System.getProperty("java.io.tmpdir")
-        final String path = streamsConfiguration.getString(StreamsConfig.STATE_DIR_CONFIG)
-        if (path != null) {
-            def p = Paths.get(path)
+        final String stateDir = streamsConfiguration.getString(StreamsConfig.STATE_DIR_CONFIG)
+        final String applicationId = streamsConfiguration.getString(StreamsConfig.APPLICATION_ID_CONFIG)
+        if (stateDir != null && applicationId != null) {
+            def p = Paths.get(stateDir, applicationId)
             final File node = p.normalize().toFile()
             // Only purge state when it's under java.io.tmpdir.  This is a safety net to prevent accidentally
             // deleting important local directory trees.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -169,14 +169,15 @@ final class ConsumerStateSingle extends ConsumerState {
     }
 
     private void resetTheFollowingPartitions(ConsumerRecord<?, ?> errorConsumerRecord, Iterator<? extends ConsumerRecord<?, ?>> iterator) {
-        Set<Integer> processedPartition = new HashSet<>();
-        processedPartition.add(errorConsumerRecord.partition());
+        Set<TopicPartition> processedPartitions = new HashSet<>();
+        processedPartitions.add(getTopicPartition(errorConsumerRecord));
         while (iterator.hasNext()) {
             ConsumerRecord<?, ?> consumerRecord = iterator.next();
-            if (!processedPartition.add(consumerRecord.partition())) {
+            TopicPartition topicPartition = getTopicPartition(consumerRecord);
+            if (!processedPartitions.add(topicPartition)) {
                 continue;
             }
-            kafkaConsumer.seek(getTopicPartition(consumerRecord), consumerRecord.offset());
+            kafkaConsumer.seek(topicPartition, consumerRecord.offset());
         }
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
@@ -6,8 +6,11 @@ import io.micronaut.context.ApplicationContext
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.common.errors.TopicExistsException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+
+import java.util.concurrent.ExecutionException
 
 abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
 
@@ -40,7 +43,13 @@ abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
 
     void createTopic(String name, int numPartitions, int replicationFactor) {
         try (def admin = AdminClient.create([(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG): bootstrapServers])) {
-            admin.createTopics([new NewTopic(name, numPartitions, (short) replicationFactor)]).all().get()
+            try {
+                admin.createTopics([new NewTopic(name, numPartitions, (short) replicationFactor)]).all().get()
+            } catch (ExecutionException e) {
+                if (!(e.cause instanceof TopicExistsException)) {
+                    throw e
+                }
+            }
         }
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -12,6 +12,7 @@ import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Blocking
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
 import org.slf4j.Logger
@@ -34,6 +35,8 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaErrorStrategySpec.class);
     private static final String RandomFailedMessage = (new Random().nextInt(30) + 10).toString();
+    private static final String MULTI_TOPIC_RETRY_FIRST_TOPIC = "a-errors-retry-multi-topic"
+    private static final String MULTI_TOPIC_RETRY_SECOND_TOPIC = "b-errors-retry-multi-topic"
 
     Map<String, Object> getConfiguration() {
         super.configuration +
@@ -44,6 +47,8 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     @Override
     void afterKafkaStarted() {
         createTopic("errors-retry-multiple-partitions", 3, 1)
+        createTopic(MULTI_TOPIC_RETRY_FIRST_TOPIC, 1, 1)
+        createTopic(MULTI_TOPIC_RETRY_SECOND_TOPIC, 1, 1)
     }
 
     void "test when the error strategy is 'resume at next offset' the next message is consumed"() {
@@ -76,6 +81,28 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         }
         and:"the retry of the first message is delivered at least 50ms afterwards"
         myConsumer.times[1] - myConsumer.times[0] >= 50
+    }
+
+    void "test when the error strategy is 'retry on error' messages from another subscribed topic are not skipped"() {
+        when: "A listener subscribed to multiple topics throws on the first topic"
+        MultiTopicRetryErrorClient myClient = context.getBean(MultiTopicRetryErrorClient)
+        myClient.sendMessage(MULTI_TOPIC_RETRY_FIRST_TOPIC, "One")
+        myClient.sendMessage(MULTI_TOPIC_RETRY_SECOND_TOPIC, "Two")
+
+        MultiTopicRetryOnErrorErrorCausingConsumer myConsumer = context.getBean(MultiTopicRetryOnErrorErrorCausingConsumer)
+
+        then: "The failing message is retried and the other topic's message is still delivered"
+        conditions.eventually {
+            myConsumer.attempts == [
+                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
+                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
+                "${MULTI_TOPIC_RETRY_SECOND_TOPIC}:Two"
+            ]
+            myConsumer.successful == [
+                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
+                "${MULTI_TOPIC_RETRY_SECOND_TOPIC}:Two"
+            ]
+        }
     }
 
     void "test when the error strategy is 'retry conditionally on error' messages can be conditionally skipped when errors occur"() {
@@ -389,6 +416,29 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
             if (count.getAndIncrement() == 0) {
                 throw new RuntimeException("Won't handle first")
             }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaListener(
+        offsetReset = EARLIEST,
+        offsetStrategy = SYNC,
+        errorStrategy = @ErrorStrategy(value = RETRY_ON_ERROR, retryDelay = "50ms"),
+        properties = @Property(name = ConsumerConfig.MAX_POLL_RECORDS_CONFIG, value = "2")
+    )
+    static class MultiTopicRetryOnErrorErrorCausingConsumer {
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> attempts = []
+        List<String> successful = []
+
+        @Topic([MULTI_TOPIC_RETRY_FIRST_TOPIC, MULTI_TOPIC_RETRY_SECOND_TOPIC])
+        void handleMessage(ConsumerRecord<String, String> consumerRecord) {
+            String delivery = "${consumerRecord.topic()}:${consumerRecord.value()}"
+            attempts << delivery
+            if (consumerRecord.topic() == MULTI_TOPIC_RETRY_FIRST_TOPIC && count.getAndIncrement() == 0) {
+                throw new RuntimeException("Won't handle first topic on first attempt")
+            }
+            successful << delivery
         }
     }
 
@@ -822,6 +872,12 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     static interface RetryErrorClient {
         @Topic("errors-retry")
         void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')
+    @KafkaClient
+    static interface MultiTopicRetryErrorClient {
+        void sendMessage(@Topic String topic, String message)
     }
 
     @Requires(property = 'spec.name', value = 'KafkaErrorStrategySpec')

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -96,12 +96,14 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         myClient.sendMessage(multiTopicRetrySecondTopic, "Two")
 
         MultiTopicRetryOnErrorErrorCausingConsumer myConsumer = context.getBean(MultiTopicRetryOnErrorErrorCausingConsumer)
+        String retriedMessage = multiTopicRetryFirstTopic + ":One"
+        String otherTopicMessage = multiTopicRetrySecondTopic + ":Two"
 
         then: "The failing message is retried and the other topic's message is still delivered"
         conditions.eventually {
-            myConsumer.attempts.count("${multiTopicRetryFirstTopic}:One") >= 2
-            myConsumer.successful.contains("${multiTopicRetryFirstTopic}:One")
-            myConsumer.successful.contains("${multiTopicRetrySecondTopic}:Two")
+            myConsumer.attempts.count(retriedMessage) >= 2
+            myConsumer.successful.contains(retriedMessage)
+            myConsumer.successful.contains(otherTopicMessage)
         }
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -19,6 +19,7 @@ import org.apache.kafka.common.TopicPartition
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
+import spock.lang.Shared
 import spock.lang.Unroll
 
 import java.util.UUID
@@ -38,8 +39,8 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaErrorStrategySpec.class);
     private static final String RandomFailedMessage = (new Random().nextInt(30) + 10).toString();
-    final String multiTopicRetryFirstTopic = "a-errors-retry-multi-topic-${UUID.randomUUID()}"
-    final String multiTopicRetrySecondTopic = "b-errors-retry-multi-topic-${UUID.randomUUID()}"
+    @Shared final String multiTopicRetryFirstTopic = "a-errors-retry-multi-topic-${UUID.randomUUID()}"
+    @Shared final String multiTopicRetrySecondTopic = "b-errors-retry-multi-topic-${UUID.randomUUID()}"
 
     Map<String, Object> getConfiguration() {
         super.configuration +

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -38,9 +38,6 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaErrorStrategySpec.class);
     private static final String RandomFailedMessage = (new Random().nextInt(30) + 10).toString();
-    private static final String MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY = '${multi.topic.retry.first-topic}'
-    private static final String MULTI_TOPIC_RETRY_SECOND_TOPIC_PROPERTY = '${multi.topic.retry.second-topic}'
-
     final String multiTopicRetryFirstTopic = "a-errors-retry-multi-topic-${UUID.randomUUID()}"
     final String multiTopicRetrySecondTopic = "b-errors-retry-multi-topic-${UUID.randomUUID()}"
 
@@ -429,14 +426,14 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         properties = @Property(name = ConsumerConfig.MAX_POLL_RECORDS_CONFIG, value = "2")
     )
     static class MultiTopicRetryOnErrorErrorCausingConsumer {
-        @Value(MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY)
+        @Value('${multi.topic.retry.first-topic}')
         String firstTopic
 
         AtomicInteger count = new AtomicInteger(0)
         List<String> attempts = new CopyOnWriteArrayList<>()
         List<String> successful = new CopyOnWriteArrayList<>()
 
-        @Topic([MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY, MULTI_TOPIC_RETRY_SECOND_TOPIC_PROPERTY])
+        @Topic(['${multi.topic.retry.first-topic}', '${multi.topic.retry.second-topic}'])
         void handleMessage(ConsumerRecord<String, String> consumerRecord) {
             String delivery = "${consumerRecord.topic()}:${consumerRecord.value()}"
             attempts << delivery

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaErrorStrategySpec.groovy
@@ -11,6 +11,7 @@ import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
 import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Blocking
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -20,6 +21,8 @@ import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import spock.lang.Unroll
 
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.NONE
@@ -35,20 +38,25 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaErrorStrategySpec.class);
     private static final String RandomFailedMessage = (new Random().nextInt(30) + 10).toString();
-    private static final String MULTI_TOPIC_RETRY_FIRST_TOPIC = "a-errors-retry-multi-topic"
-    private static final String MULTI_TOPIC_RETRY_SECOND_TOPIC = "b-errors-retry-multi-topic"
+    private static final String MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY = '${multi.topic.retry.first-topic}'
+    private static final String MULTI_TOPIC_RETRY_SECOND_TOPIC_PROPERTY = '${multi.topic.retry.second-topic}'
+
+    final String multiTopicRetryFirstTopic = "a-errors-retry-multi-topic-${UUID.randomUUID()}"
+    final String multiTopicRetrySecondTopic = "b-errors-retry-multi-topic-${UUID.randomUUID()}"
 
     Map<String, Object> getConfiguration() {
         super.configuration +
                 ["kafka.consumers.errors-retry-multiple-partitions.allow.auto.create.topics" : false,
+                 "multi.topic.retry.first-topic": multiTopicRetryFirstTopic,
+                 "multi.topic.retry.second-topic": multiTopicRetrySecondTopic,
                  "my.retry.count": "3"]
     }
 
     @Override
     void afterKafkaStarted() {
         createTopic("errors-retry-multiple-partitions", 3, 1)
-        createTopic(MULTI_TOPIC_RETRY_FIRST_TOPIC, 1, 1)
-        createTopic(MULTI_TOPIC_RETRY_SECOND_TOPIC, 1, 1)
+        createTopic(multiTopicRetryFirstTopic, 1, 1)
+        createTopic(multiTopicRetrySecondTopic, 1, 1)
     }
 
     void "test when the error strategy is 'resume at next offset' the next message is consumed"() {
@@ -86,22 +94,16 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
     void "test when the error strategy is 'retry on error' messages from another subscribed topic are not skipped"() {
         when: "A listener subscribed to multiple topics throws on the first topic"
         MultiTopicRetryErrorClient myClient = context.getBean(MultiTopicRetryErrorClient)
-        myClient.sendMessage(MULTI_TOPIC_RETRY_FIRST_TOPIC, "One")
-        myClient.sendMessage(MULTI_TOPIC_RETRY_SECOND_TOPIC, "Two")
+        myClient.sendMessage(multiTopicRetryFirstTopic, "One")
+        myClient.sendMessage(multiTopicRetrySecondTopic, "Two")
 
         MultiTopicRetryOnErrorErrorCausingConsumer myConsumer = context.getBean(MultiTopicRetryOnErrorErrorCausingConsumer)
 
         then: "The failing message is retried and the other topic's message is still delivered"
         conditions.eventually {
-            myConsumer.attempts == [
-                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
-                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
-                "${MULTI_TOPIC_RETRY_SECOND_TOPIC}:Two"
-            ]
-            myConsumer.successful == [
-                "${MULTI_TOPIC_RETRY_FIRST_TOPIC}:One",
-                "${MULTI_TOPIC_RETRY_SECOND_TOPIC}:Two"
-            ]
+            myConsumer.attempts.count("${multiTopicRetryFirstTopic}:One") >= 2
+            myConsumer.successful.contains("${multiTopicRetryFirstTopic}:One")
+            myConsumer.successful.contains("${multiTopicRetrySecondTopic}:Two")
         }
     }
 
@@ -427,15 +429,18 @@ class KafkaErrorStrategySpec extends AbstractEmbeddedServerSpec {
         properties = @Property(name = ConsumerConfig.MAX_POLL_RECORDS_CONFIG, value = "2")
     )
     static class MultiTopicRetryOnErrorErrorCausingConsumer {
-        AtomicInteger count = new AtomicInteger(0)
-        List<String> attempts = []
-        List<String> successful = []
+        @Value(MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY)
+        String firstTopic
 
-        @Topic([MULTI_TOPIC_RETRY_FIRST_TOPIC, MULTI_TOPIC_RETRY_SECOND_TOPIC])
+        AtomicInteger count = new AtomicInteger(0)
+        List<String> attempts = new CopyOnWriteArrayList<>()
+        List<String> successful = new CopyOnWriteArrayList<>()
+
+        @Topic([MULTI_TOPIC_RETRY_FIRST_TOPIC_PROPERTY, MULTI_TOPIC_RETRY_SECOND_TOPIC_PROPERTY])
         void handleMessage(ConsumerRecord<String, String> consumerRecord) {
             String delivery = "${consumerRecord.topic()}:${consumerRecord.value()}"
             attempts << delivery
-            if (consumerRecord.topic() == MULTI_TOPIC_RETRY_FIRST_TOPIC && count.getAndIncrement() == 0) {
+            if (consumerRecord.topic() == firstTopic && count.getAndIncrement() == 0) {
                 throw new RuntimeException("Won't handle first topic on first attempt")
             }
             successful << delivery

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
@@ -1,0 +1,102 @@
+package io.micronaut.configuration.kafka.processor
+
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import spock.lang.Specification
+import sun.misc.Unsafe
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class ConsumerStateSingleSpec extends Specification {
+
+    void "reset the following partitions seeks each topic partition independently"() {
+        given:
+        ConsumerStateSingle state = allocateInstance(ConsumerStateSingle)
+        List<TopicPartition> seeks = []
+        List<Long> offsets = []
+        Consumer consumer = createConsumer(seeks, offsets)
+        setField(ConsumerState, state, "kafkaConsumer", consumer)
+        Method method = ConsumerStateSingle.getDeclaredMethod("resetTheFollowingPartitions", ConsumerRecord, Iterator)
+        method.accessible = true
+
+        when:
+        method.invoke(state, [
+            new ConsumerRecord<>("topic-a", 0, 5L, null, "error"),
+            [
+                new ConsumerRecord<>("topic-b", 0, 7L, null, "retry-other-topic"),
+                new ConsumerRecord<>("topic-b", 0, 8L, null, "same-partition-second-record"),
+                new ConsumerRecord<>("topic-a", 1, 9L, null, "other-partition"),
+                new ConsumerRecord<>("topic-c", 0, 1L, null, "third-topic")
+            ].iterator()
+        ] as Object[])
+
+        then:
+        seeks == [
+            new TopicPartition("topic-b", 0),
+            new TopicPartition("topic-a", 1),
+            new TopicPartition("topic-c", 0)
+        ]
+        offsets == [7L, 9L, 1L]
+    }
+
+    private static Consumer createConsumer(List<TopicPartition> seeks, List<Long> offsets) {
+        Proxy.newProxyInstance(
+            ConsumerStateSingleSpec.classLoader,
+            [Consumer] as Class<?>[],
+            { _, method, args ->
+                if (method.name == "seek") {
+                    seeks << (TopicPartition) args[0]
+                    offsets << (Long) args[1]
+                    return null
+                }
+                defaultValue(method.returnType)
+            }
+        ) as Consumer
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == boolean) {
+            return false
+        }
+        if (returnType == byte) {
+            return (byte) 0
+        }
+        if (returnType == short) {
+            return (short) 0
+        }
+        if (returnType == int) {
+            return 0
+        }
+        if (returnType == long) {
+            return 0L
+        }
+        if (returnType == float) {
+            return 0f
+        }
+        if (returnType == double) {
+            return 0d
+        }
+        if (returnType == char) {
+            return (char) 0
+        }
+        null
+    }
+
+    private static <T> T allocateInstance(Class<T> type) {
+        Field field = Unsafe.class.getDeclaredField("theUnsafe")
+        field.accessible = true
+        Unsafe unsafe = (Unsafe) field.get(null)
+        Method allocateInstance = Unsafe.class.getDeclaredMethod("allocateInstance", Class)
+        allocateInstance.accessible = true
+        type.cast(allocateInstance.invoke(unsafe, type))
+    }
+
+    private static void setField(Class<?> owner, Object instance, String fieldName, Object value) {
+        Field field = owner.getDeclaredField(fieldName)
+        field.accessible = true
+        field.set(instance, value)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
@@ -1,24 +1,30 @@
 package io.micronaut.configuration.kafka.processor
 
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.messaging.annotation.SendTo
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import spock.lang.Specification
-import sun.misc.Unsafe
 
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
+import java.time.Duration
+import java.util.Optional
 
 class ConsumerStateSingleSpec extends Specification {
 
     void "reset the following partitions seeks each topic partition independently"() {
         given:
-        ConsumerStateSingle state = allocateInstance(ConsumerStateSingle)
         List<TopicPartition> seeks = []
         List<Long> offsets = []
         Consumer consumer = createConsumer(seeks, offsets)
-        setField(ConsumerState, state, "kafkaConsumer", consumer)
+        ConsumerStateSingle state = new ConsumerStateSingle(null, buildConsumerInfo(), consumer, new Object())
         Method method = ConsumerStateSingle.getDeclaredMethod("resetTheFollowingPartitions", ConsumerRecord, Iterator)
         method.accessible = true
 
@@ -47,6 +53,9 @@ class ConsumerStateSingleSpec extends Specification {
             ConsumerStateSingleSpec.classLoader,
             [Consumer] as Class<?>[],
             { _, method, args ->
+                if (method.name == "subscription") {
+                    return Collections.emptySet()
+                }
                 if (method.name == "seek") {
                     seeks << (TopicPartition) args[0]
                     offsets << (Long) args[1]
@@ -55,6 +64,53 @@ class ConsumerStateSingleSpec extends Specification {
                 defaultValue(method.returnType)
             }
         ) as Consumer
+    }
+
+    private static ConsumerInfo buildConsumerInfo() {
+        ReturnType<?> returnType = Proxy.newProxyInstance(
+            ConsumerStateSingleSpec.classLoader,
+            [ReturnType] as Class<?>[],
+            { _, method, _ ->
+                switch (method.name) {
+                    case "getType":
+                        return Void.TYPE
+                    case "isAsyncOrReactive":
+                        return false
+                    case "getFirstTypeVariable":
+                        return Optional.empty()
+                    default:
+                        return defaultValue(method.returnType)
+                }
+            }
+        ) as ReturnType<?>
+        ExecutableMethod<?, ?> executableMethod = Proxy.newProxyInstance(
+            ConsumerStateSingleSpec.classLoader,
+            [ExecutableMethod] as Class<?>[],
+            { _, method, args ->
+                switch (method.name) {
+                    case "getDeclaringType":
+                        return ConsumerStateSingleSpec
+                    case "getName":
+                        return "handleMessage"
+                    case "isTrue":
+                        return false
+                    case "hasAnnotation":
+                        return false
+                    case "getValue":
+                        return Optional.empty()
+                    case "getArguments":
+                        return Argument.ZERO_ARGUMENTS
+                    case "stringValues":
+                        return [] as String[]
+                    case "getReturnType":
+                        return returnType
+                    default:
+                        return defaultValue(method.returnType)
+                }
+            }
+        ) as ExecutableMethod<?, ?>
+        AnnotationValue<KafkaListener> annotation = AnnotationValue.builder(KafkaListener).build()
+        new ConsumerInfo("test-client", "test-group", OffsetStrategy.SYNC, annotation, executableMethod)
     }
 
     private static Object defaultValue(Class<?> returnType) {
@@ -83,20 +139,5 @@ class ConsumerStateSingleSpec extends Specification {
             return (char) 0
         }
         null
-    }
-
-    private static <T> T allocateInstance(Class<T> type) {
-        Field field = Unsafe.class.getDeclaredField("theUnsafe")
-        field.accessible = true
-        Unsafe unsafe = (Unsafe) field.get(null)
-        Method allocateInstance = Unsafe.class.getDeclaredMethod("allocateInstance", Class)
-        allocateInstance.accessible = true
-        type.cast(allocateInstance.invoke(unsafe, type))
-    }
-
-    private static void setField(Class<?> owner, Object instance, String fieldName, Object value) {
-        Field field = owner.getDeclaredField(fieldName)
-        field.accessible = true
-        field.set(instance, value)
     }
 }


### PR DESCRIPTION
## Summary
- track retry resets by full topic partition instead of partition number alone
- add a narrow regression spec for the partition reset logic
- add a multi-topic retry regression in the Kafka error strategy spec

## Verification
- ./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.processor.ConsumerStateSingleSpec'
- ./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.errors.KafkaErrorStrategySpec' (blocked locally: no Docker/Testcontainers runtime)

Resolves #1028