### PR TITLE
Document multiple Kafka Streams configuration

### DIFF
--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -88,7 +88,8 @@ kafka:
 .Configuring multiple Stream definitions on the same Micronaut Service.
 You can define multiple Kafka Streams on the same Micronaut application, each with their own unique configuration.
 To do this you should define the configuration with `kafka.streams.[STREAM-NAME]`.
-Assuming you have 2 or more Kafka Streams definitions on a single service, you will need to use the `default` key for at least one of them and then define `kafka.streams.[STREAM-NAME]` for the rest.
+Assuming you have 2 or more Kafka Streams definitions on a single service, you must use the `default` key for one of them and then define `kafka.streams.[STREAM-NAME]` for the rest.
+Each stream definition should also set its own unique `application.id`.
 
 For example in `application.yml`:
 
@@ -97,22 +98,24 @@ For example in `application.yml`:
 kafka:
     streams:
         default:
+          application.id: my-app-default-stream
           num:
             stream:
               threads: 1
         my-other-stream:
+          application.id: my-app-other-stream
           num:
             stream:
               threads: 10
 ----
 
-The above configuration sets the `num.stream.threads` setting of the Kafka `StreamsConfig` to `1` for the `default` stream, and the same setting to `10` for a stream named `my-stream`.
+The above configuration sets the `application.id` to `my-app-default-stream` and `num.stream.threads` to `1` for the `default` stream. It also configures a second stream named `my-other-stream` with its own `application.id` and `num.stream.threads` value of `10`.
 
 You can then inject an `api:configuration.kafka.streams.ConfiguredStreamBuilder[]` specifically for the above configuration using `jakarta.inject.Named`:
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="myOtherStream", indent=0]
 
-NOTE: If you do not provide a `@Named` on the `ConfiguredStreamBuilder` and you have multiple topology beans defined, they share the default configurations such as client id and application id. When using multiple streams in a single app, it is advisable to provide a `@Named` instance of `ConfiguredStreamBuilder` for each stream.
+NOTE: The `@Named` qualifier must be applied to the injected `ConfiguredStreamBuilder` parameter so Micronaut can bind that topology to the matching `kafka.streams.*` configuration. If you have multiple topology beans and do not qualify the `ConfiguredStreamBuilder`, they share the default configuration such as client id and application id.
 
 .Kafka Streams Word Count
 

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -88,7 +88,7 @@ kafka:
 .Configuring multiple Stream definitions on the same Micronaut Service.
 You can define multiple Kafka Streams on the same Micronaut application, each with their own unique configuration.
 To do this you should define the configuration with `kafka.streams.[STREAM-NAME]`.
-Assuming you have 2 or more Kafka Streams definitions on a single service, you must use the `default` key for one of them and then define `kafka.streams.[STREAM-NAME]` for the rest.
+If you want to configure the primary, unqualified stream explicitly, use the `default` key and then define `kafka.streams.[STREAM-NAME]` for any additional named streams.
 Each stream definition should also set its own unique `application.id`.
 
 For example in `application.yml`:
@@ -102,6 +102,11 @@ kafka:
           num:
             stream:
               threads: 1
+        my-stream:
+          application.id: my-app-my-stream
+          num:
+            stream:
+              threads: 2
         my-other-stream:
           application.id: my-app-other-stream
           num:
@@ -109,7 +114,7 @@ kafka:
               threads: 10
 ----
 
