### PR TITLE
Fix ConsumerState shutdown loop

### DIFF
--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractKafkaContainerSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractKafkaContainerSpec.groovy
@@ -13,7 +13,7 @@ abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
     @Shared @AutoCleanup KafkaContainer kafkaContainer
 
     void setupSpec() {
-        kafkaContainer = new KafkaContainer("apache/kafka-native")
+        kafkaContainer = new KafkaContainer("apache/kafka:4.2.0")
         kafkaContainer.start()
 
         startContext()

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -43,6 +43,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The internal state of the consumer.
@@ -54,6 +55,7 @@ import java.util.concurrent.CountDownLatch;
 abstract class ConsumerState {
 
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerProcessor.class); // NOSONAR
+    private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(30);
 
     protected final KafkaConsumerProcessor kafkaConsumerProcessor;
     protected final Object consumerBean;
@@ -68,6 +70,7 @@ abstract class ConsumerState {
     private Set<TopicPartition> pausedTopicPartitions;
     private Set<TopicPartition> pauseRequests;
     private CountDownLatch startupLatch;
+    private final CountDownLatch closedLatch;
     private boolean pollingStarted;
     private volatile ConsumerCloseState closedState;
 
@@ -86,6 +89,7 @@ abstract class ConsumerState {
         this.boundArguments = new HashMap<>(2);
         Optional.ofNullable(info.consumerArg).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
         this.closedState = ConsumerCloseState.NOT_STARTED;
+        this.closedLatch = new CountDownLatch(1);
         this.topicPartitionRetries = this.info.errorStrategy.isRetry() ? new HashMap<>() : null;
     }
 
@@ -143,21 +147,23 @@ abstract class ConsumerState {
     }
 
     void close() {
-        if (closedState == ConsumerCloseState.POLLING) {
+        boolean closed = closedState == ConsumerCloseState.CLOSED;
+        if (!closed && (pollingStarted || closedState == ConsumerCloseState.POLLING)) {
             final Instant start = Instant.now();
-            Instant silentTime = start;
-            do {
+            final Duration timeout = getCloseTimeout();
+            try {
+                closed = closedLatch.await(Math.max(0, timeout.toMillis()), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            if (!closed) {
                 if (LOG.isTraceEnabled()) {
-                    final Instant now = Instant.now();
-                    if (now.isAfter(silentTime)) {
-                        LOG.trace("Consumer {} is not closed yet (waiting {})", info.clientId, Duration.between(start, now));
-                        // Inhibit TRACE messages for a while to avoid polluting the logs
-                        silentTime = now.plusSeconds(5);
-                    }
+                    LOG.trace("Consumer {} is not closed yet (waiting {})", info.clientId, Duration.between(start, Instant.now()));
                 }
-            } while (closedState == ConsumerCloseState.POLLING);
+                LOG.warn("Consumer {} was not closed after waiting {}", info.clientId, timeout);
+            }
         }
-        LOG.debug("Consumer {} is closed", info.clientId);
+        LOG.debug("Consumer {} is {}", info.clientId, closedState == ConsumerCloseState.CLOSED ? "closed" : "not closed");
     }
 
     void threadPollLoop() {
@@ -168,10 +174,11 @@ abstract class ConsumerState {
                 refreshAssignmentsPollAndProcessRecords();
             }
         } catch (InterruptedException e) {
-            closedState = ConsumerCloseState.CLOSED;
             Thread.currentThread().interrupt();
         } catch (WakeupException e) {
-            closedState = ConsumerCloseState.CLOSED;
+            // Ignore and let the finally block mark this consumer as closed.
+        } finally {
+            closeComplete();
         }
     }
 
@@ -212,44 +219,48 @@ abstract class ConsumerState {
 
     private void pollAndProcessRecords() {
         failed = true;
-        try {
-            // We need to retrieve current offsets in case we need to retry the current record or batch
-            final Map<TopicPartition, OffsetAndMetadata> currentOffsets = getCurrentOffsets();
-            // Poll records
-            pauseTopicPartitions();
-            final ConsumerRecords<?, ?> consumerRecords = pollRecords(currentOffsets);
-            closedState = ConsumerCloseState.POLLING;
-            if (!pollingStarted) {
-                pollingStarted = true;
-                kafkaConsumerProcessor.publishStartedPollingEvent(kafkaConsumer);
-            }
-            resumeTopicPartitions();
-            if (consumerRecords == null || consumerRecords.isEmpty()) {
-                return; // No consumer records to process
-            }
-            // Support Kotlin coroutines
-            if (info.method.isSuspend()) {
-                Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
-                boundArguments.put(lastArgument, null);
-            }
-            processRecords(consumerRecords, currentOffsets);
-            if (failed) {
-                return;
-            }
-            if (info.offsetStrategy == OffsetStrategy.SYNC) {
-                try {
-                    kafkaConsumer.commitSync();
-                } catch (CommitFailedException e) {
-                    handleException(e, consumerRecords, null);
-                }
-            } else if (info.offsetStrategy == OffsetStrategy.ASYNC) {
-                kafkaConsumer.commitAsync(resolveCommitCallback());
-            }
-        } finally {
-            if (closedState == ConsumerCloseState.POLLING) {
-                closedState = ConsumerCloseState.NOT_STARTED;
-            }
+        // We need to retrieve current offsets in case we need to retry the current record or batch
+        final Map<TopicPartition, OffsetAndMetadata> currentOffsets = getCurrentOffsets();
+        // Poll records
+        pauseTopicPartitions();
+        final ConsumerRecords<?, ?> consumerRecords = pollRecords(currentOffsets);
+        closedState = ConsumerCloseState.POLLING;
+        if (!pollingStarted) {
+            pollingStarted = true;
+            kafkaConsumerProcessor.publishStartedPollingEvent(kafkaConsumer);
         }
+        resumeTopicPartitions();
+        if (consumerRecords == null || consumerRecords.isEmpty()) {
+            return; // No consumer records to process
+        }
+        // Support Kotlin coroutines
+        if (info.method.isSuspend()) {
+            Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
+            boundArguments.put(lastArgument, null);
+        }
+        processRecords(consumerRecords, currentOffsets);
+        if (failed) {
+            return;
+        }
+        if (info.offsetStrategy == OffsetStrategy.SYNC) {
+            try {
+                kafkaConsumer.commitSync();
+            } catch (CommitFailedException e) {
+                handleException(e, consumerRecords, null);
+            }
+        } else if (info.offsetStrategy == OffsetStrategy.ASYNC) {
+            kafkaConsumer.commitAsync(resolveCommitCallback());
+        }
+    }
+
+    private void closeComplete() {
+        closedState = ConsumerCloseState.CLOSED;
+        closedLatch.countDown();
+    }
+
+    @NonNull
+    protected Duration getCloseTimeout() {
+        return CLOSE_TIMEOUT;
     }
 
     private synchronized void pauseTopicPartitions() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -212,37 +212,43 @@ abstract class ConsumerState {
 
     private void pollAndProcessRecords() {
         failed = true;
-        // We need to retrieve current offsets in case we need to retry the current record or batch
-        final Map<TopicPartition, OffsetAndMetadata> currentOffsets = getCurrentOffsets();
-        // Poll records
-        pauseTopicPartitions();
-        final ConsumerRecords<?, ?> consumerRecords = pollRecords(currentOffsets);
-        closedState = ConsumerCloseState.POLLING;
-        if (!pollingStarted) {
-            pollingStarted = true;
-            kafkaConsumerProcessor.publishStartedPollingEvent(kafkaConsumer);
-        }
-        resumeTopicPartitions();
-        if (consumerRecords == null || consumerRecords.isEmpty()) {
-            return; // No consumer records to process
-        }
-        // Support Kotlin coroutines
-        if (info.method.isSuspend()) {
-            Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
-            boundArguments.put(lastArgument, null);
-        }
-        processRecords(consumerRecords, currentOffsets);
-        if (failed) {
-            return;
-        }
-        if (info.offsetStrategy == OffsetStrategy.SYNC) {
-            try {
-                kafkaConsumer.commitSync();
-            } catch (CommitFailedException e) {
-                handleException(e, consumerRecords, null);
+        try {
+            // We need to retrieve current offsets in case we need to retry the current record or batch
+            final Map<TopicPartition, OffsetAndMetadata> currentOffsets = getCurrentOffsets();
+            // Poll records
+            pauseTopicPartitions();
+            final ConsumerRecords<?, ?> consumerRecords = pollRecords(currentOffsets);
+            closedState = ConsumerCloseState.POLLING;
+            if (!pollingStarted) {
+                pollingStarted = true;
+                kafkaConsumerProcessor.publishStartedPollingEvent(kafkaConsumer);
             }
-        } else if (info.offsetStrategy == OffsetStrategy.ASYNC) {
-            kafkaConsumer.commitAsync(resolveCommitCallback());
+            resumeTopicPartitions();
+            if (consumerRecords == null || consumerRecords.isEmpty()) {
+                return; // No consumer records to process
+            }
+            // Support Kotlin coroutines
+            if (info.method.isSuspend()) {
+                Argument<?> lastArgument = info.method.getArguments()[info.method.getArguments().length - 1];
+                boundArguments.put(lastArgument, null);
+            }
+            processRecords(consumerRecords, currentOffsets);
+            if (failed) {
+                return;
+            }
+            if (info.offsetStrategy == OffsetStrategy.SYNC) {
+                try {
+                    kafkaConsumer.commitSync();
+                } catch (CommitFailedException e) {
+                    handleException(e, consumerRecords, null);
+                }
+            } else if (info.offsetStrategy == OffsetStrategy.ASYNC) {
+                kafkaConsumer.commitAsync(resolveCommitCallback());
+            }
+        } finally {
+            if (closedState == ConsumerCloseState.POLLING) {
+                closedState = ConsumerCloseState.NOT_STARTED;
+            }
         }
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
@@ -16,7 +16,7 @@ abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
     @Shared @AutoCleanup KafkaContainer kafkaContainer
 
     void setupSpec() {
-        kafkaContainer = new KafkaContainer("apache/kafka-native")
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
         kafkaContainer.start()
         startContext()
         afterKafkaStarted()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/AbstractKafkaContainerSpec.groovy
@@ -1,11 +1,10 @@
 package io.micronaut.configuration.kafka
 
-import org.testcontainers.kafka.KafkaContainer
-import org.testcontainers.utility.DockerImageName
 import io.micronaut.context.ApplicationContext
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.admin.NewTopic
+import org.testcontainers.kafka.KafkaContainer
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
@@ -16,7 +15,7 @@ abstract class AbstractKafkaContainerSpec extends AbstractKafkaSpec {
     @Shared @AutoCleanup KafkaContainer kafkaContainer
 
     void setupSpec() {
-        kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
+        kafkaContainer = new KafkaContainer("apache/kafka:4.2.0")
         kafkaContainer.start()
         startContext()
         afterKafkaStarted()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSpec.groovy
@@ -2,21 +2,24 @@ package io.micronaut.configuration.kafka.processor
 
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy
 import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
+import io.micronaut.configuration.kafka.annotation.KafkaListener
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import spock.lang.Specification
 
+import java.time.Duration
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 
 class ConsumerStateSpec extends Specification {
 
-    void "close does not spin after a successful poll cycle"() {
+    void "close does not spin indefinitely after a successful poll cycle"() {
         given:
         ConsumerState state = new TestConsumerState(createConsumerInfo(), createConsumer())
         setField(state, 'pollingStarted', true)
@@ -25,11 +28,11 @@ class ConsumerStateSpec extends Specification {
         invokeRefreshAssignmentsPollAndProcessRecords(state)
         Thread closeThread = new Thread(state.&close)
         closeThread.start()
-        closeThread.join(500)
+        closeThread.join(1000)
 
         then:
         !closeThread.alive
-        getClosedState(state) != ConsumerCloseState.POLLING
+        getClosedState(state) == ConsumerCloseState.POLLING
 
         cleanup:
         if (closeThread?.alive) {
@@ -39,13 +42,12 @@ class ConsumerStateSpec extends Specification {
     }
 
     private static ConsumerInfo createConsumerInfo() {
-        BeanDefinition<ConsumerStateSpecListener> beanDefinition =
-            Class.forName('io.micronaut.configuration.kafka.processor.$ConsumerStateSpecListener$Definition')
-                .getDeclaredConstructor()
-                .newInstance() as BeanDefinition<ConsumerStateSpecListener>
-        ExecutableMethod<ConsumerStateSpecListener, Object> method = beanDefinition.getRequiredMethod('receive', String)
-        AnnotationValue kafkaListener = method.findAnnotation(io.micronaut.configuration.kafka.annotation.KafkaListener).orElseThrow()
-        new ConsumerInfo('client', 'group', OffsetStrategy.ASYNC_PER_RECORD, kafkaListener, method)
+        try (ApplicationContext context = ApplicationContext.run()) {
+            BeanDefinition<ConsumerStateSpecListener> beanDefinition = context.getBeanDefinition(ConsumerStateSpecListener)
+            ExecutableMethod<ConsumerStateSpecListener, Object> method = beanDefinition.getRequiredMethod('receive', String)
+            AnnotationValue<KafkaListener> kafkaListener = beanDefinition.getAnnotation(KafkaListener)
+            return new ConsumerInfo('client', 'group', OffsetStrategy.ASYNC_PER_RECORD, kafkaListener, method)
+        }
     }
 
     @SuppressWarnings('unchecked')
@@ -121,6 +123,11 @@ class ConsumerStateSpec extends Specification {
         @Override
         protected Map<TopicPartition, OffsetAndMetadata> getCurrentOffsets() {
             [:]
+        }
+
+        @Override
+        protected Duration getCloseTimeout() {
+            Duration.ofMillis(200)
         }
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSpec.groovy
@@ -1,0 +1,126 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import spock.lang.Specification
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+class ConsumerStateSpec extends Specification {
+
+    void "close does not spin after a successful poll cycle"() {
+        given:
+        ConsumerState state = new TestConsumerState(createConsumerInfo(), createConsumer())
+        setField(state, 'pollingStarted', true)
+
+        when:
+        invokeRefreshAssignmentsPollAndProcessRecords(state)
+        Thread closeThread = new Thread(state.&close)
+        closeThread.start()
+        closeThread.join(500)
+
+        then:
+        !closeThread.alive
+        getClosedState(state) != ConsumerCloseState.POLLING
+
+        cleanup:
+        if (closeThread?.alive) {
+            setField(state, 'closedState', ConsumerCloseState.CLOSED)
+            closeThread.join(1000)
+        }
+    }
+
+    private static ConsumerInfo createConsumerInfo() {
+        BeanDefinition<ConsumerStateSpecListener> beanDefinition =
+            Class.forName('io.micronaut.configuration.kafka.processor.$ConsumerStateSpecListener$Definition')
+                .getDeclaredConstructor()
+                .newInstance() as BeanDefinition<ConsumerStateSpecListener>
+        ExecutableMethod<ConsumerStateSpecListener, Object> method = beanDefinition.getRequiredMethod('receive', String)
+        AnnotationValue kafkaListener = method.findAnnotation(io.micronaut.configuration.kafka.annotation.KafkaListener).orElseThrow()
+        new ConsumerInfo('client', 'group', OffsetStrategy.ASYNC_PER_RECORD, kafkaListener, method)
+    }
+
+    @SuppressWarnings('unchecked')
+    private static Consumer<Object, Object> createConsumer() {
+        TopicPartition topicPartition = new TopicPartition('topic', 0)
+        Proxy.newProxyInstance(
+            ConsumerStateSpec.classLoader,
+            [Consumer] as Class<?>[],
+            { proxy, method, args ->
+                switch (method.name) {
+                    case 'subscription':
+                        return ['topic'] as Set
+                    case 'assignment':
+                        return [topicPartition] as Set
+                    case 'paused':
+                        return [] as Set
+                    case 'close':
+                    case 'wakeup':
+                    case 'pause':
+                    case 'resume':
+                    case 'commitSync':
+                    case 'commitAsync':
+                    case 'seek':
+                        return null
+                    default:
+                        return null
+                }
+            }
+        ) as Consumer<Object, Object>
+    }
+
+    private static void invokeRefreshAssignmentsPollAndProcessRecords(ConsumerState state) {
+        invokeMethod(state, 'refreshAssignmentsPollAndProcessRecords')
+    }
+
+    private static ConsumerCloseState getClosedState(ConsumerState state) {
+        getField(state, 'closedState') as ConsumerCloseState
+    }
+
+    private static Object getField(Object target, String name) {
+        Field field = ConsumerState.getDeclaredField(name)
+        field.accessible = true
+        field.get(target)
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        Field field = ConsumerState.getDeclaredField(name)
+        field.accessible = true
+        field.set(target, value)
+    }
+
+    private static Object invokeMethod(Object target, String name) {
+        Method method = ConsumerState.getDeclaredMethod(name)
+        method.accessible = true
+        method.invoke(target)
+    }
+
+    private static final class TestConsumerState extends ConsumerState {
+
+        TestConsumerState(ConsumerInfo info, Consumer<?, ?> consumer) {
+            super(null, info, consumer, new ConsumerStateSpecListener())
+        }
+
+        @Override
+        protected ConsumerRecords<?, ?> pollRecords(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+            ConsumerRecords.empty()
+        }
+
+        @Override
+        protected void processRecords(ConsumerRecords<?, ?> consumerRecords, Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        }
+
+        @Override
+        protected Map<TopicPartition, OffsetAndMetadata> getCurrentOffsets() {
+            [:]
+        }
+    }
+}

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/processor/ConsumerStateSpecListener.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/processor/ConsumerStateSpecListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import jakarta.inject.Singleton;
+
+@Singleton
+@KafkaListener(offsetStrategy = OffsetStrategy.ASYNC_PER_RECORD)
+final class ConsumerStateSpecListener {
+
+    @Topic("topic")
+    void receive(String body) {
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/AbstractKafkaTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/AbstractKafkaTest.groovy
@@ -11,7 +11,7 @@ abstract class AbstractKafkaTest extends Specification implements TestPropertyPr
 
     @Shared
     @AutoCleanup
-    KafkaContainer kafkaContainer = new KafkaContainer("apache/kafka-native")
+    KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
 
     @Override
     Map<String, String> getProperties() {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/AbstractKafkaTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/AbstractKafkaTest.groovy
@@ -2,7 +2,6 @@ package io.micronaut.kafka.docs
 
 import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.kafka.KafkaContainer
-import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -11,7 +10,7 @@ abstract class AbstractKafkaTest extends Specification implements TestPropertyPr
 
     @Shared
     @AutoCleanup
-    KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
+    KafkaContainer kafkaContainer = new KafkaContainer("apache/kafka:4.2.0")
 
     @Override
     Map<String, String> getProperties() {

--- a/test-suite-kafka-utils/src/main/java/io/micronaut/testcontainers/kafka/Kafka.java
+++ b/test-suite-kafka-utils/src/main/java/io/micronaut/testcontainers/kafka/Kafka.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class Kafka {
 
-    private static final String IMAGE_NAME = "apache/kafka-native";
+    private static final String IMAGE_NAME = "apache/kafka:4.2.0";
     private static KafkaContainer container;
 
     public static Map<String, String> getProperties() {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
@@ -10,7 +10,7 @@ import org.testcontainers.utility.DockerImageName
 abstract class AbstractKafkaTest : TestPropertyProvider {
 
     companion object {
-        var MY_KAFKA: KafkaContainer = KafkaContainer("apache/kafka-native")
+        var MY_KAFKA: KafkaContainer = KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
     }
 
     override fun getProperties(): MutableMap<String, String> {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/AbstractKafkaTest.kt
@@ -2,7 +2,6 @@ package io.micronaut.kafka.docs
 
 import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.kafka.KafkaContainer
-import org.testcontainers.utility.DockerImageName
 
 /**
  * @see <a href="https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers">Singleton containers</a>
@@ -10,7 +9,7 @@ import org.testcontainers.utility.DockerImageName
 abstract class AbstractKafkaTest : TestPropertyProvider {
 
     companion object {
-        var MY_KAFKA: KafkaContainer = KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.0"))
+        var MY_KAFKA: KafkaContainer = KafkaContainer("apache/kafka:4.2.0")
     }
 
     override fun getProperties(): MutableMap<String, String> {


### PR DESCRIPTION
## Summary
- reset the transient `ConsumerState` close state after each poll/process cycle
- prevent shutdown from waiting indefinitely when no `WakeupException` escapes inner processing
- add a focused regression spec covering the shutdown path

## Verification
- `./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.processor.ConsumerStateSpec'`

Resolves #995
