### PR TITLE
Fix KafkaConfigurationSpec CI regression on 6.0.x

### DIFF
--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -145,7 +145,8 @@ class KafkaConfigurationSpec extends Specification {
     @Issue('https://github.com/micronaut-projects/micronaut-kafka/issues/1127')
     void "test ssl configuration implies ssl security protocol by default"() {
         given:
-        applicationContext = ApplicationContext.run(
+        applicationContext = ApplicationContext.builder()
+                .properties(
                 ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): 'localhost:9093',
                 ('kafka.' + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG): '/tmp/client.keystore.p12',
                 ('kafka.' + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG): 'secret',
@@ -156,6 +157,9 @@ class KafkaConfigurationSpec extends Specification {
                 ("kafka." + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
                 ("kafka." + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name
         )
+                .eagerBeansEnabled(false)
+                .eagerInitSingletons(false)
+                .start()
 
         when:
         AbstractKafkaConsumerConfiguration config = applicationContext.getBean(AbstractKafkaConsumerConfiguration)
@@ -169,7 +173,8 @@ class KafkaConfigurationSpec extends Specification {
 
     void "test explicit security protocol is not overridden when ssl properties are present"() {
         given:
-        applicationContext = ApplicationContext.run(
+        applicationContext = ApplicationContext.builder()
+                .properties(
                 ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): 'localhost:9093',
                 ('kafka.' + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG): SecurityProtocol.SASL_SSL.name,
                 ('kafka.' + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG): '/tmp/client.truststore.p12',
@@ -178,6 +183,9 @@ class KafkaConfigurationSpec extends Specification {
                 ("kafka." + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
                 ("kafka." + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name
         )
+                .eagerBeansEnabled(false)
+                .eagerInitSingletons(false)
+                .start()
 
         when:
         AbstractKafkaConsumerConfiguration config = applicationContext.getBean(AbstractKafkaConsumerConfiguration)


### PR DESCRIPTION
## Summary
- update the new SSL/SASL configuration assertions in KafkaConfigurationSpec to use an ApplicationContext builder
- disable eager bean and singleton startup for those config-only tests so AdminClient is not created during context startup
- keep the original assertions intact while avoiding the 6.0.x Java CI regression introduced after #1301

## Verification
- ./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.KafkaConfigurationSpec