### PR TITLE
Bump managed-kafka version to 3.9.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ micronaut-docs = "3.0.0"
 micronaut-gradle-plugin = "4.5.5"
 
 # Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
-managed-kafka = '3.9.1'
+managed-kafka = '3.9.2'
 
 groovy = "4.0.27"
 


### PR DESCRIPTION
Updated managed-kafka version from 3.9.1 to 3.9.2.

see: https://github.com/advisories/GHSA-5qcv-4rpc-jp93