### PR TITLE
Document runtime Kafka bootstrap configuration

### DIFF
--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -135,6 +135,21 @@ class KafkaConfigurationSpec extends Specification {
         consumer.close()
     }
 
+    void "test configure bootstrap servers programmatically at startup"() {
+        given:
+        applicationContext = ApplicationContext.builder()
+                .properties(
+                        ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): 'localhost:1111'
+                )
+                .start()
+
+        when:
+        AbstractKafkaConsumerConfiguration config = applicationContext.getBean(AbstractKafkaConsumerConfiguration)
+
+        then:
+        config.config[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] == 'localhost:1111'
+    }
+
     void "test null kafka property reports the failing property path"() {
         when:
         applicationContext = ApplicationContext.run(

--- a/src/main/docs/guide/kafkaQuickStart.adoc
+++ b/src/main/docs/guide/kafkaQuickStart.adoc
@@ -28,6 +28,12 @@ kafka:
 
 TIP: You can also set the environment variable `KAFKA_BOOTSTRAP_SERVERS` to a comma separated list of values to externalize configuration.
 
+If you resolve the Kafka brokers at application startup, you can also provide `kafka.bootstrap.servers` from an `ApplicationContextConfigurer`:
+
+snippet::io.micronaut.kafka.docs.quickstart.RuntimeBootstrapServers[tags="imports,clazz", indent=0]
+
+The `kafka.bootstrap.servers` value must be available before Kafka clients are initialized.
+
 You may also add any Apache Kafka configuration options directly under the kafka node. These configurations will apply to consumers, producers and streams:
 
 .Configuring Kafka

--- a/test-suite-groovy/build.gradle.kts
+++ b/test-suite-groovy/build.gradle.kts
@@ -3,15 +3,13 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
+val testApplicationContextConfigurerMetadata = sourceSets.test.get().output.classesDirs.asFileTree.matching {
+    include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+    include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+}
+
 tasks.withType<Test>().configureEach {
-    doFirst {
-        delete(
-            sourceSets.test.get().output.classesDirs.asFileTree.matching {
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
-            }
-        )
-    }
+    classpath = classpath.minus(testApplicationContextConfigurerMetadata)
 }
 
 dependencies {

--- a/test-suite-groovy/build.gradle.kts
+++ b/test-suite-groovy/build.gradle.kts
@@ -3,13 +3,22 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
-val testApplicationContextConfigurerMetadata = sourceSets.test.get().output.classesDirs.asFileTree.matching {
-    include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-    include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+val applicationContextConfigurerMetadata = listOf(
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer",
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**"
+)
+
+val filteredTestRuntimeOutput = tasks.register<Sync>("filteredTestRuntimeOutput") {
+    from(sourceSets.test.get().output)
+    into(layout.buildDirectory.dir("filtered-test-runtime/test"))
+    applicationContextConfigurerMetadata.forEach(::exclude)
 }
 
 tasks.withType<Test>().configureEach {
-    classpath = classpath.minus(testApplicationContextConfigurerMetadata)
+    dependsOn(filteredTestRuntimeOutput)
+    classpath =
+        files(filteredTestRuntimeOutput.map { it.destinationDir }) +
+            (classpath - sourceSets.test.get().output)
 }
 
 dependencies {

--- a/test-suite-groovy/build.gradle.kts
+++ b/test-suite-groovy/build.gradle.kts
@@ -3,6 +3,17 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
+tasks.withType<Test>().configureEach {
+    doFirst {
+        delete(
+            sourceSets.test.get().output.classesDirs.asFileTree.matching {
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+            }
+        )
+    }
+}
+
 dependencies {
     testImplementation(platform(mn.micronaut.core.bom))
     testCompileOnly(mn.micronaut.inject.groovy)

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.groovy
@@ -16,9 +16,9 @@ class RuntimeBootstrapServers implements ApplicationContextConfigurer {
             'kafka.bootstrap.servers': resolveBootstrapServers()
         ])
     }
-// end::clazz[]
 
     private static String resolveBootstrapServers() {
         'localhost:9092'
     }
 }
+// end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.kafka.docs.quickstart
+
+// tag::imports[]
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.ApplicationContextConfigurer
+import io.micronaut.context.annotation.ContextConfigurer
+// end::imports[]
+
+// tag::clazz[]
+@ContextConfigurer
+class RuntimeBootstrapServers implements ApplicationContextConfigurer {
+
+    @Override
+    void configure(ApplicationContextBuilder builder) {
+        builder.properties([
+            'kafka.bootstrap.servers': resolveBootstrapServers()
+        ])
+    }
+// end::clazz[]
+
+    private static String resolveBootstrapServers() {
+        'localhost:9092'
+    }
+}

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -4,15 +4,20 @@ plugins {
     id("io.micronaut.build.internal.kotlin-kapt")
 }
 
+val filteredTestClassesDir = layout.buildDirectory.dir("filtered-test-classes")
+
+val filteredTestClasses by tasks.registering(org.gradle.api.tasks.Sync::class) {
+    from(sourceSets.test.get().output.classesDirs)
+    into(filteredTestClassesDir)
+    includeEmptyDirs = false
+    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+}
+
 tasks.withType<Test>().configureEach {
-    doFirst {
-        delete(
-            sourceSets.test.get().output.classesDirs.asFileTree.matching {
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
-            }
-        )
-    }
+    dependsOn(filteredTestClasses)
+    testClassesDirs = files(filteredTestClassesDir)
+    classpath = files(filteredTestClassesDir) + (classpath - sourceSets.test.get().output.classesDirs)
 }
 
 dependencies {

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -4,6 +4,17 @@ plugins {
     id("io.micronaut.build.internal.kotlin-kapt")
 }
 
+tasks.withType<Test>().configureEach {
+    doFirst {
+        delete(
+            sourceSets.test.get().output.classesDirs.asFileTree.matching {
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+            }
+        )
+    }
+}
+
 dependencies {
     kaptTest(platform(mn.micronaut.core.bom))
     kaptTest(mn.micronaut.inject.java)

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -4,20 +4,27 @@ plugins {
     id("io.micronaut.build.internal.kotlin-kapt")
 }
 
-val filteredTestClassesDir = layout.buildDirectory.dir("filtered-test-classes")
+val applicationContextConfigurerMetadata = listOf(
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer",
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**"
+)
+val kaptTestClassesDir = layout.buildDirectory.dir("tmp/kapt3/classes/test")
+val filteredTestRuntimeDir = layout.buildDirectory.dir("filtered-test-runtime/test")
 
-val filteredTestClasses by tasks.registering(org.gradle.api.tasks.Sync::class) {
-    from(sourceSets.test.get().output.classesDirs)
-    into(filteredTestClassesDir)
+val filteredTestRuntimeOutput by tasks.registering(Sync::class) {
+    from(sourceSets.test.get().output)
+    from(kaptTestClassesDir)
+    into(filteredTestRuntimeDir)
     includeEmptyDirs = false
-    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+    applicationContextConfigurerMetadata.forEach(::exclude)
 }
 
 tasks.withType<Test>().configureEach {
-    dependsOn(filteredTestClasses)
-    testClassesDirs = files(filteredTestClassesDir)
-    classpath = files(filteredTestClassesDir) + (classpath - sourceSets.test.get().output.classesDirs)
+    dependsOn(filteredTestRuntimeOutput)
+    testClassesDirs = files(filteredTestRuntimeDir)
+    classpath =
+        files(filteredTestRuntimeDir) +
+            (classpath - sourceSets.test.get().output - files(kaptTestClassesDir))
 }
 
 dependencies {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.kt
@@ -16,7 +16,7 @@ class RuntimeBootstrapServers : ApplicationContextConfigurer {
             )
         )
     }
-// end::clazz[]
 
     private fun resolveBootstrapServers(): String = "localhost:9092"
 }
+// end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.kt
@@ -1,0 +1,22 @@
+package io.micronaut.kafka.docs.quickstart
+
+// tag::imports[]
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.ApplicationContextConfigurer
+import io.micronaut.context.annotation.ContextConfigurer
+// end::imports[]
+
+// tag::clazz[]
+@ContextConfigurer
+class RuntimeBootstrapServers : ApplicationContextConfigurer {
+    override fun configure(builder: ApplicationContextBuilder) {
+        builder.properties(
+            mapOf(
+                "kafka.bootstrap.servers" to resolveBootstrapServers()
+            )
+        )
+    }
+// end::clazz[]
+
+    private fun resolveBootstrapServers(): String = "localhost:9092"
+}

--- a/test-suite/build.gradle.kts
+++ b/test-suite/build.gradle.kts
@@ -2,15 +2,18 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
+val filteredTestRuntimeOutput = tasks.register<Sync>("filteredTestRuntimeOutput") {
+    from(sourceSets.test.get().output)
+    into(layout.buildDirectory.dir("filtered-test-runtime/test"))
+    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+}
+
 tasks.withType<Test>().configureEach {
-    doFirst {
-        delete(
-            sourceSets.test.get().output.classesDirs.asFileTree.matching {
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
-            }
-        )
-    }
+    dependsOn(filteredTestRuntimeOutput)
+    classpath =
+        files(filteredTestRuntimeOutput.map { it.destinationDir }) +
+            (classpath - sourceSets.test.get().output)
 }
 
 dependencies {

--- a/test-suite/build.gradle.kts
+++ b/test-suite/build.gradle.kts
@@ -2,6 +2,17 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
+tasks.withType<Test>().configureEach {
+    doFirst {
+        delete(
+            sourceSets.test.get().output.classesDirs.asFileTree.matching {
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
+                include("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+            }
+        )
+    }
+}
+
 dependencies {
     testAnnotationProcessor(platform(mn.micronaut.core.bom))
     testAnnotationProcessor(mn.micronaut.inject.java)

--- a/test-suite/build.gradle.kts
+++ b/test-suite/build.gradle.kts
@@ -2,11 +2,15 @@ plugins {
     id("io.micronaut.internal.build.kafka-testsuite")
 }
 
+val applicationContextConfigurerMetadata = listOf(
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer",
+    "META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**"
+)
+
 val filteredTestRuntimeOutput = tasks.register<Sync>("filteredTestRuntimeOutput") {
     from(sourceSets.test.get().output)
     into(layout.buildDirectory.dir("filtered-test-runtime/test"))
-    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer")
-    exclude("META-INF/micronaut/io.micronaut.context.ApplicationContextConfigurer/**")
+    applicationContextConfigurerMetadata.forEach(::exclude)
 }
 
 tasks.withType<Test>().configureEach {

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.java
@@ -1,0 +1,25 @@
+package io.micronaut.kafka.docs.quickstart;
+
+// tag::imports[]
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.context.annotation.ContextConfigurer;
+
+import java.util.Map;
+// end::imports[]
+
+// tag::clazz[]
+@ContextConfigurer
+public final class RuntimeBootstrapServers implements ApplicationContextConfigurer {
+    @Override
+    public void configure(ApplicationContextBuilder builder) {
+        builder.properties(Map.of(
+            "kafka.bootstrap.servers", resolveBootstrapServers()
+        ));
+    }
+// end::clazz[]
+
+    private static String resolveBootstrapServers() {
+        return "localhost:9092";
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/quickstart/RuntimeBootstrapServers.java
@@ -17,9 +17,9 @@ public final class RuntimeBootstrapServers implements ApplicationContextConfigur
             "kafka.bootstrap.servers", resolveBootstrapServers()
         ));
     }
-// end::clazz[]
 
     private static String resolveBootstrapServers() {
         return "localhost:9092";
     }
 }
+// end::clazz[]


### PR DESCRIPTION
## Summary
- document setting `kafka.bootstrap.servers` at runtime via `ApplicationContextConfigurer`
- add Java, Groovy, and Kotlin quickstart snippets using `@ContextConfigurer`
- cover the programmatic bootstrap-server path with a focused configuration test

## Verification
- `./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.KafkaConfigurationSpec :test-suite:testClasses :test-suite-groovy:testClasses :test-suite-kotlin:testClasses -q`

Resolves #1079
