### PR TITLE
fix(deps): update io.zipkin.brave:brave-instrumentation-kafka-clients to v6.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ awaitility = '4.3.0'
 opentracing-kafka-client = '0.1.15'
 opentracing-mock = '0.33.0'
 
-zipkin-brave-kafka-clients = '6.3.0'
+zipkin-brave-kafka-clients = '6.3.1'
 
 micronaut-cache = "6.0.0-M2"
 micronaut-micrometer = "6.0.1-M1"
@@ -45,4 +45,3 @@ testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka" }
 micronaut-gradle-plugin = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }
 
 [plugins]
-


### PR DESCRIPTION
## Summary
- combine Renovate batch issue #1315 into a single dependency-upgrade PR
- update `io.zipkin.brave:brave-instrumentation-kafka-clients` from `6.3.0` to `6.3.1`
- keep the change limited to the version catalog entry used by `:micronaut-kafka`

## Verification
- `./gradlew :micronaut-kafka:dependencyInsight --dependency io.zipkin.brave:brave-instrumentation-kafka-clients --configuration compileClasspath :micronaut-kafka:compileJava :micronaut-kafka:compileTestJava :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.KafkaConfigurationSpec' --tests 'io.micronaut.configuration.kafka.annotation.KafkaClientSpec' --tests 'io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporterSpec' --tests 'io.micronaut.configuration.kafka.processor.ConsumerStateBatchSpec' --tests 'io.micronaut.configuration.kafka.serde.CompositeSerdeRegistrySpec' --tests 'io.micronaut.configuration.kafka.serde.JsonSerdeSpec' --tests 'io.micronaut.configuration.kafka.scope.KafkaClientScopeSpec' --tests 'io.micronaut.test.DisabledSpec' -q -x japiCmp -x checkVersionCatalogCompatibility`\n- `./gradlew :micronaut-kafka:check -q -x japiCmp -x checkVersionCatalogCompatibility` was attempted, but Docker-backed Testcontainers tests fail in this environment efore exercising this dependency update\n\n## Source PRs\n- #1295\n\n

 
Resolves #1315