### PR TITLE
Clarify KafkaClient executor ordering with CompletableFuture

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaClient.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaClient.java
@@ -103,6 +103,11 @@ public @interface KafkaClient {
 
     /**
      * The executor to use to enable non-blocking producer methods.
+     * <p>
+     * For {@link java.util.concurrent.CompletableFuture} return types, each client invocation is submitted to this
+     * executor independently. Multi-threaded executors, including per-task executors such as virtual-thread
+     * executors, therefore do not preserve invocation order before calling Kafka's producer API. If producer
+     * ordering must match the order of client method calls, use a single-threaded executor or a synchronous method.
      *
      * @return The name of the executor to use
      */

--- a/src/main/docs/guide/kafkaClient/kafkaClientMethods.adoc
+++ b/src/main/docs/guide/kafkaClient/kafkaClientMethods.adoc
@@ -57,6 +57,8 @@ The following sections, which use Micronaut Reactor, cover advised configuration
 ==== Configuring An Executor
 As the `send` method of `KafkaProducer` can block the calling thread, it is recommended that you specify an executor to be used when returning either reactive types or `CompletableFuture`. This will ensure that the `send` logic is executed on a separate thread from that of the caller, and avoid undesirable conditions such as blocking of the Micronaut server's event loop.
 
+When using `CompletableFuture`, each ann:configuration.kafka.annotation.KafkaClient[] method invocation is submitted to the configured executor independently. If that executor can run multiple tasks concurrently, for example a fixed thread pool with more than one thread or a virtual-thread-per-task executor, the order in which your client methods are called is not guaranteed to match the order in which `KafkaProducer.send` is invoked. If producer call ordering matters, use a single-threaded executor or a synchronous method instead.
+
 The executor to be used may be specified via configuration properties as in the following example:
 [configuration]
 ----

--- a/src/main/docs/guide/kafkaQuickStart.adoc
+++ b/src/main/docs/guide/kafkaQuickStart.adoc
@@ -84,7 +84,7 @@ At compile time Micronaut will produce an implementation of the above interface.
 
 snippet::io.micronaut.kafka.docs.quickstart.QuickstartTest[tags=quickstart, indent=0]
 
-Note that since the `sendProduct` method returns `void` this means the method will send the `ProducerRecord` and block until the response is received. You can specify an executor and return either a `CompletableFuture` or rs:Publisher[] to support non-blocking message delivery.
+Note that since the `sendProduct` method returns `void` this means the method will send the `ProducerRecord` and block until the response is received. You can specify an executor and return either a `CompletableFuture` or rs:Publisher[] to support non-blocking message delivery. When using `CompletableFuture`, a multi-threaded or per-task executor does not preserve invocation order between client method calls, so use a single-threaded executor if producer call ordering matters.
 
 == Creating a Kafka Consumer with @KafkaListener
 


### PR DESCRIPTION
## Summary

- Clarify that `@KafkaClient` methods returning `CompletableFuture` submit work to the configured executor independently
- Document that multi-threaded and per-task executors can reorder producer calls before `KafkaProducer.send` is invoked
- Recommend using a single-threaded executor or synchronous method when producer call ordering matters

## Verification

- `./gradlew :micronaut-kafka:compileJava -q`

Resolves #1275
