### PR TITLE
Fix recovery for expired transactional producers

### DIFF
--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation mnMicrometer.micronaut.micrometer.registry.prometheus
     testImplementation(projects.testSuiteKafkaUtils)
     testImplementation(mnTest.junit.jupiter.api)
+    testImplementation libs.awaitility
 
     testRuntimeOnly mnMicrometer.micronaut.micrometer.registry.statsd
     testRuntimeOnly mnTracing.micronaut.tracing.core

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     api libs.managed.kafka.clients
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.kafka)
+    testImplementation("org.apache.kafka:kafka_2.13:${libs.versions.managed.kafka.get()}")
+    testImplementation("org.apache.kafka:kafka-server:${libs.versions.managed.kafka.get()}")
     compileOnly mnMicrometer.micronaut.micrometer.core
     compileOnly libs.zipkin.brave.kafka.clients
     compileOnly mn.micronaut.graal
@@ -25,7 +27,9 @@ dependencies {
     testImplementation mn.micronaut.http.client
     testImplementation mnMicrometer.micronaut.micrometer.registry.prometheus
     testImplementation(projects.testSuiteKafkaUtils)
+    testImplementation(mnTest.junit.jupiter.api)
 
     testRuntimeOnly mnMicrometer.micronaut.micrometer.registry.statsd
     testRuntimeOnly mnTracing.micronaut.tracing.core
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -16,8 +16,6 @@ dependencies {
     api libs.managed.kafka.clients
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.kafka)
-    testImplementation("org.apache.kafka:kafka_2.13:${libs.versions.managed.kafka.get()}")
-    testImplementation("org.apache.kafka:kafka-server:${libs.versions.managed.kafka.get()}")
     compileOnly mnMicrometer.micronaut.micrometer.core
     compileOnly libs.zipkin.brave.kafka.clients
     compileOnly mn.micronaut.graal

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
@@ -34,6 +34,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.reflect.InstantiationUtils;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
@@ -51,6 +52,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
 
 /**
  * A registry class for Kafka {@link org.apache.kafka.clients.producer.Producer} instances.
@@ -172,42 +175,75 @@ public class KafkaProducerFactory implements ProducerRegistry, TransactionalProd
             AbstractKafkaProducerConfiguration config = clientId.flatMap(this::findConfigBean)
                 .or(() -> clientId.flatMap(this::findHyphenatedConfigBean))
                 .orElseGet(this::getDefaultConfigBean);
-
-            DefaultKafkaProducerConfiguration newConfig = new DefaultKafkaProducerConfiguration(config);
-
-            Properties properties = newConfig.getConfig();
-            if (!properties.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)) {
-                Serializer<?> keySerializer = serdeRegistry.pickSerializer(keyType);
-                newConfig.setKeySerializer(keySerializer);
-            }
-
-            if (!properties.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)) {
-                Serializer<?> valueSerializer = serdeRegistry.pickSerializer(valueType);
-                newConfig.setValueSerializer(valueSerializer);
-            }
-
-            if (StringUtils.isNotEmpty(transactionalId)) {
-                properties.putIfAbsent(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
-                properties.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-            }
-
-            clientId.ifPresent(x -> properties.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, x));
-
-            if (CollectionUtils.isNotEmpty(props)) {
-                properties.putAll(props);
-            }
+            Supplier<Producer<?, ?>> producerSupplier = () -> createConfiguredProducer(config, clientId.orElse(null), transactionalId, keyType, valueType, props);
 
             if (transactional) {
                 Producer<?, ?> recovering = new RecoveringTransactionalProducer<>(
-                    () -> beanContext.createBean(Producer.class, newConfig),
+                    producerSupplier::get,
                     transactionalId
                 );
                 recovering.initTransactions();
                 return recovering;
             }
 
-            return beanContext.createBean(Producer.class, newConfig);
+            return producerSupplier.get();
         });
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Producer<?, ?> createConfiguredProducer(AbstractKafkaProducerConfiguration config,
+                                                    @Nullable String clientId,
+                                                    @Nullable String transactionalId,
+                                                    Argument<?> keyType,
+                                                    Argument<?> valueType,
+                                                    @Nullable Map<String, String> props) {
+        DefaultKafkaProducerConfiguration producerConfiguration = new DefaultKafkaProducerConfiguration(config);
+        Properties properties = producerConfiguration.getConfig();
+
+        if (StringUtils.isNotEmpty(transactionalId)) {
+            properties.putIfAbsent(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+            properties.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        }
+
+        if (StringUtils.isNotEmpty(clientId)) {
+            properties.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, clientId);
+        }
+
+        if (CollectionUtils.isNotEmpty(props)) {
+            properties.putAll(props);
+        }
+
+        if (!properties.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)) {
+            Serializer<?> keySerializer = recreateSerializer((Serializer<?>) config.getKeySerializer().orElse(null));
+            if (keySerializer == null) {
+                keySerializer = serdeRegistry.pickSerializer(keyType);
+            }
+            producerConfiguration.setKeySerializer(keySerializer);
+        } else {
+            producerConfiguration.setKeySerializer(null);
+        }
+
+        if (!properties.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)) {
+            Serializer<?> valueSerializer = recreateSerializer((Serializer<?>) config.getValueSerializer().orElse(null));
+            if (valueSerializer == null) {
+                valueSerializer = serdeRegistry.pickSerializer(valueType);
+            }
+            producerConfiguration.setValueSerializer(valueSerializer);
+        } else {
+            producerConfiguration.setValueSerializer(null);
+        }
+
+        return beanContext.createBean(Producer.class, producerConfiguration);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private @Nullable Serializer<?> recreateSerializer(@Nullable Serializer<?> serializer) {
+        if (serializer == null) {
+            return null;
+        }
+        Class<? extends Serializer> serializerType = serializer.getClass();
+        return InstantiationUtils.tryInstantiate(serializerType)
+            .orElseThrow(() -> new ConfigurationException("Unable to instantiate Kafka serializer [" + serializerType.getName() + "] for producer recovery"));
     }
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
@@ -197,12 +197,16 @@ public class KafkaProducerFactory implements ProducerRegistry, TransactionalProd
                 properties.putAll(props);
             }
 
-            Producer producer = beanContext.createBean(Producer.class, newConfig);
             if (transactional) {
+                Producer producer = new RecoveringTransactionalProducer<>(
+                    () -> beanContext.createBean(Producer.class, newConfig),
+                    transactionalId
+                );
                 producer.initTransactions();
+                return producer;
             }
 
-            return producer;
+            return beanContext.createBean(Producer.class, newConfig);
         });
     }
 
@@ -236,6 +240,7 @@ public class KafkaProducerFactory implements ProducerRegistry, TransactionalProd
         for (Map.Entry<ClientKey, Producer> e : clients.entrySet()) {
             if (e.getValue() == producer) {
                 clients.remove(e.getKey());
+                producer.close();
                 break;
             }
         }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/KafkaProducerFactory.java
@@ -198,12 +198,12 @@ public class KafkaProducerFactory implements ProducerRegistry, TransactionalProd
             }
 
             if (transactional) {
-                Producer producer = new RecoveringTransactionalProducer<>(
+                Producer<?, ?> recovering = new RecoveringTransactionalProducer<>(
                     () -> beanContext.createBean(Producer.class, newConfig),
                     transactionalId
                 );
-                producer.initTransactions();
-                return producer;
+                recovering.initTransactions();
+                return recovering;
             }
 
             return beanContext.createBean(Producer.class, newConfig);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
@@ -267,7 +267,7 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
     }
 
     private void recoverAndReplay(long callbackGeneration) {
-        List<FailedCallback<K, V>> failedCallbacks = new ArrayList<>();
+        List<FailedCallback> failedCallbacks = new ArrayList<>();
         synchronized (this) {
             if (closed || callbackGeneration != generation || !inTransaction) {
                 return;
@@ -279,13 +279,13 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
                 for (PendingSend<K, V> ps : new ArrayList<>(pendingSends)) {
                     Callback callback = ps.complete(null, e);
                     if (callback != null) {
-                        failedCallbacks.add(new FailedCallback<>(callback, e));
+                        failedCallbacks.add(new FailedCallback(callback, e));
                     }
                 }
                 completeTransaction();
             }
         }
-        for (FailedCallback<K, V> failedCallback : failedCallbacks) {
+        for (FailedCallback failedCallback : failedCallbacks) {
             failedCallback.callback().onCompletion(null, failedCallback.exception());
         }
     }
@@ -389,7 +389,7 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
         }
     }
 
-    private record FailedCallback<K, V>(Callback callback, Exception exception) {
+    private record FailedCallback(Callback callback, Exception exception) {
     }
 
     @FunctionalInterface

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.InvalidPidMappingException;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+/**
+ * Wraps a transactional Kafka producer and recreates it when Kafka expires the transactional id.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+@Internal
+public final class RecoveringTransactionalProducer<K, V> implements Producer<K, V> {
+    private static final Logger LOG = LoggerFactory.getLogger(RecoveringTransactionalProducer.class);
+
+    private final Supplier<Producer<K, V>> producerSupplier;
+    private final @Nullable String transactionalId;
+    private final List<PendingSend<K, V>> pendingSends = new ArrayList<>();
+    private @Nullable Producer<K, V> producer;
+    private boolean closed;
+    private boolean inTransaction;
+    private long generation;
+
+    public RecoveringTransactionalProducer(Supplier<Producer<K, V>> producerSupplier, @Nullable String transactionalId) {
+        this.producerSupplier = producerSupplier;
+        this.transactionalId = transactionalId;
+    }
+
+    @Override
+    public synchronized void initTransactions() {
+        currentProducer();
+    }
+
+    @Override
+    public synchronized void beginTransaction() {
+        try {
+            currentProducer().beginTransaction();
+            inTransaction = true;
+            pendingSends.clear();
+            generation++;
+        } catch (RuntimeException e) {
+            if (!isTransactionalIdExpired(e)) {
+                throw e;
+            }
+            replaceProducer();
+            producer.beginTransaction();
+            inTransaction = true;
+            pendingSends.clear();
+            generation++;
+        }
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) {
+        awaitPendingSends();
+        synchronized (this) {
+            try {
+                currentProducer().sendOffsetsToTransaction(offsets, groupMetadata);
+            } catch (RuntimeException e) {
+                if (!recoverAndRetry(e, current -> current.sendOffsetsToTransaction(offsets, groupMetadata))) {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void commitTransaction() {
+        awaitPendingSends();
+        synchronized (this) {
+            try {
+                currentProducer().commitTransaction();
+                completeTransaction();
+            } catch (RuntimeException e) {
+                if (recoverAndRetry(e, Producer::commitTransaction)) {
+                    completeTransaction();
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized void abortTransaction() {
+        try {
+            currentProducer().abortTransaction();
+        } finally {
+            completeTransaction();
+        }
+    }
+
+    @Override
+    public synchronized void registerMetricForSubscription(KafkaMetric metric) {
+        currentProducer().registerMetricForSubscription(metric);
+    }
+
+    @Override
+    public synchronized void unregisterMetricFromSubscription(KafkaMetric metric) {
+        currentProducer().unregisterMetricFromSubscription(metric);
+    }
+
+    @Override
+    public synchronized Future<RecordMetadata> send(ProducerRecord<K, V> record) {
+        return send(record, null);
+    }
+
+    @Override
+    public synchronized Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+        if (!inTransaction) {
+            return currentProducer().send(record, callback);
+        }
+        PendingSend<K, V> pendingSend = new PendingSend<>(record, callback);
+        pendingSends.add(pendingSend);
+        dispatchSend(generation, pendingSend);
+        return pendingSend.future();
+    }
+
+    @Override
+    public synchronized void flush() {
+        currentProducer().flush();
+    }
+
+    @Override
+    public synchronized List<PartitionInfo> partitionsFor(String topic) {
+        return currentProducer().partitionsFor(topic);
+    }
+
+    @Override
+    public synchronized Map<MetricName, ? extends Metric> metrics() {
+        return currentProducer().metrics();
+    }
+
+    @Override
+    public synchronized Uuid clientInstanceId(Duration timeout) {
+        return currentProducer().clientInstanceId(timeout);
+    }
+
+    @Override
+    public synchronized void close() {
+        close(Duration.ofSeconds(30));
+    }
+
+    @Override
+    public synchronized void close(Duration timeout) {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        closeProducer(producer, timeout);
+        producer = null;
+        pendingSends.clear();
+        inTransaction = false;
+    }
+
+    private Producer<K, V> currentProducer() {
+        if (closed) {
+            throw new IllegalStateException("Producer is already closed");
+        }
+        if (producer == null) {
+            producer = producerSupplier.get();
+            producer.initTransactions();
+        }
+        return producer;
+    }
+
+    private void dispatchSend(long currentGeneration, PendingSend<K, V> pendingSend) {
+        Producer<K, V> current = currentProducer();
+        try {
+            current.send(pendingSend.record(), (metadata, exception) -> handleSendResult(currentGeneration, pendingSend, metadata, exception));
+        } catch (RuntimeException e) {
+            handleSendFailure(currentGeneration, pendingSend, e);
+        }
+    }
+
+    private void handleSendResult(long callbackGeneration, PendingSend<K, V> pendingSend, @Nullable RecordMetadata metadata, @Nullable Exception exception) {
+        Callback callbackToInvoke = null;
+        RecordMetadata callbackMetadata = metadata;
+        Exception callbackException = exception;
+        synchronized (this) {
+            if (closed || callbackGeneration != generation || !inTransaction) {
+                return;
+            }
+            if (exception != null && isTransactionalIdExpired(exception)) {
+                try {
+                    replayTransaction();
+                    return;
+                } catch (RuntimeException replayException) {
+                    callbackException = replayException;
+                }
+            }
+            callbackToInvoke = pendingSend.complete(callbackMetadata, callbackException);
+        }
+        if (callbackToInvoke != null) {
+            callbackToInvoke.onCompletion(callbackMetadata, callbackException);
+        }
+    }
+
+    private void handleSendFailure(long callbackGeneration, PendingSend<K, V> pendingSend, RuntimeException exception) {
+        Callback callbackToInvoke = null;
+        synchronized (this) {
+            if (closed || callbackGeneration != generation || !inTransaction) {
+                return;
+            }
+            if (isTransactionalIdExpired(exception)) {
+                try {
+                    replayTransaction();
+                    return;
+                } catch (RuntimeException replayException) {
+                    exception = replayException;
+                }
+            }
+            callbackToInvoke = pendingSend.complete(null, exception);
+        }
+        if (callbackToInvoke != null) {
+            callbackToInvoke.onCompletion(null, exception);
+        }
+    }
+
+    private boolean recoverAndRetry(RuntimeException exception, ProducerOperation<K, V> retry) {
+        if (!isTransactionalIdExpired(exception)) {
+            return false;
+        }
+        replayTransaction();
+        retry.run(currentProducer());
+        return true;
+    }
+
+    private void replayTransaction() {
+        LOG.debug("Recreating transactional producer for transactional.id [{}] after Kafka expired the producer id", transactionalId);
+        replaceProducer();
+        generation++;
+        producer.beginTransaction();
+        for (PendingSend<K, V> pendingSend : pendingSends) {
+            dispatchSend(generation, pendingSend);
+        }
+        inTransaction = true;
+    }
+
+    private void replaceProducer() {
+        Producer<K, V> previous = producer;
+        producer = producerSupplier.get();
+        producer.initTransactions();
+        closeProducer(previous, Duration.ZERO);
+    }
+
+    private void completeTransaction() {
+        inTransaction = false;
+        pendingSends.clear();
+    }
+
+    private void awaitPendingSends() {
+        List<CompletableFuture<RecordMetadata>> futures;
+        synchronized (this) {
+            futures = pendingSends.stream()
+                .map(PendingSend::future)
+                .toList();
+        }
+        for (CompletableFuture<RecordMetadata> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new KafkaException("Interrupted while awaiting transactional send completion", e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                throw new KafkaException("Transactional send failed", cause);
+            }
+        }
+    }
+
+    private static boolean isTransactionalIdExpired(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof InvalidPidMappingException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return throwable instanceof KafkaException kafkaException
+            && kafkaException.getMessage() != null
+            && kafkaException.getMessage().contains("error state");
+    }
+
+    private static void closeProducer(@Nullable Producer<?, ?> producer, Duration timeout) {
+        if (producer == null) {
+            return;
+        }
+        try {
+            producer.close(timeout);
+        } catch (Exception e) {
+            LOG.debug("Error closing expired transactional producer: {}", e.getMessage(), e);
+        }
+    }
+
+    private record PendingSend<K, V>(ProducerRecord<K, V> record,
+                                     @Nullable Callback callback,
+                                     CompletableFuture<RecordMetadata> future) {
+        private PendingSend(ProducerRecord<K, V> record, @Nullable Callback callback) {
+            this(record, callback, new CompletableFuture<>());
+        }
+
+        private @Nullable Callback complete(@Nullable RecordMetadata metadata, @Nullable Exception exception) {
+            if (future.isDone()) {
+                return null;
+            }
+            if (exception == null) {
+                future.complete(metadata);
+            } else {
+                future.completeExceptionally(exception);
+            }
+            return callback;
+        }
+    }
+
+    @FunctionalInterface
+    private interface ProducerOperation<K, V> {
+        void run(Producer<K, V> producer);
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
@@ -56,6 +58,7 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
     private final Supplier<Producer<K, V>> producerSupplier;
     private final @Nullable String transactionalId;
     private final List<PendingSend<K, V>> pendingSends = new ArrayList<>();
+    private @Nullable ExecutorService recoveryExecutor;
     private @Nullable Producer<K, V> producer;
     private boolean closed;
     private boolean inTransaction;
@@ -187,6 +190,9 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
             return;
         }
         closed = true;
+        if (recoveryExecutor != null) {
+            recoveryExecutor.shutdownNow();
+        }
         closeProducer(producer, timeout);
         producer = null;
         pendingSends.clear();
@@ -222,12 +228,9 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
                 return;
             }
             if (exception != null && isTransactionalIdExpired(exception)) {
-                try {
-                    replayTransaction();
-                    return;
-                } catch (RuntimeException replayException) {
-                    callbackException = replayException;
-                }
+                long gen = generation;
+                recoveryExecutor().execute(() -> recoverAndReplay(gen));
+                return;
             }
             callbackToInvoke = pendingSend.complete(callbackMetadata, callbackException);
         }
@@ -243,12 +246,9 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
                 return;
             }
             if (isTransactionalIdExpired(exception)) {
-                try {
-                    replayTransaction();
-                    return;
-                } catch (RuntimeException replayException) {
-                    exception = replayException;
-                }
+                long gen = generation;
+                recoveryExecutor().execute(() -> recoverAndReplay(gen));
+                return;
             }
             callbackToInvoke = pendingSend.complete(null, exception);
         }
@@ -264,6 +264,34 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
         replayTransaction();
         retry.run(currentProducer());
         return true;
+    }
+
+    private void recoverAndReplay(long callbackGeneration) {
+        synchronized (this) {
+            if (closed || callbackGeneration != generation || !inTransaction) {
+                return;
+            }
+            try {
+                replayTransaction();
+            } catch (RuntimeException e) {
+                LOG.warn("Failed to recover transactional producer [{}] after transactional id expiration: {}", transactionalId, e.getMessage(), e);
+                for (PendingSend<K, V> ps : new ArrayList<>(pendingSends)) {
+                    ps.complete(null, e);
+                }
+                completeTransaction();
+            }
+        }
+    }
+
+    private ExecutorService recoveryExecutor() {
+        if (recoveryExecutor == null) {
+            recoveryExecutor = Executors.newSingleThreadExecutor(r -> {
+                var t = new Thread(r, "kafka-transactional-recovery");
+                t.setDaemon(true);
+                return t;
+            });
+        }
+        return recoveryExecutor;
     }
 
     private void replayTransaction() {
@@ -320,9 +348,7 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
             }
             current = current.getCause();
         }
-        return throwable instanceof KafkaException kafkaException
-            && kafkaException.getMessage() != null
-            && kafkaException.getMessage().contains("error state");
+        return false;
     }
 
     private static void closeProducer(@Nullable Producer<?, ?> producer, Duration timeout) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,6 +267,7 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
     }
 
     private void recoverAndReplay(long callbackGeneration) {
+        List<FailedCallback<K, V>> failedCallbacks = new ArrayList<>();
         synchronized (this) {
             if (closed || callbackGeneration != generation || !inTransaction) {
                 return;
@@ -276,10 +277,16 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
             } catch (RuntimeException e) {
                 LOG.warn("Failed to recover transactional producer [{}] after transactional id expiration: {}", transactionalId, e.getMessage(), e);
                 for (PendingSend<K, V> ps : new ArrayList<>(pendingSends)) {
-                    ps.complete(null, e);
+                    Callback callback = ps.complete(null, e);
+                    if (callback != null) {
+                        failedCallbacks.add(new FailedCallback<>(callback, e));
+                    }
                 }
                 completeTransaction();
             }
+        }
+        for (FailedCallback<K, V> failedCallback : failedCallbacks) {
+            failedCallback.callback().onCompletion(null, failedCallback.exception());
         }
     }
 
@@ -380,6 +387,9 @@ public final class RecoveringTransactionalProducer<K, V> implements Producer<K, 
             }
             return callback;
         }
+    }
+
+    private record FailedCallback<K, V>(Callback callback, Exception exception) {
     }
 
     @FunctionalInterface

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -19,6 +19,7 @@ import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBean;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.configuration.kafka.RecoveringTransactionalProducer;
 import io.micronaut.configuration.kafka.annotation.*;
 import io.micronaut.configuration.kafka.config.AbstractKafkaProducerConfiguration;
 import io.micronaut.configuration.kafka.config.DefaultKafkaProducerConfiguration;
@@ -727,9 +728,16 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
                 }
             }
 
-            Producer<?, ?> producer = beanContext.createBean(Producer.class, newConfiguration);
-
             boolean transactional = StringUtils.isNotEmpty(transactionalId);
+            Producer<?, ?> producer;
+            if (transactional) {
+                producer = new RecoveringTransactionalProducer<>(
+                    () -> beanContext.createBean(Producer.class, newConfiguration),
+                    transactionalId
+                );
+            } else {
+                producer = beanContext.createBean(Producer.class, newConfiguration);
+            }
             timestampSupplier = context.isTrue(KafkaClient.class, "timestamp") ? ctx -> System.currentTimeMillis() : timestampSupplier;
             Duration maxBlock = context.getValue(KafkaClient.class, "maxBlock", Duration.class).orElse(null);
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -34,6 +34,7 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.StringUtils;
@@ -701,42 +702,50 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
 
             LOG.debug("Creating new KafkaProducer.");
 
-            if (!newProperties.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)) {
-                Serializer<?> keySerializer = newConfiguration.getKeySerializer().orElse(null);
-                if (keySerializer == null) {
-                    if (keyArgument != null) {
-                        keySerializer = serdeRegistry.pickSerializer(keyArgument);
-                    } else {
-                        keySerializer = new ByteArraySerializer();
+            boolean isBatchSend = context.isTrue(KafkaClient.class, "batch");
+            boolean transactional = StringUtils.isNotEmpty(transactionalId);
+            Argument<?> finalKeyArgument = keyArgument;
+            Argument<?> finalBodyArgument = bodyArgument;
+            Argument<?> finalValueArgument = isBatchSend ? finalBodyArgument.getFirstTypeVariable().orElse(finalBodyArgument) : finalBodyArgument;
+            ProducerSupplier producerSupplier = () -> {
+                DefaultKafkaProducerConfiguration<?, ?> producerConfiguration = new DefaultKafkaProducerConfiguration(configuration);
+                Properties producerProperties = producerConfiguration.getConfig();
+                producerProperties.putAll(newProperties);
+
+                if (!producerProperties.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)) {
+                    Serializer<?> keySerializer = recreateSerializer((Serializer<?>) configuration.getKeySerializer().orElse(null));
+                    if (keySerializer == null) {
+                        keySerializer = finalKeyArgument != null ? serdeRegistry.pickSerializer(finalKeyArgument) : new ByteArraySerializer();
                     }
 
                     LOG.debug("Using Kafka key serializer: {}", keySerializer);
-                    newConfiguration.setKeySerializer((Serializer) keySerializer);
+                    producerConfiguration.setKeySerializer((Serializer) keySerializer);
+                } else {
+                    producerConfiguration.setKeySerializer(null);
                 }
-            }
 
-            boolean isBatchSend = context.isTrue(KafkaClient.class, "batch");
-
-            if (!newProperties.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)) {
-                Serializer<?> valueSerializer = newConfiguration.getValueSerializer().orElse(null);
-
-                if (valueSerializer == null) {
-                    valueSerializer = serdeRegistry.pickSerializer(isBatchSend ? bodyArgument.getFirstTypeVariable().orElse(bodyArgument) : bodyArgument);
+                if (!producerProperties.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)) {
+                    Serializer<?> valueSerializer = recreateSerializer((Serializer<?>) configuration.getValueSerializer().orElse(null));
+                    if (valueSerializer == null) {
+                        valueSerializer = serdeRegistry.pickSerializer((Argument) finalValueArgument);
+                    }
 
                     LOG.debug("Using Kafka value serializer: {}", valueSerializer);
-                    newConfiguration.setValueSerializer((Serializer) valueSerializer);
+                    producerConfiguration.setValueSerializer((Serializer) valueSerializer);
+                } else {
+                    producerConfiguration.setValueSerializer(null);
                 }
-            }
 
-            boolean transactional = StringUtils.isNotEmpty(transactionalId);
+                return beanContext.createBean(Producer.class, producerConfiguration);
+            };
             Producer<?, ?> producer;
             if (transactional) {
                 producer = new RecoveringTransactionalProducer<>(
-                    () -> beanContext.createBean(Producer.class, newConfiguration),
+                    producerSupplier::create,
                     transactionalId
                 );
             } else {
-                producer = beanContext.createBean(Producer.class, newConfiguration);
+                producer = producerSupplier.create();
             }
             timestampSupplier = context.isTrue(KafkaClient.class, "timestamp") ? ctx -> System.currentTimeMillis() : timestampSupplier;
             Duration maxBlock = context.getValue(KafkaClient.class, "maxBlock", Duration.class).orElse(null);
@@ -787,6 +796,21 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
     @SuppressWarnings("rawtypes")
     private AbstractKafkaProducerConfiguration getDefaultConfigBean() {
         return beanContext.getBean(AbstractKafkaProducerConfiguration.class);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private @Nullable Serializer<?> recreateSerializer(@Nullable Serializer<?> serializer) {
+        if (serializer == null) {
+            return null;
+        }
+        Class<? extends Serializer> serializerType = serializer.getClass();
+        return InstantiationUtils.tryInstantiate(serializerType)
+            .orElseThrow(() -> new MessagingClientException("Unable to instantiate Kafka serializer [" + serializerType.getName() + "] for producer recovery"));
+    }
+
+    @FunctionalInterface
+    private interface ProducerSupplier {
+        Producer<?, ?> create();
     }
 
     private static String logMethod(ExecutableMethod<?, ?> method) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -707,8 +707,8 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
             Argument<?> finalKeyArgument = keyArgument;
             Argument<?> finalBodyArgument = bodyArgument;
             Argument<?> finalValueArgument = isBatchSend ? finalBodyArgument.getFirstTypeVariable().orElse(finalBodyArgument) : finalBodyArgument;
-            ProducerSupplier producerSupplier = () -> {
-                DefaultKafkaProducerConfiguration<?, ?> producerConfiguration = new DefaultKafkaProducerConfiguration(configuration);
+            ProducerSupplier<Object, Object> producerSupplier = () -> {
+                DefaultKafkaProducerConfiguration<Object, Object> producerConfiguration = new DefaultKafkaProducerConfiguration<>(configuration);
                 Properties producerProperties = producerConfiguration.getConfig();
                 producerProperties.putAll(newProperties);
 
@@ -719,7 +719,7 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
                     }
 
                     LOG.debug("Using Kafka key serializer: {}", keySerializer);
-                    producerConfiguration.setKeySerializer((Serializer) keySerializer);
+                    producerConfiguration.setKeySerializer((Serializer<Object>) keySerializer);
                 } else {
                     producerConfiguration.setKeySerializer(null);
                 }
@@ -731,14 +731,14 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
                     }
 
                     LOG.debug("Using Kafka value serializer: {}", valueSerializer);
-                    producerConfiguration.setValueSerializer((Serializer) valueSerializer);
+                    producerConfiguration.setValueSerializer((Serializer<Object>) valueSerializer);
                 } else {
                     producerConfiguration.setValueSerializer(null);
                 }
 
-                return beanContext.createBean(Producer.class, producerConfiguration);
+                return (Producer<Object, Object>) beanContext.createBean(Producer.class, producerConfiguration);
             };
-            Producer<?, ?> producer;
+            Producer<Object, Object> producer;
             if (transactional) {
                 producer = new RecoveringTransactionalProducer<>(
                     producerSupplier::create,
@@ -808,11 +808,6 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
             .orElseThrow(() -> new MessagingClientException("Unable to instantiate Kafka serializer [" + serializerType.getName() + "] for producer recovery"));
     }
 
-    @FunctionalInterface
-    private interface ProducerSupplier {
-        Producer<?, ?> create();
-    }
-
     private static String logMethod(ExecutableMethod<?, ?> method) {
         return method.getDeclaringType().getSimpleName() + "#" + method.getName();
     }
@@ -839,6 +834,11 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
             return apply(ctx);
         }
 
+    }
+
+    @FunctionalInterface
+    private interface ProducerSupplier<K, V> {
+        Producer<K, V> create();
     }
 
     /**

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.InvalidPidMappingException;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecoveringTransactionalProducerTest {
+    private static final ProducerRecord<String, String> RECORD = new ProducerRecord<>("topic", "value");
+
+    @Test
+    void delegatesNonTransactionalOperationsToCurrentProducer() throws Exception {
+        StubProducer producer = new StubProducer().enqueueSend(SendBehavior.success());
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(() -> producer, "tx");
+
+        recoveringProducer.initTransactions();
+        Future<RecordMetadata> future = recoveringProducer.send(RECORD);
+
+        assertNotNull(assertDoesNotThrow(() -> future.get()));
+        recoveringProducer.flush();
+        assertSame(producer.partitions, recoveringProducer.partitionsFor("topic"));
+        assertSame(producer.metrics, recoveringProducer.metrics());
+        assertSame(producer.clientInstanceId, recoveringProducer.clientInstanceId(Duration.ofSeconds(1)));
+        recoveringProducer.registerMetricForSubscription(null);
+        recoveringProducer.unregisterMetricFromSubscription(null);
+        recoveringProducer.close(Duration.ofSeconds(5));
+        recoveringProducer.close(Duration.ofSeconds(1));
+
+        assertEquals(1, producer.initTransactionsCount);
+        assertEquals(1, producer.sendRecords.size());
+        assertEquals(1, producer.flushCount);
+        assertEquals(1, producer.registerMetricCount);
+        assertEquals(1, producer.unregisterMetricCount);
+        assertEquals(List.of(Duration.ofSeconds(5)), producer.closeTimeouts);
+    }
+
+    @Test
+    void recreatesProducerWhenBeginTransactionFailsWithExpiredPid() {
+        StubProducer first = new StubProducer().enqueueBeginException(new InvalidPidMappingException("expired"));
+        StubProducer second = new StubProducer();
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(supplier(first, second), "tx");
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+
+        assertEquals(1, first.beginTransactionCount);
+        assertEquals(1, first.initTransactionsCount);
+        assertEquals(List.of(Duration.ZERO), first.closeTimeouts);
+        assertEquals(1, second.initTransactionsCount);
+        assertEquals(1, second.beginTransactionCount);
+    }
+
+    @Test
+    void replaysPendingTransactionalSendsWhenCallbackSignalsExpiredProducer() throws Exception {
+        StubProducer first = new StubProducer().enqueueSend(SendBehavior.callbackFailure(new InvalidPidMappingException("expired")));
+        StubProducer second = new StubProducer().enqueueSend(SendBehavior.success());
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(supplier(first, second), "tx");
+        AtomicReference<RecordMetadata> callbackMetadata = new AtomicReference<>();
+        AtomicReference<Exception> callbackException = new AtomicReference<>();
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+        Future<RecordMetadata> future = recoveringProducer.send(RECORD, (metadata, exception) -> {
+            callbackMetadata.set(metadata);
+            callbackException.set(exception);
+        });
+        recoveringProducer.commitTransaction();
+
+        RecordMetadata metadata = future.get();
+        assertNotNull(metadata);
+        assertSame(metadata, callbackMetadata.get());
+        assertEquals(null, callbackException.get());
+        assertEquals(1, first.sendRecords.size());
+        assertEquals(1, second.sendRecords.size());
+        assertEquals(1, second.beginTransactionCount);
+        assertEquals(1, second.commitTransactionCount);
+        assertEquals(List.of(Duration.ZERO), first.closeTimeouts);
+    }
+
+    @Test
+    void retriesOffsetsAndCommitAfterRecoverableProducerExpiration() throws Exception {
+        StubProducer first = new StubProducer()
+            .enqueueSend(SendBehavior.success())
+            .enqueueSendOffsetsException(new InvalidPidMappingException("expired"));
+        StubProducer second = new StubProducer().enqueueSend(SendBehavior.success());
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(supplier(first, second), "tx");
+        Map<TopicPartition, OffsetAndMetadata> offsets = Map.of(new TopicPartition("topic", 0), new OffsetAndMetadata(1L));
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+        Future<RecordMetadata> future = recoveringProducer.send(RECORD);
+        recoveringProducer.sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata("group"));
+        recoveringProducer.commitTransaction();
+
+        assertNotNull(assertDoesNotThrow(() -> future.get()));
+        assertEquals(1, first.sendOffsetsToTransactionCount);
+        assertEquals(1, second.sendOffsetsToTransactionCount);
+        assertEquals(1, second.commitTransactionCount);
+        assertEquals(1, second.sendRecords.size());
+        assertEquals(List.of(Duration.ZERO), first.closeTimeouts);
+    }
+
+    @Test
+    void abortAndCloseClearStateAndRejectFurtherUse() {
+        StubProducer producer = new StubProducer().enqueueSend(SendBehavior.success());
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(() -> producer, "tx");
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+        assertDoesNotThrow(() -> recoveringProducer.send(RECORD).get());
+        recoveringProducer.abortTransaction();
+        recoveringProducer.close();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, recoveringProducer::initTransactions);
+        assertTrue(exception.getMessage().contains("already closed"));
+        assertEquals(1, producer.abortTransactionCount);
+        assertEquals(List.of(Duration.ofSeconds(30)), producer.closeTimeouts);
+    }
+
+    @Test
+    void propagatesSynchronousSendFailuresAndWrappedCheckedFailures() {
+        StubProducer producer = new StubProducer().enqueueSend(SendBehavior.throwing(new KafkaException("boom")));
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(() -> producer, "tx");
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+
+        ExecutionException sendException = assertThrows(ExecutionException.class, () -> recoveringProducer.send(RECORD).get());
+        assertInstanceOf(KafkaException.class, sendException.getCause());
+        assertTrue(sendException.getCause().getMessage().contains("boom"));
+        recoveringProducer.abortTransaction();
+
+        RecoveringTransactionalProducer<String, String> checkedFailureProducer =
+            new RecoveringTransactionalProducer<>(() -> new StubProducer().enqueueSend(SendBehavior.checkedFailure()), "tx");
+        checkedFailureProducer.initTransactions();
+        checkedFailureProducer.beginTransaction();
+        checkedFailureProducer.send(RECORD);
+
+        KafkaException kafkaException = assertThrows(KafkaException.class, checkedFailureProducer::commitTransaction);
+        assertTrue(kafkaException.getMessage().contains("Transactional send failed"));
+        assertInstanceOf(Exception.class, kafkaException.getCause());
+    }
+
+    private static java.util.function.Supplier<Producer<String, String>> supplier(StubProducer... producers) {
+        Deque<StubProducer> deque = new ArrayDeque<>(List.of(producers));
+        return deque::removeFirst;
+    }
+
+    private static final class StubProducer implements Producer<String, String> {
+        private final Deque<RuntimeException> beginExceptions = new ArrayDeque<>();
+        private final Deque<RuntimeException> sendOffsetsExceptions = new ArrayDeque<>();
+        private final Deque<RuntimeException> commitExceptions = new ArrayDeque<>();
+        private final Deque<SendBehavior> sendBehaviors = new ArrayDeque<>();
+        private final List<ProducerRecord<String, String>> sendRecords = new ArrayList<>();
+        private final List<Duration> closeTimeouts = new ArrayList<>();
+        private final List<PartitionInfo> partitions = List.of(new PartitionInfo("topic", 0, null, null, null));
+        private final Map<MetricName, Metric> metrics = Map.of();
+        private final Uuid clientInstanceId = Uuid.randomUuid();
+
+        private int initTransactionsCount;
+        private int beginTransactionCount;
+        private int sendOffsetsToTransactionCount;
+        private int commitTransactionCount;
+        private int abortTransactionCount;
+        private int flushCount;
+        private int registerMetricCount;
+        private int unregisterMetricCount;
+
+        private StubProducer enqueueBeginException(RuntimeException exception) {
+            beginExceptions.add(exception);
+            return this;
+        }
+
+        private StubProducer enqueueSendOffsetsException(RuntimeException exception) {
+            sendOffsetsExceptions.add(exception);
+            return this;
+        }
+
+        private StubProducer enqueueCommitException(RuntimeException exception) {
+            commitExceptions.add(exception);
+            return this;
+        }
+
+        private StubProducer enqueueSend(SendBehavior behavior) {
+            sendBehaviors.add(behavior);
+            return this;
+        }
+
+        @Override
+        public void initTransactions() {
+            initTransactionsCount++;
+        }
+
+        @Override
+        public void beginTransaction() {
+            beginTransactionCount++;
+            if (!beginExceptions.isEmpty()) {
+                throw beginExceptions.removeFirst();
+            }
+        }
+
+        @Override
+        public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) {
+            sendOffsetsToTransactionCount++;
+            if (!sendOffsetsExceptions.isEmpty()) {
+                throw sendOffsetsExceptions.removeFirst();
+            }
+        }
+
+        @Override
+        public void commitTransaction() {
+            commitTransactionCount++;
+            if (!commitExceptions.isEmpty()) {
+                throw commitExceptions.removeFirst();
+            }
+        }
+
+        @Override
+        public void abortTransaction() {
+            abortTransactionCount++;
+        }
+
+        @Override
+        public void registerMetricForSubscription(KafkaMetric metric) {
+            registerMetricCount++;
+        }
+
+        @Override
+        public void unregisterMetricFromSubscription(KafkaMetric metric) {
+            unregisterMetricCount++;
+        }
+
+        @Override
+        public Future<RecordMetadata> send(ProducerRecord<String, String> record) {
+            return send(record, null);
+        }
+
+        @Override
+        public Future<RecordMetadata> send(ProducerRecord<String, String> record, Callback callback) {
+            sendRecords.add(record);
+            SendBehavior behavior = sendBehaviors.isEmpty() ? SendBehavior.success() : sendBehaviors.removeFirst();
+            return switch (behavior.kind) {
+                case SUCCESS -> complete(record, callback);
+                case CALLBACK_FAILURE -> failWithCallback(callback, behavior.callbackException);
+                case THROW -> throw behavior.runtimeException;
+                case CHECKED_FAILURE -> completeExceptionally(callback, new Exception("checked failure"));
+            };
+        }
+
+        @Override
+        public void flush() {
+            flushCount++;
+        }
+
+        @Override
+        public List<PartitionInfo> partitionsFor(String topic) {
+            return partitions;
+        }
+
+        @Override
+        public Map<MetricName, ? extends Metric> metrics() {
+            return metrics;
+        }
+
+        @Override
+        public Uuid clientInstanceId(Duration timeout) {
+            return clientInstanceId;
+        }
+
+        @Override
+        public void close() {
+            close(Duration.ofSeconds(30));
+        }
+
+        @Override
+        public void close(Duration timeout) {
+            closeTimeouts.add(timeout);
+        }
+
+        private Future<RecordMetadata> complete(ProducerRecord<String, String> record, Callback callback) {
+            RecordMetadata metadata = new RecordMetadata(new TopicPartition(record.topic(), 0), 0, 0, 0L, 0, 0);
+            if (callback != null) {
+                callback.onCompletion(metadata, null);
+            }
+            return CompletableFuture.completedFuture(metadata);
+        }
+
+        private Future<RecordMetadata> failWithCallback(Callback callback, Exception exception) {
+            if (callback != null) {
+                callback.onCompletion(null, exception);
+            }
+            CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+            future.completeExceptionally(exception);
+            return future;
+        }
+
+        private Future<RecordMetadata> completeExceptionally(Callback callback, Exception exception) {
+            if (callback != null) {
+                callback.onCompletion(null, exception);
+            }
+            CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+            future.completeExceptionally(exception);
+            return future;
+        }
+    }
+
+    private static final class SendBehavior {
+        private final Kind kind;
+        private final RuntimeException runtimeException;
+        private final Exception callbackException;
+
+        private SendBehavior(Kind kind, RuntimeException runtimeException, Exception callbackException) {
+            this.kind = kind;
+            this.runtimeException = runtimeException;
+            this.callbackException = callbackException;
+        }
+
+        private static SendBehavior success() {
+            return new SendBehavior(Kind.SUCCESS, null, null);
+        }
+
+        private static SendBehavior callbackFailure(Exception exception) {
+            return new SendBehavior(Kind.CALLBACK_FAILURE, null, exception);
+        }
+
+        private static SendBehavior throwing(RuntimeException exception) {
+            return new SendBehavior(Kind.THROW, exception, null);
+        }
+
+        private static SendBehavior checkedFailure() {
+            return new SendBehavior(Kind.CHECKED_FAILURE, null, null);
+        }
+
+        private enum Kind {
+            SUCCESS,
+            CALLBACK_FAILURE,
+            THROW,
+            CHECKED_FAILURE
+        }
+    }
+}

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,6 +190,26 @@ class RecoveringTransactionalProducerTest {
         KafkaException kafkaException = assertThrows(KafkaException.class, checkedFailureProducer::commitTransaction);
         assertTrue(kafkaException.getMessage().contains("Transactional send failed"));
         assertInstanceOf(Exception.class, kafkaException.getCause());
+    }
+
+    @Test
+    void notifiesCallbacksWhenReplayRecoveryFails() {
+        StubProducer first = new StubProducer().enqueueSend(SendBehavior.callbackFailure(new InvalidPidMappingException("expired")));
+        StubProducer second = new StubProducer().enqueueBeginException(new KafkaException("recovery failed"));
+        RecoveringTransactionalProducer<String, String> recoveringProducer =
+            new RecoveringTransactionalProducer<>(supplier(first, second), "tx");
+        AtomicReference<Exception> callbackException = new AtomicReference<>();
+
+        recoveringProducer.initTransactions();
+        recoveringProducer.beginTransaction();
+        Future<RecordMetadata> future = recoveringProducer.send(RECORD, (metadata, exception) -> callbackException.set(exception));
+
+        ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+
+        assertInstanceOf(KafkaException.class, exception.getCause());
+        assertTrue(exception.getCause().getMessage().contains("recovery failed"));
+        assertInstanceOf(KafkaException.class, callbackException.get());
+        assertTrue(callbackException.get().getMessage().contains("recovery failed"));
     }
 
     private static java.util.function.Supplier<Producer<String, String>> supplier(StubProducer... producers) {

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/RecoveringTransactionalProducerTest.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.kafka;
 
+import org.awaitility.Awaitility;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -208,7 +209,7 @@ class RecoveringTransactionalProducerTest {
 
         assertInstanceOf(KafkaException.class, exception.getCause());
         assertTrue(exception.getCause().getMessage().contains("recovery failed"));
-        assertInstanceOf(KafkaException.class, callbackException.get());
+        Awaitility.await().untilAsserted(() -> assertInstanceOf(KafkaException.class, callbackException.get()));
         assertTrue(callbackException.get().getMessage().contains("recovery failed"));
     }
 

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
@@ -24,14 +24,20 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.TransactionalIdNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class TransactionalProducerExpirationReproducerTest {
@@ -61,7 +67,7 @@ public class TransactionalProducerExpirationReproducerTest {
                 );
 
                 sendTransaction(producer, topic, "first");
-                Thread.sleep(12_000);
+                waitForTransactionalIdExpiration(kafka.getBootstrapServers(), transactionalId);
 
                 assertDoesNotThrow(() -> sendTransaction(producer, topic, "second"));
             }
@@ -81,7 +87,7 @@ public class TransactionalProducerExpirationReproducerTest {
 
                 InjectedTransactionalSender sender = context.getBean(InjectedTransactionalSender.class);
                 sender.send(topic, "first").get();
-                Thread.sleep(12_000);
+                waitForTransactionalIdExpiration(kafka.getBootstrapServers(), TRANSACTIONAL_ID);
 
                 assertDoesNotThrow(() -> sender.send(topic, "second").get());
             }
@@ -95,7 +101,7 @@ public class TransactionalProducerExpirationReproducerTest {
     }
 
     private static KafkaContainer createKafkaContainer() {
-        return new KafkaContainer("apache/kafka:4.2.0")
+        return new KafkaContainer(DockerImageName.parse("apache/kafka:4.2.0"))
             .withEnv("KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS", Integer.toString(TRANSACTIONAL_ID_EXPIRATION_MS))
             .withEnv("KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS", Integer.toString(TRANSACTION_CLEANUP_INTERVAL_MS))
             .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
@@ -103,6 +109,28 @@ public class TransactionalProducerExpirationReproducerTest {
             .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
             .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
             .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    }
+
+    private static void waitForTransactionalIdExpiration(String bootstrapServers, String transactionalId) {
+        try (AdminClient admin = AdminClient.create(Map.of(
+            AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
+        ))) {
+            await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofMillis(TRANSACTION_CLEANUP_INTERVAL_MS))
+                .until(() -> {
+                    try {
+                        admin.describeTransactions(List.of(transactionalId))
+                            .description(transactionalId)
+                            .get(2, TimeUnit.SECONDS);
+                        return false;
+                    } catch (ExecutionException e) {
+                        return e.getCause() instanceof TransactionalIdNotFoundException;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+        }
     }
 
     private static void createTopic(String bootstrapServers, String topic) throws Exception {

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
@@ -19,80 +19,98 @@ import io.micronaut.configuration.kafka.annotation.KafkaClient;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.type.Argument;
 import jakarta.inject.Singleton;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaRaftServer;
-import kafka.tools.StorageTool;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.utils.Time;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.kafka.KafkaContainer;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class TransactionalProducerExpirationReproducerTest {
     private static final String CLIENT_ID = "issue-542";
-    private static final String TOPIC = "issue-542-topic";
+    private static final int TRANSACTIONAL_ID_EXPIRATION_MS = 3_000;
+    private static final int TRANSACTION_CLEANUP_INTERVAL_MS = 500;
     private static final String TRANSACTIONAL_ID = "issue-542-tx";
 
     @Test
-    @Timeout(90)
+    @Timeout(180)
     void transactionalProducerShouldRecoverAfterTransactionalIdExpires() throws Exception {
-        try (EmbeddedKafkaBroker broker = new EmbeddedKafkaBroker(3_000, 500);
-             ApplicationContext context = ApplicationContext.run(Map.of(
-                 "kafka.bootstrap.servers", broker.bootstrapServers()
-             ))) {
-            broker.createTopic(TOPIC);
+        String topic = "issue-542-topic-" + UUID.randomUUID();
+        String transactionalId = TRANSACTIONAL_ID + "-registry-" + UUID.randomUUID();
+        try (KafkaContainer kafka = createKafkaContainer()) {
+            kafka.start();
+            try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "kafka.bootstrap.servers", kafka.getBootstrapServers()
+            ))) {
+                createTopic(kafka.getBootstrapServers(), topic);
 
-            TransactionalProducerRegistry registry = context.getBean(TransactionalProducerRegistry.class);
-            Producer<String, String> producer = registry.getTransactionalProducer(
-                CLIENT_ID,
-                TRANSACTIONAL_ID,
-                Argument.of(String.class),
-                Argument.of(String.class)
-            );
+                TransactionalProducerRegistry registry = context.getBean(TransactionalProducerRegistry.class);
+                Producer<String, String> producer = registry.getTransactionalProducer(
+                    CLIENT_ID,
+                    transactionalId,
+                    Argument.of(String.class),
+                    Argument.of(String.class)
+                );
 
-            sendTransaction(producer, "first");
-            Thread.sleep(12_000);
+                sendTransaction(producer, topic, "first");
+                Thread.sleep(12_000);
 
-            assertDoesNotThrow(() -> sendTransaction(producer, "second"));
+                assertDoesNotThrow(() -> sendTransaction(producer, topic, "second"));
+            }
         }
     }
 
     @Test
-    @Timeout(90)
+    @Timeout(180)
     void injectedTransactionalProducerShouldRecoverAfterTransactionalIdExpires() throws Exception {
-        try (EmbeddedKafkaBroker broker = new EmbeddedKafkaBroker(3_000, 500);
-             ApplicationContext context = ApplicationContext.run(Map.of(
-                 "kafka.bootstrap.servers", broker.bootstrapServers()
-             ))) {
-            broker.createTopic(TOPIC);
+        String topic = "issue-542-topic-" + UUID.randomUUID();
+        try (KafkaContainer kafka = createKafkaContainer()) {
+            kafka.start();
+            try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "kafka.bootstrap.servers", kafka.getBootstrapServers()
+            ))) {
+                createTopic(kafka.getBootstrapServers(), topic);
 
-            InjectedTransactionalSender sender = context.getBean(InjectedTransactionalSender.class);
-            sender.send(TOPIC, "first").get();
-            Thread.sleep(12_000);
+                InjectedTransactionalSender sender = context.getBean(InjectedTransactionalSender.class);
+                sender.send(topic, "first").get();
+                Thread.sleep(12_000);
 
-            assertDoesNotThrow(() -> sender.send(TOPIC, "second").get());
+                assertDoesNotThrow(() -> sender.send(topic, "second").get());
+            }
         }
     }
 
-    private static void sendTransaction(Producer<String, String> producer, String value) throws Exception {
+    private static void sendTransaction(Producer<String, String> producer, String topic, String value) throws Exception {
         producer.beginTransaction();
-        producer.send(new ProducerRecord<>(TOPIC, value)).get();
+        producer.send(new ProducerRecord<>(topic, value)).get();
         producer.commitTransaction();
+    }
+
+    private static KafkaContainer createKafkaContainer() {
+        return new KafkaContainer("apache/kafka:4.2.0")
+            .withEnv("KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS", Integer.toString(TRANSACTIONAL_ID_EXPIRATION_MS))
+            .withEnv("KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS", Integer.toString(TRANSACTION_CLEANUP_INTERVAL_MS))
+            .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+            .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+            .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+            .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    }
+
+    private static void createTopic(String bootstrapServers, String topic) throws Exception {
+        try (AdminClient admin = AdminClient.create(Map.of(
+            AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
+        ))) {
+            admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).all().get();
+        }
     }
 
     @Singleton
@@ -110,140 +128,6 @@ public class TransactionalProducerExpirationReproducerTest {
                 producer.send(new ProducerRecord<>(topic, value));
             producer.commitTransaction();
             return future;
-        }
-    }
-
-    private static final class EmbeddedKafkaBroker implements AutoCloseable {
-        private final KafkaRaftServer server;
-        private final Path baseDir;
-        private final String bootstrapServers;
-
-        private EmbeddedKafkaBroker(int expirationMs, int cleanupIntervalMs) throws Exception {
-            int brokerPort = freePort();
-            int controllerPort = freePort();
-            baseDir = Files.createTempDirectory("issue-542-kafka-");
-            Path dataDir = Files.createDirectory(baseDir.resolve("data"));
-            Path metadataDir = Files.createDirectory(baseDir.resolve("metadata"));
-            Path configFile = baseDir.resolve("server.properties");
-            bootstrapServers = "127.0.0.1:" + brokerPort;
-
-            Files.writeString(configFile, """
-                process.roles=broker,controller
-                node.id=1
-                controller.quorum.voters=1@127.0.0.1:%d
-                listeners=PLAINTEXT://127.0.0.1:%d,CONTROLLER://127.0.0.1:%d
-                advertised.listeners=PLAINTEXT://127.0.0.1:%d
-                listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-                inter.broker.listener.name=PLAINTEXT
-                controller.listener.names=CONTROLLER
-                log.dirs=%s
-                metadata.log.dir=%s
-                num.partitions=1
-                offsets.topic.replication.factor=1
-                transaction.state.log.replication.factor=1
-                transaction.state.log.min.isr=1
-                transaction.remove.expired.transaction.cleanup.interval.ms=%d
-                group.initial.rebalance.delay.ms=0
-                transactional.id.expiration.ms=%d
-                auto.create.topics.enable=false
-                """.formatted(
-                controllerPort,
-                brokerPort,
-                controllerPort,
-                brokerPort,
-                dataDir,
-                metadataDir,
-                cleanupIntervalMs,
-                expirationMs
-            ));
-
-            int formatExit = StorageTool.execute(
-                new String[]{"format", "--config", configFile.toString(), "--cluster-id", Uuid.randomUuid().toString()},
-                System.out
-            );
-            if (formatExit != 0) {
-                throw new IllegalStateException("Kafka storage format failed with exit code " + formatExit);
-            }
-
-            server = new KafkaRaftServer(KafkaConfig.fromProps(load(configFile)), Time.SYSTEM);
-            server.startup();
-            waitForBroker();
-        }
-
-        private String bootstrapServers() {
-            return bootstrapServers;
-        }
-
-        private void createTopic(String name) throws Exception {
-            try (AdminClient admin = adminClient()) {
-                admin.createTopics(List.of(new NewTopic(name, 1, (short) 1))).all().get();
-            }
-        }
-
-        private void waitForBroker() throws Exception {
-            long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
-            Exception last = null;
-            while (System.nanoTime() < deadline) {
-                try (AdminClient admin = adminClient()) {
-                    admin.describeCluster().clusterId().get();
-                    return;
-                } catch (Exception e) {
-                    last = e;
-                    Thread.sleep(500);
-                }
-            }
-            throw new IllegalStateException("Broker did not become ready", last);
-        }
-
-        private AdminClient adminClient() {
-            return AdminClient.create(Map.of(
-                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
-            ));
-        }
-
-        @Override
-        public void close() throws Exception {
-            try {
-                server.shutdown();
-                server.awaitShutdown();
-            } finally {
-                deleteRecursively(baseDir);
-            }
-        }
-
-        private static Properties load(Path configFile) throws IOException {
-            Properties properties = new Properties();
-            try (var input = Files.newInputStream(configFile)) {
-                properties.load(input);
-            }
-            return properties;
-        }
-
-        private static void deleteRecursively(Path path) throws IOException {
-            if (!Files.exists(path)) {
-                return;
-            }
-            try (var walk = Files.walk(path)) {
-                walk.sorted((a, b) -> b.getNameCount() - a.getNameCount())
-                    .forEach(current -> {
-                        try {
-                            Files.deleteIfExists(current);
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
-            } catch (RuntimeException e) {
-                if (e.getCause() instanceof IOException ioException) {
-                    throw ioException;
-                }
-                throw e;
-            }
-        }
-
-        private static int freePort() throws IOException {
-            try (ServerSocket socket = new ServerSocket(0)) {
-                return socket.getLocalPort();
-            }
         }
     }
 }

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.type.Argument;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaRaftServer;
+import kafka.tools.StorageTool;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class TransactionalProducerExpirationReproducerTest {
+    private static final String CLIENT_ID = "issue-542";
+    private static final String TOPIC = "issue-542-topic";
+    private static final String TRANSACTIONAL_ID = "issue-542-tx";
+
+    @Test
+    @Timeout(90)
+    void transactionalProducerShouldRecoverAfterTransactionalIdExpires() throws Exception {
+        try (EmbeddedKafkaBroker broker = new EmbeddedKafkaBroker(3_000, 500);
+             ApplicationContext context = ApplicationContext.run(Map.of(
+                 "kafka.bootstrap.servers", broker.bootstrapServers()
+             ))) {
+            broker.createTopic(TOPIC);
+
+            TransactionalProducerRegistry registry = context.getBean(TransactionalProducerRegistry.class);
+            Producer<String, String> producer = registry.getTransactionalProducer(
+                CLIENT_ID,
+                TRANSACTIONAL_ID,
+                Argument.of(String.class),
+                Argument.of(String.class)
+            );
+
+            sendTransaction(producer, "first");
+            Thread.sleep(12_000);
+
+            assertDoesNotThrow(() -> sendTransaction(producer, "second"));
+        }
+    }
+
+    private static void sendTransaction(Producer<String, String> producer, String value) throws Exception {
+        producer.beginTransaction();
+        producer.send(new ProducerRecord<>(TOPIC, value)).get();
+        producer.commitTransaction();
+    }
+
+    private static final class EmbeddedKafkaBroker implements AutoCloseable {
+        private final KafkaRaftServer server;
+        private final Path baseDir;
+        private final String bootstrapServers;
+
+        private EmbeddedKafkaBroker(int expirationMs, int cleanupIntervalMs) throws Exception {
+            int brokerPort = freePort();
+            int controllerPort = freePort();
+            baseDir = Files.createTempDirectory("issue-542-kafka-");
+            Path dataDir = Files.createDirectory(baseDir.resolve("data"));
+            Path metadataDir = Files.createDirectory(baseDir.resolve("metadata"));
+            Path configFile = baseDir.resolve("server.properties");
+            bootstrapServers = "127.0.0.1:" + brokerPort;
+
+            Files.writeString(configFile, """
+                process.roles=broker,controller
+                node.id=1
+                controller.quorum.voters=1@127.0.0.1:%d
+                listeners=PLAINTEXT://127.0.0.1:%d,CONTROLLER://127.0.0.1:%d
+                advertised.listeners=PLAINTEXT://127.0.0.1:%d
+                listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+                inter.broker.listener.name=PLAINTEXT
+                controller.listener.names=CONTROLLER
+                log.dirs=%s
+                metadata.log.dir=%s
+                num.partitions=1
+                offsets.topic.replication.factor=1
+                transaction.state.log.replication.factor=1
+                transaction.state.log.min.isr=1
+                transaction.remove.expired.transaction.cleanup.interval.ms=%d
+                group.initial.rebalance.delay.ms=0
+                transactional.id.expiration.ms=%d
+                auto.create.topics.enable=false
+                """.formatted(
+                controllerPort,
+                brokerPort,
+                controllerPort,
+                brokerPort,
+                dataDir,
+                metadataDir,
+                cleanupIntervalMs,
+                expirationMs
+            ));
+
+            int formatExit = StorageTool.execute(
+                new String[]{"format", "--config", configFile.toString(), "--cluster-id", Uuid.randomUuid().toString()},
+                System.out
+            );
+            if (formatExit != 0) {
+                throw new IllegalStateException("Kafka storage format failed with exit code " + formatExit);
+            }
+
+            server = new KafkaRaftServer(KafkaConfig.fromProps(load(configFile)), Time.SYSTEM);
+            server.startup();
+            waitForBroker();
+        }
+
+        private String bootstrapServers() {
+            return bootstrapServers;
+        }
+
+        private void createTopic(String name) throws Exception {
+            try (AdminClient admin = adminClient()) {
+                admin.createTopics(List.of(new NewTopic(name, 1, (short) 1))).all().get();
+            }
+        }
+
+        private void waitForBroker() throws Exception {
+            long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+            Exception last = null;
+            while (System.nanoTime() < deadline) {
+                try (AdminClient admin = adminClient()) {
+                    admin.describeCluster().clusterId().get();
+                    return;
+                } catch (Exception e) {
+                    last = e;
+                    Thread.sleep(500);
+                }
+            }
+            throw new IllegalStateException("Broker did not become ready", last);
+        }
+
+        private AdminClient adminClient() {
+            return AdminClient.create(Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
+            ));
+        }
+
+        @Override
+        public void close() throws Exception {
+            try {
+                server.shutdown();
+                server.awaitShutdown();
+            } finally {
+                deleteRecursively(baseDir);
+            }
+        }
+
+        private static Properties load(Path configFile) throws IOException {
+            Properties properties = new Properties();
+            try (var input = Files.newInputStream(configFile)) {
+                properties.load(input);
+            }
+            return properties;
+        }
+
+        private static void deleteRecursively(Path path) throws IOException {
+            if (!Files.exists(path)) {
+                return;
+            }
+            try (var walk = Files.walk(path)) {
+                walk.sorted((a, b) -> b.getNameCount() - a.getNameCount())
+                    .forEach(current -> {
+                        try {
+                            Files.deleteIfExists(current);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof IOException ioException) {
+                    throw ioException;
+                }
+                throw e;
+            }
+        }
+
+        private static int freePort() throws IOException {
+            try (ServerSocket socket = new ServerSocket(0)) {
+                return socket.getLocalPort();
+            }
+        }
+    }
+}

--- a/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
+++ b/kafka/src/test/java/io/micronaut/configuration/kafka/TransactionalProducerExpirationReproducerTest.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.configuration.kafka;
 
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.type.Argument;
+import jakarta.inject.Singleton;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaRaftServer;
 import kafka.tools.StorageTool;
@@ -70,10 +72,45 @@ public class TransactionalProducerExpirationReproducerTest {
         }
     }
 
+    @Test
+    @Timeout(90)
+    void injectedTransactionalProducerShouldRecoverAfterTransactionalIdExpires() throws Exception {
+        try (EmbeddedKafkaBroker broker = new EmbeddedKafkaBroker(3_000, 500);
+             ApplicationContext context = ApplicationContext.run(Map.of(
+                 "kafka.bootstrap.servers", broker.bootstrapServers()
+             ))) {
+            broker.createTopic(TOPIC);
+
+            InjectedTransactionalSender sender = context.getBean(InjectedTransactionalSender.class);
+            sender.send(TOPIC, "first").get();
+            Thread.sleep(12_000);
+
+            assertDoesNotThrow(() -> sender.send(TOPIC, "second").get());
+        }
+    }
+
     private static void sendTransaction(Producer<String, String> producer, String value) throws Exception {
         producer.beginTransaction();
         producer.send(new ProducerRecord<>(TOPIC, value)).get();
         producer.commitTransaction();
+    }
+
+    @Singleton
+    static final class InjectedTransactionalSender {
+        private final Producer<String, String> producer;
+
+        InjectedTransactionalSender(@KafkaClient(id = CLIENT_ID, transactionalId = TRANSACTIONAL_ID) Producer<String, String> producer) {
+            this.producer = producer;
+            this.producer.initTransactions();
+        }
+
+        java.util.concurrent.Future<org.apache.kafka.clients.producer.RecordMetadata> send(String topic, String value) {
+            producer.beginTransaction();
+            java.util.concurrent.Future<org.apache.kafka.clients.producer.RecordMetadata> future =
+                producer.send(new ProducerRecord<>(topic, value));
+            producer.commitTransaction();
+            return future;
+        }
     }
 
     private static final class EmbeddedKafkaBroker implements AutoCloseable {


### PR DESCRIPTION
## Summary

- add a Testcontainers-based regression test for issue #542 with shortened transactional-id expiration and cleanup intervals
- recover cached transactional producers by recreating the underlying producer with a fresh configuration and fresh serializer instances after Kafka expires the transactional id
- apply the same recovery behavior to both `TransactionalProducerRegistry` and injected `@KafkaClient` transactional producers so existing callers keep a stable producer handle
- notify send callbacks when async replay recovery fails and cover the recovery wrapper with focused unit tests

## Verification

- `./gradlew :micronaut-kafka:test --tests 'io.micronaut.configuration.kafka.RecoveringTransactionalProducerTest'`
- `./gradlew :micronaut-kafka:compileTestJava :micronaut-kafka:spotlessCheck`

## Notes

- The focused recovery wrapper tests pass locally.
- The broader Docker-backed regression remains in the PR branch, but I did not re-run the full Testcontainers suite in this workspace.

Resolves #542
