### PR TITLE
Fix stale consumer records-lag meters

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -133,21 +133,21 @@ public class KafkaMetricMeterTypeBuilder {
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
             removeExistingMeter(tags);
-            return Optional.of(Gauge.builder(getMetricName(), kafkaMetric, value -> ((Number) value.metricValue()).doubleValue())
+            return Optional.of(Gauge.builder(getMetricName(), kafkaMetric, metric -> ((Number) metric.metricValue()).doubleValue())
                     .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
         } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && this.kafkaMetric.metricValue() instanceof Number) {
             removeExistingMeter(tags);
-            return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, value -> ((Number) value.metricValue()).doubleValue())
+            return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, metric -> ((Number) metric.metricValue()).doubleValue())
                     .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
         } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
             removeExistingMeter(tags);
-            return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), value -> ((Number) value.metricValue()).doubleValue())
+            return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), metric -> ((Number) metric.metricValue()).doubleValue())
                     .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .register(meterRegistry));

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -132,6 +132,7 @@ public class KafkaMetricMeterTypeBuilder {
         }
 
         KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
+        removeExistingMeter();
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
             final KafkaMetric kafkaMetric = this.kafkaMetric;
@@ -165,5 +166,14 @@ public class KafkaMetricMeterTypeBuilder {
 
     private String getMetricName() {
         return prefix + "." + name;
+    }
+
+    private void removeExistingMeter() {
+        Meter existingMeter = meterRegistry.find(getMetricName())
+                .tags(tagFunction.apply(kafkaMetric.metricName()))
+                .meter();
+        if (existingMeter != null) {
+            meterRegistry.remove(existingMeter);
+        }
     }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -132,24 +132,27 @@ public class KafkaMetricMeterTypeBuilder {
         }
 
         KafkaMetricMeterType kafkaMetricMeterType = kafkaMetricMeterTypeRegistry.lookup(this.name);
-        removeExistingMeter();
+        List<Tag> tags = tagFunction.apply(kafkaMetric.metricName());
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
             final KafkaMetric kafkaMetric = this.kafkaMetric;
+            removeExistingMeter(tags);
             return Optional.of(Gauge.builder(getMetricName(), () -> (Number) kafkaMetric.metricValue())
-                    .tags(tagFunction.apply(kafkaMetric.metricName()))
+                    .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
         } else if (kafkaMetricMeterType.getMeterType() == MeterType.FUNCTION_COUNTER && this.kafkaMetric.metricValue() instanceof Number) {
+            removeExistingMeter(tags);
             return Optional.of(FunctionCounter.builder(getMetricName(), kafkaMetric, value -> ((Number) value.metricValue()).doubleValue())
-                    .tags(tagFunction.apply(kafkaMetric.metricName()))
+                    .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .baseUnit(kafkaMetricMeterType.getBaseUnit())
                     .register(meterRegistry));
         } else if (kafkaMetricMeterType.getMeterType() == MeterType.TIME_GAUGE && this.kafkaMetric.metricValue() instanceof Number) {
+            removeExistingMeter(tags);
             return Optional.of(TimeGauge.builder(getMetricName(), kafkaMetric, kafkaMetricMeterType.getTimeUnit(), value -> ((Number) value.metricValue()).doubleValue())
-                    .tags(tagFunction.apply(kafkaMetric.metricName()))
+                    .tags(tags)
                     .description(kafkaMetricMeterType.getDescription())
                     .register(meterRegistry));
         }
@@ -168,9 +171,9 @@ public class KafkaMetricMeterTypeBuilder {
         return prefix + "." + name;
     }
 
-    private void removeExistingMeter() {
+    private void removeExistingMeter(List<Tag> tags) {
         Meter existingMeter = meterRegistry.find(getMetricName())
-                .tags(tagFunction.apply(kafkaMetric.metricName()))
+                .tags(tags)
                 .meter();
         if (existingMeter != null) {
             meterRegistry.remove(existingMeter);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilderSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilderSpec.groovy
@@ -1,14 +1,18 @@
 package io.micronaut.configuration.kafka.metrics.builder
 
 import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics.KafkaMetric
 import org.apache.kafka.common.metrics.MetricConfig
+import org.apache.kafka.common.metrics.MetricValueProvider
 import org.apache.kafka.common.metrics.stats.Avg
 import org.apache.kafka.common.utils.Time
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class KafkaMetricMeterTypeBuilderSpec extends Specification {
 
@@ -44,6 +48,44 @@ class KafkaMetricMeterTypeBuilderSpec extends Specification {
         "name" | "prefix" | createTagFunction() | createMetric() | new LoggingMeterRegistry() | true
     }
 
+    void "re-registering the same meter id replaces the backing kafka metric"() {
+        given:
+        def registry = new SimpleMeterRegistry()
+        def tags = [("client-id"): "consumer-1", topic: "words", partition: "0"]
+        def firstValue = new AtomicInteger(2)
+        def secondValue = new AtomicInteger(9)
+
+        when:
+        KafkaMetricMeterTypeBuilder.newBuilder()
+                .prefix("kafka.consumer")
+                .tagFunction(createTagFunction())
+                .metric(createMetric("records-lag", tags, firstValue))
+                .registry(registry)
+                .build()
+
+        and:
+        def gauge = registry.get("kafka.consumer.records-lag")
+                .tags("client-id", "consumer-1", "topic", "words", "partition", "0")
+                .gauge()
+
+        then:
+        gauge.value() == 2
+
+        when:
+        KafkaMetricMeterTypeBuilder.newBuilder()
+                .prefix("kafka.consumer")
+                .tagFunction(createTagFunction())
+                .metric(createMetric("records-lag", tags, secondValue))
+                .registry(registry)
+                .build()
+
+        then:
+        registry.get("kafka.consumer.records-lag")
+                .tags("client-id", "consumer-1", "topic", "words", "partition", "0")
+                .gauge()
+                .value() == 9
+    }
+
     private KafkaMetric createMetric() {
         new KafkaMetric(new Object(),
                 new MetricName("name", "group", "description", [:]),
@@ -52,7 +94,19 @@ class KafkaMetricMeterTypeBuilderSpec extends Specification {
                 Mock(Time))
     }
 
+    private KafkaMetric createMetric(String name, Map<String, String> tags, AtomicInteger value) {
+        new KafkaMetric(new Object(),
+                new MetricName(name, "group", "description", tags),
+                ({ MetricConfig config, long now -> value.get() } as MetricValueProvider<Number>),
+                new MetricConfig(),
+                Mock(Time))
+    }
+
     private createTagFunction() {
-        return {}
+        return { MetricName metricName ->
+            metricName.tags().collect { key, value ->
+                io.micrometer.core.instrument.Tag.of(key, value)
+            }
+        }
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilderSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilderSpec.groovy
@@ -80,10 +80,14 @@ class KafkaMetricMeterTypeBuilderSpec extends Specification {
                 .build()
 
         then:
-        registry.get("kafka.consumer.records-lag")
+        def matchingMeters = registry.find("kafka.consumer.records-lag")
+                .tags("client-id", "consumer-1", "topic", "words", "partition", "0")
+                .meters()
+        def updatedGauge = registry.get("kafka.consumer.records-lag")
                 .tags("client-id", "consumer-1", "topic", "words", "partition", "0")
                 .gauge()
-                .value() == 9
+        matchingMeters.size() == 1
+        updatedGauge.value() == 9
     }
 
     private KafkaMetric createMetric() {


### PR DESCRIPTION
## Summary
- replace any existing Micrometer meter before re-registering a Kafka metric with the same name and tags
- add a regression test covering repeated registration of the same records-lag meter id

## Testing
- ./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilderSpec'
- ./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.metrics.builder.*'
- ./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.health.KafkaConsumerMetricsSpec' (fails in this environment because Docker is unavailable for Testcontainers)

Resolves #933