### PR TITLE
Add Kafka listener invocation scope

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/AbstractKafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/AbstractKafkaStreamsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,8 +72,9 @@ public class AbstractKafkaStreamsConfiguration<K, V> extends AbstractKafkaConfig
         if (environment.getActiveNames().contains(Environment.TEST)) {
             String tmpDir = System.getProperty("java.io.tmpdir");
             if (StringUtils.isNotEmpty(tmpDir)) {
-                if (new File(tmpDir, applicationName).mkdirs()) {
-                    config.putIfAbsent(StreamsConfig.STATE_DIR_CONFIG, tmpDir);
+                File stateDir = new File(tmpDir, applicationName);
+                if (stateDir.mkdirs() || stateDir.isDirectory()) {
+                    config.putIfAbsent(StreamsConfig.STATE_DIR_CONFIG, stateDir.getAbsolutePath());
                 }
             }
         }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsConfigurationSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsConfigurationSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.configuration.kafka.streams
+
+import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration
+import io.micronaut.context.env.Environment
+import io.micronaut.runtime.ApplicationConfiguration
+import org.apache.kafka.streams.StreamsConfig
+import spock.lang.Specification
+
+class KafkaStreamsConfigurationSpec extends Specification {
+
+    void "test environment uses an application-specific kafka streams state directory"() {
+        given:
+        def environment = Stub(Environment) {
+            getActiveNames() >> ([Environment.TEST] as Set)
+            containsProperties('kafka') >> false
+        }
+        def applicationConfiguration = Stub(ApplicationConfiguration) {
+            getName() >> Optional.of('state-dir-spec')
+        }
+        def defaultConfiguration = new KafkaDefaultConfiguration(environment)
+
+        when:
+        def configuration = new DefaultKafkaStreamsConfiguration(defaultConfiguration, applicationConfiguration, environment)
+
+        then:
+        configuration.config.getProperty(StreamsConfig.STATE_DIR_CONFIG) ==
+            new File(System.getProperty('java.io.tmpdir'), 'state-dir-spec').absolutePath
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaScope.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.annotation;
+
+import io.micronaut.runtime.context.scope.ScopedProxy;
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A custom scope that binds a bean to the current Kafka listener invocation.
+ *
+ * <p>For listeners in single-record mode the scope is active for one consumed record.
+ * For listeners in batch mode the scope is active for the entire batch.</p>
+ *
+ * @author graemerocher
+ * @since 5.5.0
+ */
+@ScopedProxy
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Scope
+public @interface KafkaScope {
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 /**
  * The internal state of the consumer.
@@ -113,15 +114,19 @@ abstract class ConsumerState {
     @Nullable
     protected abstract Map<TopicPartition, OffsetAndMetadata> getCurrentOffsets();
 
-    protected final void withKafkaScope(Runnable action) {
+    protected final <T> T withKafkaScope(Supplier<T> action) {
         KafkaCustomScope kafkaScope = kafkaConsumerProcessor == null ? null : kafkaConsumerProcessor.getKafkaScope();
         if (kafkaScope == null) {
-            action.run();
-            return;
+            return action.get();
         }
-        try (KafkaCustomScope.Scope ignored = kafkaScope.open()) {
+        return kafkaScope.execute(action);
+    }
+
+    protected final void withKafkaScope(Runnable action) {
+        withKafkaScope(() -> {
             action.run();
-        }
+            return null;
+        });
     }
 
     void pause() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -19,6 +19,7 @@ import io.micronaut.configuration.kafka.KafkaMessage;
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy;
 import io.micronaut.configuration.kafka.exceptions.OffsetCommitExceptionLogger;
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerException;
+import io.micronaut.configuration.kafka.scope.KafkaCustomScope;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -111,6 +112,17 @@ abstract class ConsumerState {
 
     @Nullable
     protected abstract Map<TopicPartition, OffsetAndMetadata> getCurrentOffsets();
+
+    protected final void withKafkaScope(Runnable action) {
+        KafkaCustomScope kafkaScope = kafkaConsumerProcessor == null ? null : kafkaConsumerProcessor.getKafkaScope();
+        if (kafkaScope == null) {
+            action.run();
+            return;
+        }
+        try (KafkaCustomScope.Scope ignored = kafkaScope.open()) {
+            action.run();
+        }
+    }
 
     void pause() {
         pause(assignments);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -89,20 +89,22 @@ final class ConsumerStateBatch extends ConsumerState {
     protected void processRecords(ConsumerRecords<?, ?> consumerRecords, @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
             for (ConsumerRecords<?, ?> topicRecords : recordsByTopic(consumerRecords)) {
-                final String topic = topicRecords.partitions().stream().findFirst().map(TopicPartition::topic).orElseThrow();
-                final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
-                Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
-                    final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(topicRecords);
-                    boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+                withKafkaScope(() -> {
+                    final String topic = topicRecords.partitions().stream().findFirst().map(TopicPartition::topic).orElseThrow();
+                    final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
+                    Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
+                        final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(topicRecords);
+                        boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+                    });
+                    Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
+                    if (method.isSuspend()) {
+                        Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
+                        boundArguments.put(lastArgument, null);
+                    }
+                    final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
+                    final Object result = batchBinder.bind(method, kafkaConsumerProcessor.getBatchBinderRegistry(), topicRecords).invoke(consumerBean);
+                    handleResult(normalizeResult(result), topicRecords, topic);
                 });
-                Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
-                if (method.isSuspend()) {
-                    Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
-                    boundArguments.put(lastArgument, null);
-                }
-                final ExecutableBinder<ConsumerRecords<?, ?>> batchBinder = new DefaultExecutableBinder<>(boundArguments);
-                final Object result = batchBinder.bind(method, kafkaConsumerProcessor.getBatchBinderRegistry(), topicRecords).invoke(consumerBean);
-                handleResult(normalizeResult(result), topicRecords, topic);
             }
             failed = false;
         } catch (Exception e) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,38 +80,28 @@ final class ConsumerStateSingle extends ConsumerState {
         while (iterator.hasNext()) {
             final ConsumerRecord<?, ?> consumerRecord = iterator.next();
             final String topic = consumerRecord.topic();
-
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
-            }
-
-            updateCurrentOffsets(consumerRecord, currentOffsets);
+            logRecord(topic, consumerRecord);
+            trackCurrentOffset(consumerRecord, currentOffsets);
             final KafkaSeekOperations seek = bindRecordArguments(topic, currentOffsets);
-
-            final boolean[] stopProcessing = new boolean[1];
-            withKafkaScope(() -> {
-                if (processRecord(consumerRecord, consumerRecords, iterator)) {
-                    stopProcessing[0] = true;
-                    return;
-                }
-                commitOffsets(consumerRecords, consumerRecord, currentOffsets);
-                performDeferredSeek(seek);
-            });
-            if (stopProcessing[0]) {
+            if (withKafkaScope(() -> processRecord(topic, consumerRecords, currentOffsets, iterator, consumerRecord, seek))) {
                 return;
             }
         }
         failed = false;
     }
 
-    private void updateCurrentOffsets(ConsumerRecord<?, ?> consumerRecord,
+    private void logRecord(String topic, ConsumerRecord<?, ?> consumerRecord) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Kafka consumer [{}] received record: {}", info.logMethod(topic), consumerRecord);
+        }
+    }
+
+    private void trackCurrentOffset(ConsumerRecord<?, ?> consumerRecord,
         Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         if (!info.trackPartitions) {
             return;
         }
-        final TopicPartition topicPartition = getTopicPartition(consumerRecord);
-        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(consumerRecord.offset() + 1, null);
-        currentOffsets.put(topicPartition, offsetAndMetadata);
+        currentOffsets.put(getTopicPartition(consumerRecord), new OffsetAndMetadata(consumerRecord.offset() + 1, null));
     }
 
     @Nullable
@@ -128,20 +118,34 @@ final class ConsumerStateSingle extends ConsumerState {
         return seek;
     }
 
-    private boolean processRecord(ConsumerRecord<?, ?> consumerRecord,
+    private boolean processRecord(String topic,
         ConsumerRecords<?, ?> consumerRecords,
-        Iterator<? extends ConsumerRecord<?, ?>> iterator) {
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets,
+        Iterator<? extends ConsumerRecord<?, ?>> iterator,
+        ConsumerRecord<?, ?> consumerRecord,
+        @Nullable KafkaSeekOperations seek) {
         try {
-            process(consumerRecord, consumerRecords);
-            return false;
+            process(topic, consumerRecord, consumerRecords);
         } catch (Exception e) {
-            if (!resolveWithErrorStrategy(consumerRecords, consumerRecord, e)) {
-                return false;
+            if (handleRecordFailure(consumerRecords, iterator, consumerRecord, e)) {
+                return true;
             }
-            resetTheFollowingPartitions(consumerRecord, iterator);
-            failed = true;
-            return true;
         }
+        commitOffsets(consumerRecords, consumerRecord, currentOffsets);
+        performDeferredSeek(seek);
+        return false;
+    }
+
+    private boolean handleRecordFailure(ConsumerRecords<?, ?> consumerRecords,
+        Iterator<? extends ConsumerRecord<?, ?>> iterator,
+        ConsumerRecord<?, ?> consumerRecord,
+        Exception e) {
+        if (!resolveWithErrorStrategy(consumerRecords, consumerRecord, e)) {
+            return false;
+        }
+        resetTheFollowingPartitions(consumerRecord, iterator);
+        failed = true;
+        return true;
     }
 
     private void commitOffsets(ConsumerRecords<?, ?> consumerRecords,
@@ -155,17 +159,16 @@ final class ConsumerStateSingle extends ConsumerState {
     }
 
     private void performDeferredSeek(@Nullable KafkaSeekOperations seek) {
-        if (seek == null) {
-            return;
+        if (seek != null) {
+            // Performs seek operations that were deferred by the user
+            final KafkaSeeker seeker = KafkaSeeker.newInstance(kafkaConsumer);
+            seek.forEach(seeker::perform);
         }
-        // Performs seek operations that were deferred by the user
-        final KafkaSeeker seeker = KafkaSeeker.newInstance(kafkaConsumer);
-        seek.forEach(seeker::perform);
     }
 
-    private void process(ConsumerRecord<?, ?> consumerRecord,
+    private void process(String topic,
+        ConsumerRecord<?, ?> consumerRecord,
         ConsumerRecords<?, ?> consumerRecords) {
-        final String topic = consumerRecord.topic();
         final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
         if (method.isSuspend()) {
             Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -88,12 +88,18 @@ final class ConsumerStateSingle extends ConsumerState {
             updateCurrentOffsets(consumerRecord, currentOffsets);
             final KafkaSeekOperations seek = bindRecordArguments(topic, currentOffsets);
 
-            if (processRecord(consumerRecord, consumerRecords, iterator)) {
+            final boolean[] stopProcessing = new boolean[1];
+            withKafkaScope(() -> {
+                if (processRecord(consumerRecord, consumerRecords, iterator)) {
+                    stopProcessing[0] = true;
+                    return;
+                }
+                commitOffsets(consumerRecords, consumerRecord, currentOffsets);
+                performDeferredSeek(seek);
+            });
+            if (stopProcessing[0]) {
                 return;
             }
-
-            commitOffsets(consumerRecords, consumerRecord, currentOffsets);
-            performDeferredSeek(seek);
         }
         failed = false;
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -142,6 +142,7 @@ class KafkaConsumerProcessor
     private final ConditionalRetryBehaviourHandler conditionalRetryBehaviourHandler;
 
     private final Supplier<Optional<KafkaCustomScope>> kafkaCustomScopeSupplier;
+
     /**
      * Creates a new processor using the given {@link ExecutorService} to schedule consumers on.
      *

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -55,6 +55,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -98,6 +99,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -139,6 +141,7 @@ class KafkaConsumerProcessor
     private final ApplicationEventPublisher<KafkaConsumerSubscribedEvent> kafkaConsumerSubscribedEventPublisher;
     private final ConditionalRetryBehaviourHandler conditionalRetryBehaviourHandler;
 
+    private final Supplier<Optional<KafkaCustomScope>> kafkaCustomScopeSupplier;
     /**
      * Creates a new processor using the given {@link ExecutorService} to schedule consumers on.
      *
@@ -189,6 +192,7 @@ class KafkaConsumerProcessor
         this.kafkaConsumerStartedPollingEventPublisher = startedEventPublisher;
         this.kafkaConsumerSubscribedEventPublisher = subscribedEventPublisher;
         this.conditionalRetryBehaviourHandler = conditionalRetryBehaviourHandler;
+        this.kafkaCustomScopeSupplier = SupplierUtil.memoized(() -> beanContext.findBean(KafkaCustomScope.class));
         this.beanContext.getBeanDefinitions(Qualifiers.byType(KafkaListener.class))
                 .forEach(definition -> {
                     // pre-initialize singletons before processing
@@ -431,7 +435,7 @@ class KafkaConsumerProcessor
 
     @Nullable
     KafkaCustomScope getKafkaScope() {
-        return beanContext.findBean(KafkaCustomScope.class).orElse(null);
+        return kafkaCustomScopeSupplier.get().orElse(null);
     }
 
     private static List<ExecutableMethod<?, ?>> resolveConsumerMethods(

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -39,6 +39,7 @@ import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler;
 import io.micronaut.configuration.kafka.seek.KafkaSeeker;
 import io.micronaut.configuration.kafka.serde.SerdeRegistry;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.configuration.kafka.scope.KafkaCustomScope;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -426,6 +427,11 @@ class KafkaConsumerProcessor
 
     BatchConsumerRecordsBinderRegistry getBatchBinderRegistry() {
         return batchBinderRegistry;
+    }
+
+    @Nullable
+    KafkaCustomScope getKafkaScope() {
+        return beanContext.findBean(KafkaCustomScope.class).orElse(null);
     }
 
     private static List<ExecutableMethod<?, ?>> resolveConsumerMethods(

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Stores {@link KafkaScope} beans for the duration of a Kafka listener invocation.
@@ -60,6 +61,31 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
         return () -> close(entry);
     }
 
+    /**
+     * Executes an action within a Kafka scope.
+     *
+     * @param action The action to execute
+     * @param <T> The result type
+     * @return The action result
+     */
+    public <T> T execute(Supplier<T> action) {
+        try (Scope scope = open()) {
+            return action.get();
+        }
+    }
+
+    /**
+     * Executes an action within a Kafka scope.
+     *
+     * @param action The action to execute
+     */
+    public void execute(Runnable action) {
+        execute(() -> {
+            action.run();
+            return null;
+        });
+    }
+
     @Override
     public boolean isRunning() {
         return true;
@@ -71,8 +97,7 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
     }
 
     @Override
-    @Nullable
-    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+    protected @Nullable Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
         Deque<ScopeEntry> stack = scopes.get();
         if (stack == null || stack.isEmpty()) {
             if (forCreation) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
@@ -101,7 +102,7 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
     }
 
     @Override
-    protected @Nullable Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+    protected @Nullable Map<@NonNull BeanIdentifier, @NonNull CreatedBean<@NonNull ?>> getScopeMap(boolean forCreation) {
         Deque<ScopeEntry> stack = scopes.get();
         if (stack == null || stack.isEmpty()) {
             if (forCreation) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -19,12 +19,12 @@ import io.micronaut.configuration.kafka.annotation.KafkaScope;
 import io.micronaut.context.scope.AbstractConcurrentCustomScope;
 import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -135,6 +135,6 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
     }
 
     private static final class ScopeEntry {
-        private final Map<BeanIdentifier, CreatedBean<?>> beans = new HashMap<>(2);
+        private final Map<BeanIdentifier, CreatedBean<?>> beans = CollectionUtils.newHashMap(2);
     }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -22,6 +22,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
@@ -99,7 +101,7 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
     }
 
     @Override
-    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+    protected @Nullable Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
         Deque<ScopeEntry> stack = scopes.get();
         if (stack == null || stack.isEmpty()) {
             if (forCreation) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.scope;
+
+import io.micronaut.configuration.kafka.annotation.KafkaScope;
+import io.micronaut.context.scope.AbstractConcurrentCustomScope;
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.BeanIdentifier;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores {@link KafkaScope} beans for the duration of a Kafka listener invocation.
+ *
+ * @author graemerocher
+ * @since 5.5.0
+ */
+@Singleton
+@Internal
+public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaScope> {
+
+    private final java.lang.ThreadLocal<Deque<ScopeEntry>> scopes = new java.lang.ThreadLocal<>();
+
+    public KafkaCustomScope() {
+        super(KafkaScope.class);
+    }
+
+    /**
+     * Activates the Kafka scope on the current thread.
+     *
+     * @return A handle that closes the current scope when the invocation ends
+     */
+    public Scope open() {
+        Deque<ScopeEntry> stack = scopes.get();
+        if (stack == null) {
+            stack = new ArrayDeque<>(1);
+            scopes.set(stack);
+        }
+        ScopeEntry entry = new ScopeEntry();
+        stack.addLast(entry);
+        return () -> close(entry);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        scopes.remove();
+    }
+
+    @Override
+    @Nullable
+    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+        Deque<ScopeEntry> stack = scopes.get();
+        if (stack == null || stack.isEmpty()) {
+            if (forCreation) {
+                throw new IllegalStateException("No active Kafka scope");
+            }
+            return null;
+        }
+        return stack.peekLast().beans;
+    }
+
+    private void close(ScopeEntry expected) {
+        Deque<ScopeEntry> stack = scopes.get();
+        if (stack == null || stack.isEmpty()) {
+            return;
+        }
+        ScopeEntry current = stack.removeLast();
+        if (current != expected) {
+            throw new IllegalStateException("Kafka scope closed out of order");
+        }
+        destroyScope(current.beans);
+        if (stack.isEmpty()) {
+            scopes.remove();
+        }
+    }
+
+    /**
+     * Handle for an active Kafka scope.
+     */
+    @FunctionalInterface
+    public interface Scope extends AutoCloseable {
+        @Override
+        void close();
+    }
+
+    private static final class ScopeEntry {
+        private final Map<BeanIdentifier, CreatedBean<?>> beans = new HashMap<>(2);
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/KafkaCustomScope.java
@@ -21,9 +21,8 @@ import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
-import org.jspecify.annotations.Nullable;
-
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,8 +68,11 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
      * @return The action result
      */
     public <T> T execute(Supplier<T> action) {
-        try (Scope scope = open()) {
+        Scope activeScope = open();
+        try {
             return action.get();
+        } finally {
+            activeScope.close();
         }
     }
 
@@ -97,13 +99,13 @@ public final class KafkaCustomScope extends AbstractConcurrentCustomScope<KafkaS
     }
 
     @Override
-    protected @Nullable Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
         Deque<ScopeEntry> stack = scopes.get();
         if (stack == null || stack.isEmpty()) {
             if (forCreation) {
                 throw new IllegalStateException("No active Kafka scope");
             }
-            return null;
+            return Collections.emptyMap();
         }
         return stack.peekLast().beans;
     }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/scope/package-info.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/scope/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Kafka scope support.
+ *
+ * @since 5.5.0
+ */
+@NullMarked
+package io.micronaut.configuration.kafka.scope;
+
+import org.jspecify.annotations.NullMarked;

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaScopeConsumerStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaScopeConsumerStateSpec.groovy
@@ -25,6 +25,7 @@ import org.apache.kafka.common.TopicPartition
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
+import java.util.Properties
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -114,14 +115,14 @@ class KafkaScopeConsumerStateSpec extends Specification {
         BeanDefinition<SingleScopedListener> beanDefinition = context.getBeanDefinition(SingleScopedListener)
         ExecutableMethod<SingleScopedListener, Object> method = beanDefinition.getRequiredMethod('receive', String)
         AnnotationValue<KafkaListener> kafkaListener = beanDefinition.getAnnotation(KafkaListener)
-        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, method)
+        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, new Properties(), method)
     }
 
     private ConsumerInfo batchConsumerInfo() {
         BeanDefinition<BatchScopedListener> beanDefinition = context.getBeanDefinition(BatchScopedListener)
         ExecutableMethod<BatchScopedListener, Object> method = beanDefinition.getRequiredMethod('receive', List)
         AnnotationValue<KafkaListener> kafkaListener = beanDefinition.getAnnotation(KafkaListener)
-        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, method)
+        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, new Properties(), method)
     }
 
     private static ConsumerRecords<String, String> records(ConsumerRecord<String, String>... records) {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaScopeConsumerStateSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaScopeConsumerStateSpec.groovy
@@ -1,0 +1,206 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.KafkaScope
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry
+import io.micronaut.configuration.kafka.bind.batch.BatchConsumerRecordsBinderRegistry
+import io.micronaut.configuration.kafka.scope.KafkaCustomScope
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Executable
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+class KafkaScopeConsumerStateSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(['spec.name': 'KafkaScopeConsumerStateSpec'])
+
+    void setup() {
+        InvocationScopedBean.DESTROYED.set(0)
+        context.getBean(SingleScopedListener).reset()
+        context.getBean(BatchScopedListener).reset()
+    }
+
+    void "single consumer state recreates the scope for each record"() {
+        given:
+        ConsumerStateSingle state = new ConsumerStateSingle(
+            kafkaConsumerProcessor(),
+            singleConsumerInfo(),
+            kafkaConsumer(),
+            context.getBean(SingleScopedListener)
+        )
+        ConsumerRecords<String, String> records = records(
+            new ConsumerRecord<>('topic', 0, 0L, 'key-1', 'one'),
+            new ConsumerRecord<>('topic', 0, 1L, 'key-2', 'two')
+        )
+        SingleScopedListener listener = context.getBean(SingleScopedListener)
+
+        when:
+        state.processRecords(records, [:])
+
+        then:
+        listener.directIds.size() == 2
+        listener.directIds == listener.helperIds
+        listener.directIds.toSet().size() == 2
+        InvocationScopedBean.DESTROYED.get() == 2
+    }
+
+    void "batch consumer state shares a scope across the batch and recreates it for the next batch"() {
+        given:
+        ConsumerStateBatch state = new ConsumerStateBatch(
+            kafkaConsumerProcessor(),
+            batchConsumerInfo(),
+            kafkaConsumer(),
+            context.getBean(BatchScopedListener)
+        )
+        BatchScopedListener listener = context.getBean(BatchScopedListener)
+
+        when:
+        state.processRecords(records(
+            new ConsumerRecord<>('topic', 0, 0L, 'key-1', 'one'),
+            new ConsumerRecord<>('topic', 0, 1L, 'key-2', 'two')
+        ), [:])
+        state.processRecords(records(
+            new ConsumerRecord<>('topic', 0, 2L, 'key-3', 'three')
+        ), [:])
+
+        then:
+        listener.directIds.size() == 2
+        listener.batchSizes == [2, 1]
+        listener.directIds.toSet().size() == 2
+        listener.helperIdsPerInvocation[0].every { it == listener.directIds[0] }
+        listener.helperIdsPerInvocation[1].every { it == listener.directIds[1] }
+        InvocationScopedBean.DESTROYED.get() == 2
+    }
+
+    private KafkaConsumerProcessor kafkaConsumerProcessor() {
+        ConsumerRecordBinderRegistry binderRegistry = new ConsumerRecordBinderRegistry(ConversionService.SHARED)
+        BatchConsumerRecordsBinderRegistry batchBinderRegistry = new BatchConsumerRecordsBinderRegistry(binderRegistry, ConversionService.SHARED)
+        KafkaCustomScope kafkaScope = context.getBean(KafkaCustomScope)
+        Mock(KafkaConsumerProcessor) {
+            getBinderRegistry() >> binderRegistry
+            getBatchBinderRegistry() >> batchBinderRegistry
+            getKafkaScope() >> kafkaScope
+        }
+    }
+
+    private Consumer<?, ?> kafkaConsumer() {
+        Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+            commitSync(_ as Map<TopicPartition, OffsetAndMetadata>) >> null
+            commitAsync(_ as Map<TopicPartition, OffsetAndMetadata>, _) >> null
+        }
+    }
+
+    private ConsumerInfo singleConsumerInfo() {
+        BeanDefinition<SingleScopedListener> beanDefinition = context.getBeanDefinition(SingleScopedListener)
+        ExecutableMethod<SingleScopedListener, Object> method = beanDefinition.getRequiredMethod('receive', String)
+        AnnotationValue<KafkaListener> kafkaListener = beanDefinition.getAnnotation(KafkaListener)
+        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, method)
+    }
+
+    private ConsumerInfo batchConsumerInfo() {
+        BeanDefinition<BatchScopedListener> beanDefinition = context.getBeanDefinition(BatchScopedListener)
+        ExecutableMethod<BatchScopedListener, Object> method = beanDefinition.getRequiredMethod('receive', List)
+        AnnotationValue<KafkaListener> kafkaListener = beanDefinition.getAnnotation(KafkaListener)
+        new ConsumerInfo('client', 'group', OffsetStrategy.DISABLED, kafkaListener, method)
+    }
+
+    private static ConsumerRecords<String, String> records(ConsumerRecord<String, String>... records) {
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> byPartition = [:].withDefault { [] }
+        records.each { record ->
+            byPartition[new TopicPartition(record.topic(), record.partition())].add(record)
+        }
+        new ConsumerRecords<>(byPartition)
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeConsumerStateSpec')
+    @Singleton
+    static class InvocationScopedHelper {
+        @Inject InvocationScopedBean invocationScopedBean
+
+        String currentId() {
+            invocationScopedBean.currentId()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeConsumerStateSpec')
+    @KafkaScope
+    static class InvocationScopedBean {
+        static final AtomicInteger DESTROYED = new AtomicInteger()
+
+        final String id = UUID.randomUUID().toString()
+
+        String currentId() {
+            id
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.incrementAndGet()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeConsumerStateSpec')
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST)
+    static class SingleScopedListener {
+        final List<String> directIds = new CopyOnWriteArrayList<>()
+        final List<String> helperIds = new CopyOnWriteArrayList<>()
+
+        @Inject InvocationScopedBean invocationScopedBean
+        @Inject InvocationScopedHelper invocationScopedHelper
+
+        @Executable
+        void receive(String value) {
+            directIds.add(invocationScopedBean.currentId())
+            helperIds.add(invocationScopedHelper.currentId())
+        }
+
+        void reset() {
+            directIds.clear()
+            helperIds.clear()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeConsumerStateSpec')
+    @KafkaListener(offsetReset = OffsetReset.EARLIEST, batch = true)
+    static class BatchScopedListener {
+        final List<String> directIds = new CopyOnWriteArrayList<>()
+        final List<Integer> batchSizes = new CopyOnWriteArrayList<>()
+        final List<List<String>> helperIdsPerInvocation = new CopyOnWriteArrayList<>()
+
+        @Inject InvocationScopedBean invocationScopedBean
+        @Inject InvocationScopedHelper invocationScopedHelper
+
+        @Executable
+        void receive(List<String> values) {
+            directIds.add(invocationScopedBean.currentId())
+            batchSizes.add(values.size())
+            helperIdsPerInvocation.add(values.collect { invocationScopedHelper.currentId() })
+        }
+
+        void reset() {
+            directIds.clear()
+            batchSizes.clear()
+            helperIdsPerInvocation.clear()
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/scope/KafkaScopeSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/scope/KafkaScopeSpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.configuration.kafka.scope
+
+import io.micronaut.configuration.kafka.annotation.KafkaScope
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import jakarta.annotation.PreDestroy
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class KafkaScopeSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(['spec.name': 'KafkaScopeSpec'])
+
+    void setup() {
+        InvocationScopedBean.DESTROYED.set(0)
+    }
+
+    void "kafka scoped beans resolve within an active scope and are recreated for the next scope"() {
+        given:
+        KafkaCustomScope scope = context.getBean(KafkaCustomScope)
+        ScopedConsumer consumer = context.getBean(ScopedConsumer)
+
+        when:
+        String directId
+        String helperId
+        try (def ignored = scope.open()) {
+            directId = consumer.directId()
+            helperId = consumer.helperId()
+        }
+
+        and:
+        String nextId
+        try (def ignored = scope.open()) {
+            nextId = consumer.directId()
+        }
+
+        then:
+        directId == helperId
+        directId != nextId
+        InvocationScopedBean.DESTROYED.get() == 2
+    }
+
+    void "kafka scoped bean access fails without an active scope"() {
+        given:
+        ScopedConsumer consumer = context.getBean(ScopedConsumer)
+
+        when:
+        consumer.directId()
+
+        then:
+        IllegalStateException e = thrown()
+        e.message.contains('No active Kafka scope')
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeSpec')
+    @Singleton
+    static class ScopedConsumer {
+        @Inject InvocationScopedBean invocationScopedBean
+        @Inject ScopedHelper scopedHelper
+
+        String directId() {
+            invocationScopedBean.currentId()
+        }
+
+        String helperId() {
+            scopedHelper.currentId()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeSpec')
+    @Singleton
+    static class ScopedHelper {
+        @Inject InvocationScopedBean invocationScopedBean
+
+        String currentId() {
+            invocationScopedBean.currentId()
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaScopeSpec')
+    @KafkaScope
+    static class InvocationScopedBean {
+        static final AtomicInteger DESTROYED = new AtomicInteger()
+
+        final String id = UUID.randomUUID().toString()
+
+        String currentId() {
+            id
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYED.incrementAndGet()
+        }
+    }
+}

--- a/src/main/docs/guide/kafkaListener/kafkaListenerScope.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerScope.adoc
@@ -1,0 +1,16 @@
+If you need a bean instance that is scoped to a Kafka listener invocation, annotate that bean with ann:configuration.kafka.annotation.KafkaScope[].
+
+The scope is active on the Kafka consumer thread while a listener method is executing:
+
+- For regular listeners, a new scoped bean is created for each consumed record.
+- For batch listeners, a new scoped bean is created for each consumed batch.
+
+Any collaborators resolved within the same listener invocation share the same scoped bean instance.
+
+.Declaring a Kafka-scoped bean
+snippet::io.micronaut.kafka.docs.consumer.scope.ProductListener[tags="imports,scope", indent=0]
+
+.Injecting the scoped bean into a listener
+snippet::io.micronaut.kafka.docs.consumer.scope.ProductListener[tags="listener", indent=0]
+
+The scoped bean is destroyed when the listener invocation completes, which makes it suitable for per-message state such as derived metadata, correlation data, or values that should stay stable for the duration of a single listener execution.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -14,6 +14,7 @@ kafkaClient:
 kafkaListener:
   title: Kafka Consumers Using @KafkaListener
   kafkaListenerMethods: Defining @KafkaListener Methods
+  kafkaListenerScope: Scoping Beans to a Kafka Listener Invocation
   kafkaListenerConfiguration: Configuring @KafkaListener beans
   kafkaOffsets: Commiting Kafka Offsets
   kafkaSeek:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/scope/ProductListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/scope/ProductListener.groovy
@@ -21,8 +21,7 @@ class ProductListener {
 
     @Topic('products')
     void receive(String product) {
-        String correlationId = productMetadata.correlationId
-        // use the same metadata instance throughout this listener invocation
+        println "Received ${product} with correlation ${productMetadata.correlationId}"
     }
 }
 // end::listener[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/scope/ProductListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/scope/ProductListener.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.kafka.docs.consumer.scope
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.KafkaScope
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.Topic
+import jakarta.inject.Inject
+
+// tag::listener[]
+@KafkaListener(offsetReset = OffsetReset.EARLIEST)
+class ProductListener {
+
+    // tag::scope[]
+    @KafkaScope
+    static class ProductMetadata {
+        final String correlationId = UUID.randomUUID().toString()
+    }
+    // end::scope[]
+
+    @Inject ProductMetadata productMetadata
+
+    @Topic('products')
+    void receive(String product) {
+        String correlationId = productMetadata.correlationId
+        // use the same metadata instance throughout this listener invocation
+    }
+}
+// end::listener[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -3,6 +3,7 @@ package io.micronaut.kafka.docs.streams
 import io.micronaut.context.ApplicationContext
 import io.micronaut.testcontainers.kafka.Kafka
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.KafkaStreams.State
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -22,7 +23,9 @@ class WordCountStreamTest extends Specification {
         ApplicationContext ctx = ApplicationContext.run(config)
         when:
         conditions.within(30) {
-            ctx.getBeansOfType(KafkaStreams).every { stream -> stream.state().isRunningOrRebalancing() }
+            def states = ctx.getBeansOfType(KafkaStreams)*.state()
+            states.any { state -> state.isRunningOrRebalancing() } &&
+                states.findAll { state -> state != State.CREATED }.every { state -> state.isRunningOrRebalancing() }
         }
         WordCountClient client = ctx.getBean(WordCountClient)
         client.publishSentence('test to test for words')

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -7,6 +7,9 @@ import org.apache.kafka.streams.KafkaStreams.State
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.nio.file.Files
+import java.util.UUID
+
 class WordCountStreamTest extends Specification {
 
     PollingConditions conditions = new PollingConditions()
@@ -14,12 +17,17 @@ class WordCountStreamTest extends Specification {
     void "test word counter"() {
         given:
         def config = new HashMap<>(Kafka.getProperties());
+        def uniqueSuffix = UUID.randomUUID().toString()
+        def stateDir = Files.createTempDirectory('test-suite-groovy-word-count-stream-')
+        stateDir.toFile().deleteOnExit()
         config.put("kafka.enabled", "true");
         config.put("micronaut.application.name", "test-suite-groovy-word-count-stream");
+        config.put("kafka.streams.default.application.id", "test-suite-groovy-word-count-stream-${uniqueSuffix}");
+        config.put("kafka.streams.default.state.dir", stateDir.toString());
         config.put("spec.name", "WordCountStreamTest");
-        config.put("kafka.streams.my-stream.application.id", "test-suite-groovy-my-stream");
+        config.put("kafka.streams.my-stream.application.id", "test-suite-groovy-my-stream-${uniqueSuffix}");
         config.put("kafka.streams.my-stream.start-kafka-streams", "false");
-        config.put("kafka.streams.my-other-stream.application.id", "test-suite-groovy-my-other-stream");
+        config.put("kafka.streams.my-other-stream.application.id", "test-suite-groovy-my-other-stream-${uniqueSuffix}");
         config.put("kafka.streams.my-other-stream.start-kafka-streams", "false");
         ApplicationContext ctx = ApplicationContext.run(config)
         when:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -2,6 +2,7 @@ package io.micronaut.kafka.docs.streams
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.testcontainers.kafka.Kafka
+import org.apache.kafka.streams.KafkaStreams
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -20,6 +21,9 @@ class WordCountStreamTest extends Specification {
         config.put("kafka.streams.my-other-stream.start-kafka-streams", "false");
         ApplicationContext ctx = ApplicationContext.run(config)
         when:
+        conditions.within(30) {
+            ctx.getBeansOfType(KafkaStreams).every { stream -> stream.state().isRunningOrRebalancing() }
+        }
         WordCountClient client = ctx.getBean(WordCountClient)
         client.publishSentence('test to test for words')
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -25,7 +25,7 @@ class WordCountStreamTest extends Specification {
 
         then:
         WordCountListener listener = ctx.getBean(WordCountListener)
-        conditions.within(10) {
+        conditions.within(30) {
             listener.getWordCounts().size() == 4 &&
             listener.getCount('test')  == 2 &&
             listener.getCount('to')    == 1 &&

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -15,6 +15,7 @@ class WordCountStreamTest extends Specification {
         given:
         def config = new HashMap<>(Kafka.getProperties());
         config.put("kafka.enabled", "true");
+        config.put("micronaut.application.name", "test-suite-groovy-word-count-stream");
         config.put("spec.name", "WordCountStreamTest");
         config.put("kafka.streams.my-stream.application.id", "test-suite-groovy-my-stream");
         config.put("kafka.streams.my-stream.start-kafka-streams", "false");

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/streams/WordCountStreamTest.groovy
@@ -24,8 +24,9 @@ class WordCountStreamTest extends Specification {
         when:
         conditions.within(30) {
             def states = ctx.getBeansOfType(KafkaStreams)*.state()
-            states.any { state -> state.isRunningOrRebalancing() } &&
-                states.findAll { state -> state != State.CREATED }.every { state -> state.isRunningOrRebalancing() }
+            states.size() == 3 &&
+                states.count { state -> state.isRunningOrRebalancing() } == 1 &&
+                states.count { state -> state == State.CREATED } == 2
         }
         WordCountClient client = ctx.getBean(WordCountClient)
         client.publishSentence('test to test for words')

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/scope/ProductListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/scope/ProductListener.kt
@@ -24,8 +24,7 @@ class ProductListener {
 
     @Topic("products")
     fun receive(product: String) {
-        val correlationId = productMetadata.correlationId()
-        // use the same metadata instance throughout this listener invocation
+        println("Received $product with correlation ${productMetadata.correlationId()}")
     }
 }
 // end::listener[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/scope/ProductListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/scope/ProductListener.kt
@@ -1,0 +1,31 @@
+package io.micronaut.kafka.docs.consumer.scope
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.KafkaScope
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.Topic
+import jakarta.inject.Inject
+import java.util.UUID
+
+// tag::listener[]
+@KafkaListener(offsetReset = OffsetReset.EARLIEST)
+class ProductListener {
+
+    // tag::scope[]
+    @KafkaScope
+    open class ProductMetadata {
+        private val correlationId: String = UUID.randomUUID().toString()
+
+        open fun correlationId(): String = correlationId
+    }
+    // end::scope[]
+
+    @Inject lateinit var productMetadata: ProductMetadata
+
+    @Topic("products")
+    fun receive(product: String) {
+        val correlationId = productMetadata.correlationId()
+        // use the same metadata instance throughout this listener invocation
+    }
+}
+// end::listener[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -6,6 +6,7 @@ import io.micronaut.testcontainers.kafka.Kafka
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.KafkaStreams.State
 import java.util.concurrent.TimeUnit
 
 internal class WordCountStreamTest {
@@ -26,7 +27,9 @@ internal class WordCountStreamTest {
         )
         ApplicationContext.run(props).use { ctx ->
             await().atMost(30, TimeUnit.SECONDS).until {
-                ctx.getBeansOfType(KafkaStreams::class.java).all { stream -> stream.state().isRunningOrRebalancing }
+                val states = ctx.getBeansOfType(KafkaStreams::class.java).map(KafkaStreams::state)
+                states.any(State::isRunningOrRebalancing) &&
+                        states.filter { state -> state != State.CREATED }.all(State::isRunningOrRebalancing)
             }
 
             val client = ctx.getBean(WordCountClient::class.java)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -5,6 +5,7 @@ import io.micronaut.core.util.StringUtils
 import io.micronaut.testcontainers.kafka.Kafka
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
+import org.apache.kafka.streams.KafkaStreams
 import java.util.concurrent.TimeUnit
 
 internal class WordCountStreamTest {
@@ -24,6 +25,10 @@ internal class WordCountStreamTest {
             )
         )
         ApplicationContext.run(props).use { ctx ->
+            await().atMost(30, TimeUnit.SECONDS).until {
+                ctx.getBeansOfType(KafkaStreams::class.java).all { stream -> stream.state().isRunningOrRebalancing }
+            }
+
             val client = ctx.getBean(WordCountClient::class.java)
             client.publishSentence("test to test for words")
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -29,7 +29,7 @@ internal class WordCountStreamTest {
 
             val listener = ctx.getBean(WordCountListener::class.java)
 
-            await().atMost(10, TimeUnit.SECONDS).until {
+            await().atMost(30, TimeUnit.SECONDS).until {
                 listener.getWordCounts().size == 4 &&
                         listener.getCount("test") == 2L &&
                         listener.getCount("to") == 1L &&

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -28,8 +28,9 @@ internal class WordCountStreamTest {
         ApplicationContext.run(props).use { ctx ->
             await().atMost(30, TimeUnit.SECONDS).until {
                 val states = ctx.getBeansOfType(KafkaStreams::class.java).map(KafkaStreams::state)
-                states.any(State::isRunningOrRebalancing) &&
-                        states.filter { state -> state != State.CREATED }.all(State::isRunningOrRebalancing)
+                states.size == 3 &&
+                        states.count(State::isRunningOrRebalancing) == 1 &&
+                        states.count { state -> state == State.CREATED } == 2
             }
 
             val client = ctx.getBean(WordCountClient::class.java)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -7,7 +7,9 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.apache.kafka.streams.KafkaStreams
 import org.apache.kafka.streams.KafkaStreams.State
+import java.nio.file.Files
 import java.util.concurrent.TimeUnit
+import java.util.UUID
 
 internal class WordCountStreamTest {
 
@@ -15,14 +17,20 @@ internal class WordCountStreamTest {
     @Suppress("UNCHECKED_CAST")
     fun testWordCounter() {
         val props = Kafka.getProperties() as MutableMap<String, Any>
+        val uniqueSuffix = UUID.randomUUID().toString()
+        val stateDir = Files.createTempDirectory("test-suite-kotlin-word-count-stream-").toFile().apply {
+            deleteOnExit()
+        }
         props.putAll(
             mapOf(
                 "kafka.enabled" to StringUtils.TRUE,
                 "micronaut.application.name" to "test-suite-kotlin-word-count-stream",
+                "kafka.streams.default.application.id" to "test-suite-kotlin-word-count-stream-$uniqueSuffix",
+                "kafka.streams.default.state.dir" to stateDir.absolutePath,
                 "spec.name" to "WordCountStreamTest",
-                "kafka.streams.my-stream.application.id" to "test-suite-kotlin-my-stream",
+                "kafka.streams.my-stream.application.id" to "test-suite-kotlin-my-stream-$uniqueSuffix",
                 "kafka.streams.my-stream.start-kafka-streams" to StringUtils.FALSE,
-                "kafka.streams.my-other-stream.application.id" to "test-suite-kotlin-my-other-stream",
+                "kafka.streams.my-other-stream.application.id" to "test-suite-kotlin-my-other-stream-$uniqueSuffix",
                 "kafka.streams.my-other-stream.start-kafka-streams" to StringUtils.FALSE
             )
         )

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/streams/WordCountStreamTest.kt
@@ -18,6 +18,7 @@ internal class WordCountStreamTest {
         props.putAll(
             mapOf(
                 "kafka.enabled" to StringUtils.TRUE,
+                "micronaut.application.name" to "test-suite-kotlin-word-count-stream",
                 "spec.name" to "WordCountStreamTest",
                 "kafka.streams.my-stream.application.id" to "test-suite-kotlin-my-stream",
                 "kafka.streams.my-stream.start-kafka-streams" to StringUtils.FALSE,

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/scope/ProductListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/scope/ProductListener.java
@@ -27,8 +27,7 @@ public class ProductListener {
 
     @Topic("products")
     void receive(String product) {
-        String correlationId = productMetadata.getCorrelationId();
-        // use the same metadata instance throughout this listener invocation
+        System.out.println("Received " + product + " with correlation " + productMetadata.getCorrelationId());
     }
 }
 // end::listener[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/scope/ProductListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/scope/ProductListener.java
@@ -1,0 +1,34 @@
+package io.micronaut.kafka.docs.consumer.scope;
+
+// tag::imports[]
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.KafkaScope;
+import io.micronaut.configuration.kafka.annotation.OffsetReset;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import jakarta.inject.Inject;
+// end::imports[]
+
+// tag::listener[]
+@KafkaListener(offsetReset = OffsetReset.EARLIEST)
+public class ProductListener {
+
+    // tag::scope[]
+    @KafkaScope
+    static class ProductMetadata {
+        private final String correlationId = java.util.UUID.randomUUID().toString();
+
+        String getCorrelationId() {
+            return correlationId;
+        }
+    }
+    // end::scope[]
+
+    @Inject ProductMetadata productMetadata;
+
+    @Topic("products")
+    void receive(String product) {
+        String correlationId = productMetadata.getCorrelationId();
+        // use the same metadata instance throughout this listener invocation
+    }
+}
+// end::listener[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -30,7 +30,7 @@ class WordCountStreamTest {
 
             WordCountListener listener = ctx.getBean(WordCountListener.class);
 
-            await().atMost(10, SECONDS).until(() ->
+            await().atMost(30, SECONDS).until(() ->
                 listener.getWordCounts().size() == 4 &&
                     listener.getCount("test")  == 2 &&
                     listener.getCount("to")    == 1 &&

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -20,6 +20,7 @@ class WordCountStreamTest {
         Map<String, String> kafkaProps = Kafka.getProperties();
         Map<String, Object> config = new HashMap<>(kafkaProps);
         config.put("kafka.enabled", StringUtils.TRUE);
+        config.put("micronaut.application.name", "test-suite-java-word-count-stream");
         config.put("spec.name", "WordCountStreamTest");
         config.put("kafka.streams.my-stream.application.id", "test-suite-java-my-stream");
         config.put("kafka.streams.my-stream.start-kafka-streams", StringUtils.FALSE);

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -29,8 +29,9 @@ class WordCountStreamTest {
         try (ApplicationContext ctx = ApplicationContext.run(config)) {
             await().atMost(30, SECONDS).until(() -> {
                 var states = ctx.getBeansOfType(KafkaStreams.class).stream().map(KafkaStreams::state).toList();
-                return states.stream().anyMatch(State::isRunningOrRebalancing)
-                    && states.stream().filter(state -> state != State.CREATED).allMatch(State::isRunningOrRebalancing);
+                return states.size() == 3
+                    && states.stream().filter(State::isRunningOrRebalancing).count() == 1
+                    && states.stream().filter(state -> state == State.CREATED).count() == 2;
             });
 
             WordCountClient client = ctx.getBean(WordCountClient.class);

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -5,6 +5,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.testcontainers.kafka.Kafka;
 import org.junit.jupiter.api.Test;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,9 +27,11 @@ class WordCountStreamTest {
         config.put("kafka.streams.my-other-stream.start-kafka-streams", StringUtils.FALSE);
 
         try (ApplicationContext ctx = ApplicationContext.run(config)) {
-            await().atMost(30, SECONDS).until(() ->
-                ctx.getBeansOfType(KafkaStreams.class).stream().allMatch(stream -> stream.state().isRunningOrRebalancing())
-            );
+            await().atMost(30, SECONDS).until(() -> {
+                var states = ctx.getBeansOfType(KafkaStreams.class).stream().map(KafkaStreams::state).toList();
+                return states.stream().anyMatch(State::isRunningOrRebalancing)
+                    && states.stream().filter(state -> state != State.CREATED).allMatch(State::isRunningOrRebalancing);
+            });
 
             WordCountClient client = ctx.getBean(WordCountClient.class);
             client.publishSentence("test to test for words");

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -7,8 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -16,15 +20,20 @@ import static org.awaitility.Awaitility.await;
 class WordCountStreamTest {
 
     @Test
-    void testWordCounter() {
+    void testWordCounter() throws IOException {
         Map<String, String> kafkaProps = Kafka.getProperties();
         Map<String, Object> config = new HashMap<>(kafkaProps);
+        String uniqueSuffix = UUID.randomUUID().toString();
+        Path stateDir = Files.createTempDirectory("test-suite-java-word-count-stream-");
+        stateDir.toFile().deleteOnExit();
         config.put("kafka.enabled", StringUtils.TRUE);
         config.put("micronaut.application.name", "test-suite-java-word-count-stream");
+        config.put("kafka.streams.default.application.id", "test-suite-java-word-count-stream-" + uniqueSuffix);
+        config.put("kafka.streams.default.state.dir", stateDir.toString());
         config.put("spec.name", "WordCountStreamTest");
-        config.put("kafka.streams.my-stream.application.id", "test-suite-java-my-stream");
+        config.put("kafka.streams.my-stream.application.id", "test-suite-java-my-stream-" + uniqueSuffix);
         config.put("kafka.streams.my-stream.start-kafka-streams", StringUtils.FALSE);
-        config.put("kafka.streams.my-other-stream.application.id", "test-suite-java-my-other-stream");
+        config.put("kafka.streams.my-other-stream.application.id", "test-suite-java-my-other-stream-" + uniqueSuffix);
         config.put("kafka.streams.my-other-stream.start-kafka-streams", StringUtils.FALSE);
 
         try (ApplicationContext ctx = ApplicationContext.run(config)) {

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/streams/WordCountStreamTest.java
@@ -4,6 +4,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.testcontainers.kafka.Kafka;
 import org.junit.jupiter.api.Test;
+import org.apache.kafka.streams.KafkaStreams;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,6 +26,10 @@ class WordCountStreamTest {
         config.put("kafka.streams.my-other-stream.start-kafka-streams", StringUtils.FALSE);
 
         try (ApplicationContext ctx = ApplicationContext.run(config)) {
+            await().atMost(30, SECONDS).until(() ->
+                ctx.getBeansOfType(KafkaStreams.class).stream().allMatch(stream -> stream.state().isRunningOrRebalancing())
+            );
+
             WordCountClient client = ctx.getBean(WordCountClient.class);
             client.publishSentence("test to test for words");
 


### PR DESCRIPTION
## Summary
- add @KafkaScope for beans that should live for a single Kafka listener invocation
- activate and destroy the scope around single-record and batch listener execution
- document the new scope in the guide with Java, Groovy, and Kotlin snippets

## Verification
- ./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.scope.KafkaScopeSpec --tests io.micronaut.configuration.kafka.processor.KafkaScopeConsumerStateSpec :test-suite:compileTestJava :test-suite-groovy:compileTestGroovy :test-suite-kotlin:compileTestKotlin publishGuide docs

Resolves #1017
