### PR TITLE
Fix ConsumerStateBatch retry NPE when offsets are missing

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -35,6 +35,7 @@ import reactor.util.function.Tuple2;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -172,7 +173,11 @@ final class ConsumerStateBatch extends ConsumerState {
     private int getCurrentRetryCount(Set<TopicPartition> partitions,
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         return partitions.stream()
-            .map(tp -> getPartitionRetryState(tp, currentOffsets.get(tp).offset()))
+            .map(tp -> {
+                OffsetAndMetadata offsetAndMetadata = currentOffsets.get(tp);
+                return offsetAndMetadata == null ? null : getPartitionRetryState(tp, offsetAndMetadata.offset());
+            })
+            .filter(Objects::nonNull)
             .mapToInt(x -> x.currentRetryCount)
             .max().orElse(info.retryCount);
     }
@@ -183,28 +188,37 @@ final class ConsumerStateBatch extends ConsumerState {
 
     private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets, RecordDeserializationException ex) {
-        // Only after the first poll there are no current offsets, but they can be reconstructed from the exception
-        return CollectionUtils.isEmpty(currentOffsets)
-            ? Map.of(ex.topicPartition(), new OffsetAndMetadata(ex.offset(), null))
-            : currentOffsets;
+        // Current offsets can be missing after the first poll if assignments changed while records were being fetched.
+        if (CollectionUtils.isEmpty(currentOffsets)) {
+            return Map.of(ex.topicPartition(), new OffsetAndMetadata(ex.offset(), null));
+        }
+        if (currentOffsets.containsKey(ex.topicPartition())) {
+            return currentOffsets;
+        }
+        Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = new HashMap<>(currentOffsets);
+        reconstructedOffsets.put(ex.topicPartition(), new OffsetAndMetadata(ex.offset(), null));
+        return reconstructedOffsets;
     }
 
     @Nullable
     private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets,
         @Nullable ConsumerRecords<?, ?> consumerRecords) {
-        // Only after the first poll there are no current offsets, but they can be reconstructed from the fetched records
-        if (CollectionUtils.isEmpty(currentOffsets) && consumerRecords != null) {
-            Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = new HashMap<>();
-            for (ConsumerRecord<?, ?> record : consumerRecords) {
-                TopicPartition tp = new TopicPartition(record.topic(), record.partition());
-                if (!reconstructedOffsets.containsKey(tp)) {
-                    reconstructedOffsets.put(tp, new OffsetAndMetadata(record.offset(), null));
-                }
-            }
-            return reconstructedOffsets;
-        } else {
+        // Current offsets can be missing for some partitions if assignments changed while records were being fetched.
+        if (consumerRecords == null) {
             return currentOffsets;
         }
+        Map<TopicPartition, OffsetAndMetadata> reconstructedOffsets = CollectionUtils.isEmpty(currentOffsets)
+            ? new HashMap<>()
+            : new HashMap<>(currentOffsets);
+        boolean changed = CollectionUtils.isEmpty(currentOffsets);
+        for (ConsumerRecord<?, ?> record : consumerRecords) {
+            TopicPartition tp = new TopicPartition(record.topic(), record.partition());
+            if (!reconstructedOffsets.containsKey(tp)) {
+                reconstructedOffsets.put(tp, new OffsetAndMetadata(record.offset(), null));
+                changed = true;
+            }
+        }
+        return changed ? reconstructedOffsets : currentOffsets;
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateBatchSpec.groovy
@@ -1,0 +1,125 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.inject.ExecutableMethod
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import spock.lang.Specification
+
+import java.time.Duration
+
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_ON_ERROR
+
+class ConsumerStateBatchSpec extends Specification {
+
+    void "getCurrentRetryCount ignores partitions missing from current offsets"() {
+        given:
+        ConsumerStateBatch consumerStateBatch = newConsumerStateBatch()
+        TopicPartition first = new TopicPartition('topic', 0)
+        TopicPartition second = new TopicPartition('topic', 1)
+
+        when:
+        int currentRetryCount = invokePrivateMethod(
+                consumerStateBatch,
+                'getCurrentRetryCount',
+                [Set, Map] as Class[],
+                [([first, second] as Set), [(first): new OffsetAndMetadata(42L, null)]] as Object[]
+        ) as int
+
+        then:
+        currentRetryCount == 1
+    }
+
+    void "resolveWithErrorStrategy reconstructs missing offsets for the current batch"() {
+        given:
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock(KafkaConsumerProcessor) {
+            scheduleTask(_, _) >> { Duration retryDelay, Runnable task -> }
+        }
+        Consumer<?, ?> kafkaConsumer = Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+        }
+        ConsumerStateBatch consumerState = newConsumerStateBatch(kafkaConsumerProcessor, kafkaConsumer)
+        TopicPartition existingPartition = new TopicPartition('topic', 0)
+        TopicPartition batchPartition = new TopicPartition('topic', 1)
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets = [(existingPartition): new OffsetAndMetadata(5L, null)]
+        ConsumerRecords<?, ?> consumerRecords = new ConsumerRecords<>([
+                (batchPartition): [new ConsumerRecord<>('topic', 1, 10L, 'key', 'value')]
+        ])
+
+        when:
+        boolean shouldRetry = invokePrivateMethod(
+                consumerState,
+                'resolveWithErrorStrategy',
+                [ConsumerRecords, Map, Throwable] as Class[],
+                [consumerRecords, currentOffsets, new RuntimeException('boom')] as Object[]
+        ) as boolean
+
+        then:
+        shouldRetry
+        1 * kafkaConsumer.seek(batchPartition, 10L)
+        0 * kafkaConsumer.seek(existingPartition, _)
+        0 * kafkaConsumerProcessor.handleException(_, _)
+    }
+
+    private ConsumerStateBatch newConsumerStateBatch() {
+        newConsumerStateBatch(Mock(KafkaConsumerProcessor), Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+        })
+    }
+
+    private ConsumerStateBatch newConsumerStateBatch(KafkaConsumerProcessor kafkaConsumerProcessor, Consumer<?, ?> kafkaConsumer) {
+        ConsumerInfo consumerInfo = new ConsumerInfo(
+                'client',
+                'group',
+                OffsetStrategy.DISABLED,
+                kafkaListenerAnnotation(),
+                executableMethod()
+        )
+        new ConsumerStateBatch(kafkaConsumerProcessor, consumerInfo, kafkaConsumer, new Object())
+    }
+
+    private static Object invokePrivateMethod(Object target, String name, Class[] parameterTypes, Object[] arguments) {
+        def method = target.class.getDeclaredMethod(name, parameterTypes)
+        method.accessible = true
+        method.invoke(target, arguments)
+    }
+
+    private AnnotationValue<KafkaListener> kafkaListenerAnnotation() {
+        AnnotationValue.builder(KafkaListener)
+                .member('batch', true)
+                .member('errorStrategy', AnnotationValue.builder(ErrorStrategy)
+                        .member('value', RETRY_ON_ERROR)
+                        .member('retryCount', 3)
+                        .build())
+                .build()
+    }
+
+    private ExecutableMethod<?, ?> executableMethod() {
+        ReturnType<?> returnType = Stub() {
+            getType() >> void
+            isAsyncOrReactive() >> false
+            getFirstTypeVariable() >> Optional.empty()
+        }
+        Stub(ExecutableMethod) {
+            getDeclaringType() >> TestBatchListener
+            getName() >> 'receive'
+            isTrue(KafkaListener, 'batch') >> true
+            hasAnnotation(_ as Class) >> false
+            getValue(KafkaListener, 'pollTimeout', Duration) >> Optional.of(Duration.ofMillis(100))
+            getArguments() >> Argument.ZERO_ARGUMENTS
+            stringValues(_ as Class) >> ([] as String[])
+            getReturnType() >> returnType
+        }
+    }
+
+    private static final class TestBatchListener {
+    }
+}


### PR DESCRIPTION
## Summary
- avoid dereferencing missing batch current offsets when retrying a failed batch
- reconstruct missing offsets from the current batch or deserialization exception when assignments change
- add regression coverage for the retry-count path and retry resolution flow

## Verification
- ./gradlew :micronaut-kafka:test --rerun-tasks --tests io.micronaut.configuration.kafka.processor.ConsumerStateBatchSpec
- ./gradlew :micronaut-kafka:spotlessCheck

Resolves #1004
