### PR TITLE
Make null kafka config errors explicit

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
@@ -84,7 +84,7 @@ public abstract class AbstractKafkaConfiguration<K, V> implements Toggleable {
         }).forEach(entry -> {
             Object value = entry.getValue();
             if (value == null) {
-                throw new ConfigurationException("Value for property kafka." + entry.getKey() + " resolved as null");
+                throw new ConfigurationException("Value for property " + PREFIX + "." + entry.getKey().toString() + " resolved as null");
             }
             if (environment.getConversionService().canConvert(value.getClass(), String.class)) {
                 Optional<?> converted = environment.getConversionService().convert(value, String.class);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/config/AbstractKafkaConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.kafka.config;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.Toggleable;
 
 import org.jspecify.annotations.NonNull;
@@ -82,8 +83,11 @@ public abstract class AbstractKafkaConfiguration<K, V> implements Toggleable {
             return Stream.of("embedded", "consumers", "producers", "streams").noneMatch(key::startsWith);
         }).forEach(entry -> {
             Object value = entry.getValue();
-            if (environment.getConversionService().canConvert(entry.getValue().getClass(), String.class)) {
-                Optional<?> converted = environment.getConversionService().convert(entry.getValue(), String.class);
+            if (value == null) {
+                throw new ConfigurationException("Value for property kafka." + entry.getKey() + " resolved as null");
+            }
+            if (environment.getConversionService().canConvert(value.getClass(), String.class)) {
+                Optional<?> converted = environment.getConversionService().convert(value, String.class);
                 if (converted.isPresent()) {
                     value = converted.get();
                 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -10,6 +10,8 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.EnvironmentPropertySource
 import io.micronaut.context.env.MapPropertySource
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -137,6 +139,22 @@ class KafkaConfigurationSpec extends Specification {
 
         cleanup:
         consumer.close()
+    }
+
+    void "test null kafka property reports the failing property path"() {
+        when:
+        applicationContext = ApplicationContext.run(
+                ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): "localhost:1111",
+                ('kafka.custom.users'): null,
+                ("kafka." + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+                ("kafka." + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name
+        )
+        applicationContext.getBean(AbstractKafkaConsumerConfiguration)
+
+        then:
+        BeanInstantiationException exception = thrown()
+        exception.cause instanceof ConfigurationException
+        exception.cause.message == "Value for property kafka.custom.users resolved as null"
     }
 
     void "test override consumer default properties"() {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -154,7 +154,8 @@ class KafkaConfigurationSpec extends Specification {
         then:
         BeanInstantiationException exception = thrown()
         exception.cause instanceof ConfigurationException
-        exception.cause.message == "Value for property kafka.custom.users resolved as null"
+        exception.cause.message.contains("kafka.custom.users")
+        exception.cause.message.contains("resolved as null")
     }
 
     void "test override consumer default properties"() {


### PR DESCRIPTION
## Summary

- fail fast when a kafka.* property resolves to null
- report the full kafka property path in the configuration error
- add a regression test covering a custom null kafka property
 
Resolves #1236