-The above configuration sets the `application.id` to `my-app-default-stream` and `num.stream.threads` to `1` for the `default` stream. It also configures a second stream named `my-other-stream` with its own `application.id` and `num.stream.threads` value of `10`.
+The above configuration sets the `application.id` to `my-app-default-stream` and `num.stream.threads` to `1` for the `default` stream. It also configures a named stream `my-stream` and a second named stream `my-other-stream`, each with their own `application.id` and `num.stream.threads` settings.
 
 You can then inject an `api:configuration.kafka.streams.ConfiguredStreamBuilder[]` specifically for the above configuration using `jakarta.inject.Named`:
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStream.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStream.groovy
@@ -54,7 +54,7 @@ class WordCountStream {
     // tag::namedStream[]
     @Singleton
     @Named('my-stream')
-    KStream<String, String> myStream(ConfiguredStreamBuilder builder) {
+    KStream<String, String> myStream(@Named('my-stream') ConfiguredStreamBuilder builder) {
 
         // end::namedStream[]
         // set default serdes
@@ -78,7 +78,7 @@ class WordCountStream {
     // tag::myOtherStream[]
     @Singleton
     @Named('my-other-stream')
-    KStream<String, String> myOtherKStream(ConfiguredStreamBuilder builder)  {
+    KStream<String, String> myOtherKStream(@Named('my-other-stream') ConfiguredStreamBuilder builder)  {
         return builder.stream('my-other-stream')
     }
     // end::myOtherStream[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -14,6 +14,10 @@ class WordCountStreamTest extends Specification {
         def config = new HashMap<>(Kafka.getProperties());
         config.put("kafka.enabled", "true");
         config.put("spec.name", "WordCountStreamTest");
+        config.put("kafka.streams.my-stream.application.id", "test-suite-groovy-my-stream");
+        config.put("kafka.streams.my-stream.start-kafka-streams", "false");
+        config.put("kafka.streams.my-other-stream.application.id", "test-suite-groovy-my-other-stream");
+        config.put("kafka.streams.my-other-stream.start-kafka-streams", "false");
         ApplicationContext ctx = ApplicationContext.run(config)
         when:
         WordCountClient client = ctx.getBean(WordCountClient)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStream.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStream.kt
@@ -57,7 +57,7 @@ class WordCountStream {
     // tag::namedStream[]
     @Singleton
     @Named("my-stream")
-    fun myStream(builder: ConfiguredStreamBuilder): KStream<String, String> {
+    fun myStream(@Named("my-stream") builder: ConfiguredStreamBuilder): KStream<String, String> {
         // end::namedStream[]
 
         // set default serdes
@@ -84,7 +84,7 @@ class WordCountStream {
     // tag::myOtherStream[]
     @Singleton
     @Named("my-other-stream")
-    fun myOtherKStream(builder: ConfiguredStreamBuilder): KStream<String, String> {
+    fun myOtherKStream(@Named("my-other-stream") builder: ConfiguredStreamBuilder): KStream<String, String> {
         return builder.stream("my-other-stream")
     }
     // end::myOtherStream[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -13,7 +13,16 @@ internal class WordCountStreamTest {
     @Suppress("UNCHECKED_CAST")
     fun testWordCounter() {
         val props = Kafka.getProperties() as MutableMap<String, Any>
-        props.putAll(mapOf("kafka.enabled" to StringUtils.TRUE, "spec.name" to "WordCountStreamTest"))
+        props.putAll(
+            mapOf(
+                "kafka.enabled" to StringUtils.TRUE,
+                "spec.name" to "WordCountStreamTest",
+                "kafka.streams.my-stream.application.id" to "test-suite-kotlin-my-stream",
+                "kafka.streams.my-stream.start-kafka-streams" to StringUtils.FALSE,
+                "kafka.streams.my-other-stream.application.id" to "test-suite-kotlin-my-other-stream",
+                "kafka.streams.my-other-stream.start-kafka-streams" to StringUtils.FALSE
+            )
+        )
         ApplicationContext.run(props).use { ctx ->
             val client = ctx.getBean(WordCountClient::class.java)
             client.publishSentence("test to test for words")

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStream.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStream.java
@@ -58,7 +58,7 @@ public class WordCountStream {
     // tag::namedStream[]
     @Singleton
     @Named("my-stream")
-    KStream<String, String> myStream(ConfiguredStreamBuilder builder) {
+    KStream<String, String> myStream(@Named("my-stream") ConfiguredStreamBuilder builder) {
 
         // end::namedStream[]
         // set default serdes
@@ -82,7 +82,7 @@ public class WordCountStream {
     // tag::myOtherStream[]
     @Singleton
     @Named("my-other-stream")
-    KStream<String, String> myOtherKStream(ConfiguredStreamBuilder builder)  {
+    KStream<String, String> myOtherKStream(@Named("my-other-stream") ConfiguredStreamBuilder builder)  {
         return builder.stream("my-other-stream");
     }
     // end::myOtherStream[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -19,6 +19,10 @@ class WordCountStreamTest {
         Map<String, Object> config = new HashMap<>(kafkaProps);
         config.put("kafka.enabled", StringUtils.TRUE);
         config.put("spec.name", "WordCountStreamTest");
+        config.put("kafka.streams.my-stream.application.id", "test-suite-java-my-stream");
+        config.put("kafka.streams.my-stream.start-kafka-streams", StringUtils.FALSE);
+        config.put("kafka.streams.my-other-stream.application.id", "test-suite-java-my-other-stream");
+        config.put("kafka.streams.my-other-stream.start-kafka-streams", StringUtils.FALSE);
 
         try (ApplicationContext ctx = ApplicationContext.run(config)) {
             WordCountClient client = ctx.getBean(WordCountClient.class);


### PR DESCRIPTION
## Summary
- clarify the multiple Kafka Streams guide to require one `default` stream configuration and a unique `application.id` per stream
- document that `@Named` must qualify the injected `ConfiguredStreamBuilder` parameter for named stream topologies
- align the Java, Groovy, and Kotlin docs snippet sources with the guide

## Verification
- `./gradlew :test-suite:compileTestJava :test-suite-groovy:compileTestGroovy :test-suite-kotlin:compileTestKotlin`

Resolves #1022
