### PR TITLE
Implement graceful shutdown for Kafka consumers

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -70,6 +71,8 @@ abstract class ConsumerState {
     private CountDownLatch startupLatch;
     private boolean pollingStarted;
     private volatile ConsumerCloseState closedState;
+    private volatile boolean shutdownRequested;
+    private final CompletableFuture<Void> shutdownFuture = new CompletableFuture<>();
 
     protected ConsumerState(
         KafkaConsumerProcessor kafkaConsumerProcessor,
@@ -142,6 +145,18 @@ abstract class ConsumerState {
         }
     }
 
+    void requestShutdown() {
+        shutdownRequested = true;
+    }
+
+    CompletableFuture<Void> getShutdownFuture() {
+        return shutdownFuture;
+    }
+
+    boolean isActive() {
+        return !shutdownFuture.isDone();
+    }
+
     void close() {
         if (closedState == ConsumerCloseState.POLLING) {
             final Instant start = Instant.now();
@@ -163,15 +178,17 @@ abstract class ConsumerState {
     void threadPollLoop() {
         try (kafkaConsumer) {
             holdStartup();
-            //noinspection InfiniteLoopStatement
-            while (true) { //NOSONAR
+            while (!shutdownRequested) {
                 refreshAssignmentsPollAndProcessRecords();
             }
         } catch (InterruptedException e) {
-            closedState = ConsumerCloseState.CLOSED;
             Thread.currentThread().interrupt();
         } catch (WakeupException e) {
+            // Closing a Kafka consumer relies on wakeup to break a blocked poll.
+            LOG.debug("Consumer {} woken up during shutdown", info.clientId);
+        } finally {
             closedState = ConsumerCloseState.CLOSED;
+            shutdownFuture.complete(null);
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -59,6 +59,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.messaging.annotation.MessageBody;
 import io.micronaut.messaging.exceptions.MessagingSystemException;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
 import io.micronaut.scheduling.ScheduledExecutorTaskScheduler;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.TaskScheduler;
@@ -85,9 +86,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -105,7 +108,7 @@ import java.util.regex.PatternSyntaxException;
 @Requires(beans = KafkaDefaultConfiguration.class)
 @Internal
 class KafkaConsumerProcessor
-        implements ExecutableMethodProcessor<Topic>, AutoCloseable, ConsumerRegistry {
+        implements ExecutableMethodProcessor<Topic>, AutoCloseable, ConsumerRegistry, GracefulShutdownCapable {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerProcessor.class);
     private static final ByteArrayDeserializer DEFAULT_KEY_DESERIALIZER = new ByteArrayDeserializer();
@@ -312,14 +315,38 @@ class KafkaConsumerProcessor
     }
 
     @Override
+    public CompletableFuture<Void> shutdownGracefully() {
+        if (consumers.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        consumers.values().forEach(ConsumerState::requestShutdown);
+        consumers.values().forEach(ConsumerState::wakeUp);
+        return CompletableFuture.allOf(consumers.values().stream()
+            .map(ConsumerState::getShutdownFuture)
+            .toArray(CompletableFuture[]::new));
+    }
+
+    @Override
+    public OptionalLong reportActiveTasks() {
+        return OptionalLong.of(consumers.values().stream()
+            .filter(ConsumerState::isActive)
+            .count());
+    }
+
+    @Override
     @PreDestroy
     public void close() {
         kafkaConsumerGroupManager.getRegisteredClientIdsForDeletion().forEach(clientId -> {
             LOG.info("Already closed consumer client : {}", clientId);
             consumers.remove(clientId);
         });
-        consumers.values().forEach(ConsumerState::wakeUp);
-        consumers.values().forEach(ConsumerState::close);
+        consumers.values().forEach(ConsumerState::requestShutdown);
+        consumers.values().forEach(state -> {
+            if (state.isActive()) {
+                state.wakeUp();
+            }
+            state.close();
+        });
         consumers.clear();
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -316,12 +316,13 @@ class KafkaConsumerProcessor
 
     @Override
     public CompletableFuture<Void> shutdownGracefully() {
-        if (consumers.isEmpty()) {
+        List<ConsumerState> consumerStates = List.copyOf(consumers.values());
+        if (consumerStates.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
-        consumers.values().forEach(ConsumerState::requestShutdown);
-        consumers.values().forEach(ConsumerState::wakeUp);
-        return CompletableFuture.allOf(consumers.values().stream()
+        consumerStates.forEach(ConsumerState::requestShutdown);
+        consumerStates.forEach(ConsumerState::wakeUp);
+        return CompletableFuture.allOf(consumerStates.stream()
             .map(ConsumerState::getShutdownFuture)
             .toArray(CompletableFuture[]::new));
     }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
@@ -6,6 +6,9 @@ import io.micronaut.context.annotation.Requires
 
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
@@ -24,14 +27,17 @@ class KafkaGracefulShutdownSpec extends AbstractKafkaContainerSpec {
                 (EMBEDDED_TOPICS): ['idle-topic']
             ]
             ApplicationContext ctx = ApplicationContext.run(config)
-
+            Duration shutdownDuration
         when: "the context is closed"
             Instant start = Instant.now()
             ctx.close()
-            Duration shutdownDuration = Duration.between(start, Instant.now())
-
+            shutdownDuration = Duration.between(start, Instant.now())
         then: "shutdown completes quickly without waiting the full grace period"
-            shutdownDuration.seconds < 5
+            shutdownDuration.toMillis() < 5000
+        cleanup:
+            if (ctx.isRunning()) {
+                ctx.close()
+            }
     }
 
     void "graceful shutdown completes in-flight message processing"() {
@@ -45,27 +51,31 @@ class KafkaGracefulShutdownSpec extends AbstractKafkaContainerSpec {
                 (EMBEDDED_TOPICS): ['in-flight-products']
             ]
             ApplicationContext ctx = ApplicationContext.run(config)
-
+            Duration shutdownDuration
         when: "a message is sent"
             def client = ctx.getBean(InFlightClient)
             def consumer = ctx.getBean(InFlightConsumer)
             client.send("test-product")
-
         then: "message starts processing"
             conditions.eventually {
-                consumer.processing.get()
+                consumer.hasStartedProcessing()
             }
-
         when: "shutdown is triggered while processing"
             Instant start = Instant.now()
-            ctx.close()
-            Duration shutdownDuration = Duration.between(start, Instant.now())
-
+            def closeFuture = CompletableFuture.runAsync {
+                ctx.close()
+            }
+            consumer.allowProcessingToComplete()
+            closeFuture.get(15, TimeUnit.SECONDS)
+            shutdownDuration = Duration.between(start, Instant.now())
         then: "the message is fully processed"
             consumer.messageProcessed.get()
-
         and: "shutdown completes before grace period"
-            shutdownDuration.seconds < 15
+            shutdownDuration.toMillis() < 15000
+        cleanup:
+            if (ctx.isRunning()) {
+                ctx.close()
+            }
     }
 
     @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownIdleSpec')
@@ -82,17 +92,27 @@ class KafkaGracefulShutdownSpec extends AbstractKafkaContainerSpec {
     static class InFlightConsumer {
         AtomicBoolean processing = new AtomicBoolean(false)
         AtomicBoolean messageProcessed = new AtomicBoolean(false)
+        CountDownLatch processingStarted = new CountDownLatch(1)
+        CountDownLatch completionSignal = new CountDownLatch(1)
 
         @Topic("in-flight-products")
         void receive(String product) {
             processing.set(true)
+            processingStarted.countDown()
             try {
-                // Simulate some processing time
-                sleep(2000)
+                completionSignal.await(5, TimeUnit.SECONDS)
                 messageProcessed.set(true)
             } finally {
                 processing.set(false)
             }
+        }
+
+        boolean hasStartedProcessing() {
+            processingStarted.getCount() == 0
+        }
+
+        void allowProcessingToComplete() {
+            completionSignal.countDown()
         }
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaGracefulShutdownSpec.groovy
@@ -1,0 +1,105 @@
+package io.micronaut.configuration.kafka.annotation
+
+import io.micronaut.configuration.kafka.AbstractKafkaContainerSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static io.micronaut.configuration.kafka.annotation.OffsetReset.EARLIEST
+import static io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration.EMBEDDED_TOPICS
+
+class KafkaGracefulShutdownSpec extends AbstractKafkaContainerSpec {
+
+    void "graceful shutdown completes promptly with idle consumers"() {
+        given: "a new application context with graceful shutdown enabled"
+            def config = [
+                'kafka.bootstrap.servers': bootstrapServers,
+                'kafka.enabled': 'true',
+                'spec.name': 'KafkaGracefulShutdownIdleSpec',
+                'micronaut.lifecycle.graceful-shutdown.enabled': 'true',
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '30s',
+                (EMBEDDED_TOPICS): ['idle-topic']
+            ]
+            ApplicationContext ctx = ApplicationContext.run(config)
+
+        when: "the context is closed"
+            Instant start = Instant.now()
+            ctx.close()
+            Duration shutdownDuration = Duration.between(start, Instant.now())
+
+        then: "shutdown completes quickly without waiting the full grace period"
+            shutdownDuration.seconds < 5
+    }
+
+    void "graceful shutdown completes in-flight message processing"() {
+        given: "a consumer that takes time to process messages"
+            def config = [
+                'kafka.bootstrap.servers': bootstrapServers,
+                'kafka.enabled': 'true',
+                'spec.name': 'KafkaGracefulShutdownInFlightSpec',
+                'micronaut.lifecycle.graceful-shutdown.enabled': 'true',
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '30s',
+                (EMBEDDED_TOPICS): ['in-flight-products']
+            ]
+            ApplicationContext ctx = ApplicationContext.run(config)
+
+        when: "a message is sent"
+            def client = ctx.getBean(InFlightClient)
+            def consumer = ctx.getBean(InFlightConsumer)
+            client.send("test-product")
+
+        then: "message starts processing"
+            conditions.eventually {
+                consumer.processing.get()
+            }
+
+        when: "shutdown is triggered while processing"
+            Instant start = Instant.now()
+            ctx.close()
+            Duration shutdownDuration = Duration.between(start, Instant.now())
+
+        then: "the message is fully processed"
+            consumer.messageProcessed.get()
+
+        and: "shutdown completes before grace period"
+            shutdownDuration.seconds < 15
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownIdleSpec')
+    @KafkaListener(groupId = "idle-consumer", offsetReset = EARLIEST)
+    static class IdleConsumer {
+        @Topic("idle-topic")
+        void receive(String message) {
+            // Idle consumer - receives no messages during test
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownInFlightSpec')
+    @KafkaListener(groupId = "in-flight-consumer", offsetReset = EARLIEST)
+    static class InFlightConsumer {
+        AtomicBoolean processing = new AtomicBoolean(false)
+        AtomicBoolean messageProcessed = new AtomicBoolean(false)
+
+        @Topic("in-flight-products")
+        void receive(String product) {
+            processing.set(true)
+            try {
+                // Simulate some processing time
+                sleep(2000)
+                messageProcessed.set(true)
+            } finally {
+                processing.set(false)
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaGracefulShutdownInFlightSpec')
+    @KafkaClient
+    static interface InFlightClient {
+        @Topic("in-flight-products")
+        void send(String product)
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessorGracefulShutdownSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessorGracefulShutdownSpec.groovy
@@ -1,0 +1,106 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.ProducerRegistry
+import io.micronaut.configuration.kafka.TransactionalProducerRegistry
+import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry
+import io.micronaut.configuration.kafka.bind.batch.BatchConsumerRecordsBinderRegistry
+import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration
+import io.micronaut.configuration.kafka.event.KafkaConsumerStartedPollingEvent
+import io.micronaut.configuration.kafka.event.KafkaConsumerSubscribedEvent
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
+import io.micronaut.configuration.kafka.serde.SerdeRegistry
+import io.micronaut.context.BeanContext
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.runtime.ApplicationConfiguration
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
+
+class KafkaConsumerProcessorGracefulShutdownSpec extends Specification {
+
+    void "shutdownGracefully wakes consumers and waits for their shutdown futures"() {
+        given:
+        KafkaConsumerProcessor processor = newKafkaConsumerProcessor()
+        ConsumerState first = Mock()
+        ConsumerState second = Mock()
+        CompletableFuture<Void> firstFuture = new CompletableFuture<>()
+        CompletableFuture<Void> secondFuture = new CompletableFuture<>()
+        processor.@consumers.put('first', first)
+        processor.@consumers.put('second', second)
+
+        when:
+        CompletableFuture<Void> shutdown = processor.shutdownGracefully()
+
+        then:
+        !shutdown.done
+        1 * first.requestShutdown()
+        1 * first.wakeUp()
+        1 * first.getShutdownFuture() >> firstFuture
+        1 * second.requestShutdown()
+        1 * second.wakeUp()
+        1 * second.getShutdownFuture() >> secondFuture
+
+        when:
+        firstFuture.complete(null)
+
+        then:
+        !shutdown.done
+
+        when:
+        secondFuture.complete(null)
+
+        then:
+        shutdown.get() == null
+    }
+
+    void "reportActiveTasks counts active consumers"() {
+        given:
+        KafkaConsumerProcessor processor = newKafkaConsumerProcessor()
+        ConsumerState first = Stub() {
+            isActive() >> true
+        }
+        ConsumerState second = Stub() {
+            isActive() >> false
+        }
+        ConsumerState third = Stub() {
+            isActive() >> true
+        }
+        processor.@consumers.put('first', first)
+        processor.@consumers.put('second', second)
+        processor.@consumers.put('third', third)
+
+        when:
+        OptionalLong activeTasks = processor.reportActiveTasks()
+
+        then:
+        activeTasks.present
+        activeTasks.asLong == 2L
+    }
+
+    private KafkaConsumerProcessor newKafkaConsumerProcessor() {
+        BeanContext beanContext = Stub() {
+            getBeanDefinitions(_) >> ([] as Collection<BeanDefinition<?>>)
+        }
+        new KafkaConsumerProcessor(
+            Stub(ExecutorService),
+            Stub(ApplicationConfiguration),
+            Stub(KafkaConsumerGroupManager),
+            beanContext,
+            Stub(AbstractKafkaConsumerConfiguration),
+            Stub(ConsumerRecordBinderRegistry),
+            Stub(BatchConsumerRecordsBinderRegistry),
+            Stub(SerdeRegistry),
+            Stub(ProducerRegistry),
+            Stub(KafkaListenerExceptionHandler),
+            Stub(ScheduledExecutorService),
+            Stub(TransactionalProducerRegistry),
+            Stub(ApplicationEventPublisher<KafkaConsumerStartedPollingEvent>),
+            Stub(ApplicationEventPublisher<KafkaConsumerSubscribedEvent>),
+            Stub(ConditionalRetryBehaviourHandler)
+        )
+    }
+}


### PR DESCRIPTION
This updates Kafka consumer shutdown to participate in Micronaut graceful shutdown.

It implements `GracefulShutdownCapable` in `KafkaConsumerProcessor`, signals active consumers to stop polling during graceful shutdown, and tracks shutdown completion so Micronaut can stop waiting as soon as Kafka consumers finish.

The PR also incorporates the integration test coverage from #1279 and adds a focused unit spec for the processor shutdown contract.

Verification:
- `./gradlew :micronaut-kafka:compileTestGroovy`
- `./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.processor.KafkaConsumerProcessorGracefulShutdownSpec --tests io.micronaut.configuration.kafka.processor.ConsumerStateBatchSpec`

Resolves #1278
