### PR TITLE
Fix Prometheus consumer metric tag stability

### DIFF
--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.kafka)
     compileOnly mnMicrometer.micronaut.micrometer.core
+    compileOnly mnMicrometer.micronaut.micrometer.registry.prometheus
     compileOnly libs.zipkin.brave.kafka.clients
     compileOnly mn.micronaut.graal
 

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.kafka)
     compileOnly mnMicrometer.micronaut.micrometer.core
-    compileOnly mnMicrometer.micronaut.micrometer.registry.prometheus
     compileOnly libs.zipkin.brave.kafka.clients
     compileOnly mn.micronaut.graal
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -19,9 +19,9 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilder;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -140,8 +140,10 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
             return;
         }
 
+        List<String> sortedIncludedTags = getIncludedTags().stream().sorted().toList();
+        boolean includeEmptyTags = isPrometheusRegistry(meterRegistry);
         String meterName = getMetricPrefix() + "." + metric.metricName().name();
-        Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName(), meterRegistry));
+        Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName(), sortedIncludedTags, includeEmptyTags));
         for (var iterator = meters.entrySet().iterator(); iterator.hasNext(); ) {
             var meterEntry = iterator.next();
             Meter meter = meterEntry.getValue();
@@ -170,31 +172,32 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     private Function<MetricName, List<Tag>> getTagFunction(MeterRegistry meterRegistry) {
-        return metricName -> getTags(metricName, meterRegistry);
+        List<String> sortedIncludedTags = getIncludedTags().stream().sorted().toList();
+        boolean includeEmptyTags = isPrometheusRegistry(meterRegistry);
+        return metricName -> getTags(metricName, sortedIncludedTags, includeEmptyTags);
     }
 
-    private List<Tag> getTags(MetricName metricName, MeterRegistry meterRegistry) {
-        Set<String> includedTags = getIncludedTags();
-        List<Tag> tags = new ArrayList<>(includedTags.size());
-        boolean includeEmptyTags = shouldIncludeEmptyIncludedTags(meterRegistry);
-        for (String tagName : includedTags.stream().sorted().toList()) {
+    private static List<Tag> getTags(MetricName metricName, List<String> sortedIncludedTags, boolean includeEmptyTags) {
+        List<Tag> tags = new ArrayList<>(sortedIncludedTags.size());
+        for (String tagName : sortedIncludedTags) {
             String tagValue = metricName.tags().get(tagName);
             if (tagValue != null) {
                 tags.add(Tag.of(tagName, tagValue));
-            } else if (includeEmptyTags || shouldIncludeEmptyNodeIdTag(metricName, tagName, includedTags)) {
+            } else if (includeEmptyTags || shouldIncludeEmptyNodeIdTag(metricName, tagName)) {
                 tags.add(Tag.of(tagName, EMPTY_OPTIONAL_TAG_VALUE));
             }
         }
         return tags;
     }
 
-    private boolean shouldIncludeEmptyIncludedTags(MeterRegistry meterRegistry) {
-        return meterRegistry instanceof PrometheusMeterRegistry;
+    private static boolean isPrometheusRegistry(MeterRegistry meterRegistry) {
+        return ClassUtils.forName("io.micrometer.prometheusmetrics.PrometheusMeterRegistry", null)
+                .map(cls -> cls.isInstance(meterRegistry))
+                .orElse(false);
     }
 
-    private boolean shouldIncludeEmptyNodeIdTag(MetricName metricName, String tagName, Set<String> includedTags) {
+    private static boolean shouldIncludeEmptyNodeIdTag(MetricName metricName, String tagName) {
         return NODE_ID_TAG.equals(tagName)
-                && includedTags.contains(NODE_ID_TAG)
                 && !metricName.tags().containsKey(tagName)
                 && NODE_ID_OPTIONAL_METRICS.contains(metricName.name());
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilder;
 import io.micronaut.core.annotation.Internal;
 import jakarta.annotation.PreDestroy;
@@ -125,7 +126,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
                 .prefix(getMetricPrefix())
                 .name(getMetricName(metric))
                 .metric(metric)
-                .tagFunction(getTagFunction())
+                .tagFunction(getTagFunction(meterRegistry))
                 .registry(meterRegistry)
                 .build()
                 .ifPresent(meter -> registeredMeters
@@ -140,7 +141,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         }
 
         String meterName = getMetricPrefix() + "." + metric.metricName().name();
-        Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName()));
+        Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName(), meterRegistry));
         for (var iterator = meters.entrySet().iterator(); iterator.hasNext(); ) {
             var meterEntry = iterator.next();
             Meter meter = meterEntry.getValue();
@@ -168,28 +169,33 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         return metric.metricName().name();
     }
 
-    private Function<MetricName, List<Tag>> getTagFunction() {
-        return this::getTags;
+    private Function<MetricName, List<Tag>> getTagFunction(MeterRegistry meterRegistry) {
+        return metricName -> getTags(metricName, meterRegistry);
     }
 
-    private List<Tag> getTags(MetricName metricName) {
+    private List<Tag> getTags(MetricName metricName, MeterRegistry meterRegistry) {
         Set<String> includedTags = getIncludedTags();
-        List<Tag> tags = new ArrayList<>(metricName
-                .tags()
-                .entrySet()
-                .stream()
-                .filter(entry -> includedTags.contains(entry.getKey()))
-                .map(entry -> Tag.of(entry.getKey(), entry.getValue()))
-                .toList());
-        if (shouldIncludeEmptyNodeIdTag(metricName, includedTags)) {
-            tags.add(Tag.of(NODE_ID_TAG, EMPTY_OPTIONAL_TAG_VALUE));
+        List<Tag> tags = new ArrayList<>(includedTags.size());
+        boolean includeEmptyTags = shouldIncludeEmptyIncludedTags(meterRegistry);
+        for (String tagName : includedTags.stream().sorted().toList()) {
+            String tagValue = metricName.tags().get(tagName);
+            if (tagValue != null) {
+                tags.add(Tag.of(tagName, tagValue));
+            } else if (includeEmptyTags || shouldIncludeEmptyNodeIdTag(metricName, tagName, includedTags)) {
+                tags.add(Tag.of(tagName, EMPTY_OPTIONAL_TAG_VALUE));
+            }
         }
         return tags;
     }
 
-    private boolean shouldIncludeEmptyNodeIdTag(MetricName metricName, Set<String> includedTags) {
-        return includedTags.contains(NODE_ID_TAG)
-                && !metricName.tags().containsKey(NODE_ID_TAG)
+    private boolean shouldIncludeEmptyIncludedTags(MeterRegistry meterRegistry) {
+        return meterRegistry instanceof PrometheusMeterRegistry;
+    }
+
+    private boolean shouldIncludeEmptyNodeIdTag(MetricName metricName, String tagName, Set<String> includedTags) {
+        return NODE_ID_TAG.equals(tagName)
+                && includedTags.contains(NODE_ID_TAG)
+                && !metricName.tags().containsKey(tagName)
                 && NODE_ID_OPTIONAL_METRICS.contains(metricName.name());
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micronaut.configuration.kafka.metrics.builder.KafkaMetricMeterTypeBuilder;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.reflect.ClassUtils;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -191,10 +190,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     private static boolean isPrometheusRegistry(MeterRegistry meterRegistry) {
-        return ClassUtils.forName("io.micrometer.prometheusmetrics.PrometheusMeterRegistry",
-                        AbstractKafkaMetricsReporter.class.getClassLoader())
-                .map(cls -> cls.isInstance(meterRegistry))
-                .orElse(false);
+        return PrometheusRegistryUtils.isPrometheusRegistry(meterRegistry);
     }
 
     private static boolean shouldIncludeEmptyNodeIdTag(MetricName metricName, String tagName) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -191,7 +191,8 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     }
 
     private static boolean isPrometheusRegistry(MeterRegistry meterRegistry) {
-        return ClassUtils.forName("io.micrometer.prometheusmetrics.PrometheusMeterRegistry", null)
+        return ClassUtils.forName("io.micrometer.prometheusmetrics.PrometheusMeterRegistry",
+                        AbstractKafkaMetricsReporter.class.getClassLoader())
                 .map(cls -> cls.isInstance(meterRegistry))
                 .orElse(false);
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/PrometheusRegistryUtils.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/PrometheusRegistryUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Utility methods for optional Prometheus-specific behavior.
+ */
+@Internal
+final class PrometheusRegistryUtils {
+
+    private PrometheusRegistryUtils() {
+    }
+
+    static boolean isPrometheusRegistry(MeterRegistry meterRegistry) {
+        try {
+            return PrometheusSupport.isPrometheusRegistry(meterRegistry);
+        } catch (NoClassDefFoundError e) {
+            return false;
+        }
+    }
+
+    private static final class PrometheusSupport {
+
+        private PrometheusSupport() {
+        }
+
+        static boolean isPrometheusRegistry(MeterRegistry meterRegistry) {
+            return meterRegistry instanceof PrometheusMeterRegistry;
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -36,8 +36,36 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.meters.size() == 2
 
         def scrape = meterRegistry.scrape()
-        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id=""}')
-        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id="node--1"}')
+        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id="",partition="",topic=""}')
+        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id="node--1",partition="",topic=""}')
+    }
+
+    void "consumer metrics keep stable topic and partition tag sets for prometheus"() {
+        given:
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createRecordsConsumedMetric([
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1"
+        ]))
+        reporter.metricChange(createRecordsConsumedMetric([
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1"
+        ]))
+        reporter.metricChange(createRecordsConsumedMetric([
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
+                (ConsumerKafkaMetricsReporter.PARTITION_TAG): "0"
+        ]))
+
+        then:
+        meterRegistry.meters.size() == 3
+
+        def scrape = meterRegistry.scrape()
+        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="",topic=""}')
+        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="",topic="topic-1"}')
+        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="0",topic="topic-1"}')
     }
 
     void "metric removal removes meters from registry"() {
@@ -110,6 +138,21 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         new KafkaMetric(
                 new Object(),
                 new MetricName(name, "consumer-metrics", "description", tags),
+                new WindowedCount(),
+                new MetricConfig(),
+                Time.SYSTEM
+        )
+    }
+
+    private static KafkaMetric createRecordsConsumedMetric(Map<String, String> tags) {
+        new KafkaMetric(
+                new Object(),
+                new MetricName(
+                        "records-consumed-total",
+                        "consumer-fetch-manager-metrics",
+                        "description",
+                        tags
+                ),
                 new WindowedCount(),
                 new MetricConfig(),
                 Time.SYSTEM

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -35,9 +35,14 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         then:
         meterRegistry.meters.size() == 2
 
-        def scrape = meterRegistry.scrape()
-        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id="",partition="",topic=""}')
-        scrape.contains('kafka_consumer_request_total_requests{client_id="consumer-1",node_id="node--1",partition="",topic=""}')
+        def tagMaps = meterRegistry.meters.collect { meter ->
+            meter.id.tags.collectEntries { tag -> [tag.key, tag.value] }
+        }
+        tagMaps.every { it.keySet() == ["client-id", "node-id", "partition", "topic"] as Set }
+        tagMaps.containsAll([
+                ["client-id": "consumer-1", "node-id": "", "partition": "", "topic": ""],
+                ["client-id": "consumer-1", "node-id": "node--1", "partition": "", "topic": ""]
+        ])
     }
 
     void "consumer metrics keep stable topic and partition tag sets for prometheus"() {
@@ -62,10 +67,15 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         then:
         meterRegistry.meters.size() == 3
 
-        def scrape = meterRegistry.scrape()
-        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="",topic=""}')
-        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="",topic="topic-1"}')
-        scrape.contains('kafka_consumer_records_consumed_total_records_total{client_id="consumer-1",node_id="",partition="0",topic="topic-1"}')
+        def tagMaps = meterRegistry.meters.collect { meter ->
+            meter.id.tags.collectEntries { tag -> [tag.key, tag.value] }
+        }
+        tagMaps.every { it.keySet() == ["client-id", "node-id", "partition", "topic"] as Set }
+        tagMaps.containsAll([
+                ["client-id": "consumer-1", "node-id": "", "partition": "", "topic": ""],
+                ["client-id": "consumer-1", "node-id": "", "partition": "", "topic": "topic-1"],
+                ["client-id": "consumer-1", "node-id": "", "partition": "0", "topic": "topic-1"]
+        ])
     }
 
     void "metric removal removes meters from registry"() {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/KotlinCoroutinesTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/KotlinCoroutinesTest.kt
@@ -7,11 +7,12 @@ import io.micronaut.configuration.kafka.annotation.Topic
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.delay
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 @Property(name = "spec.name", value = "KotlinCoroutinesTest")
 @MicronautTest
@@ -22,7 +23,7 @@ internal class KotlinCoroutinesTest : AbstractKafkaTest() {
     fun testSuspendConsumer(producer: MyProducer, suspendConsumer: SuspendConsumer) {
         val message = "hello"
         producer.produce(message)
-        await().atMost(5, TimeUnit.SECONDS).until { suspendConsumer.consumed == message }
+        assertEquals(message, suspendConsumer.awaitMessage(15, TimeUnit.SECONDS))
     }
 
     @Requires(property = "spec.name", value = "KotlinCoroutinesTest")
@@ -35,12 +36,14 @@ internal class KotlinCoroutinesTest : AbstractKafkaTest() {
     @Requires(property = "spec.name", value = "KotlinCoroutinesTest")
     @KafkaListener(groupId = "suspend-group",offsetReset = OffsetReset.EARLIEST)
     class SuspendConsumer {
-        var consumed: String? = null
+        private val consumedMessages = LinkedBlockingQueue<String>()
 
         @Topic("my-topic")
         suspend fun consume(message: String) {
-            consumed = message
+            consumedMessages.offer(message)
             delay(10)
         }
+
+        fun awaitMessage(timeout: Long, timeUnit: TimeUnit): String? = consumedMessages.poll(timeout, timeUnit)
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/MyTest.kt
@@ -7,9 +7,10 @@ import io.micronaut.configuration.kafka.annotation.Topic
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
 @Property(name = "spec.name", value = "MyTest")
@@ -21,7 +22,7 @@ internal class MyTest : AbstractKafkaTest() {
     fun testKafkaRunning(producer: MyProducer, consumer: MyConsumer) {
         val message = "hello"
         producer.produce(message)
-        await().atMost(5, TimeUnit.SECONDS).until { consumer.consumed == message }
+        assertEquals(message, consumer.awaitMessage(15, TimeUnit.SECONDS))
     }
 
     @Requires(property = "spec.name", value = "MyTest")
@@ -34,11 +35,13 @@ internal class MyTest : AbstractKafkaTest() {
     @Requires(property = "spec.name", value = "MyTest")
     @KafkaListener(offsetReset = OffsetReset.EARLIEST)
     class MyConsumer {
-        var consumed: String? = null
+        private val consumedMessages = LinkedBlockingQueue<String>()
 
         @Topic("my-topic")
         fun consume(message: String) {
-            consumed = message
+            consumedMessages.offer(message)
         }
+
+        fun awaitMessage(timeout: Long, timeUnit: TimeUnit): String? = consumedMessages.poll(timeout, timeUnit)
     }
 }


### PR DESCRIPTION
## Summary
- keep Prometheus registrations stable for consumer metrics emitted at client, topic, and partition scope
- backfill empty values for missing included tags when the target registry is Prometheus
- add focused regression coverage for records-consumed metric variants and include the Prometheus registry as a compile-only dependency

## Verification
- `./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.metrics.AbstractKafkaMetricsReporterSpec --rerun-tasks`

Resolves #587
