### PR TITLE
Document same-topic multi-type Kafka listeners

### DIFF
--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -15,6 +15,8 @@ snippet::io.micronaut.kafka.docs.consumer.config.ConsumerGroupIdListener[tags=an
 The above examples will run the consumer within a consumer group called `myGroup`.
 In this case, each record will be consumed by one consumer instance of the consumer group.
 
+NOTE: Kafka delivers records per consumer group before Micronaut binds listener method arguments. If multiple `@KafkaListener` methods subscribe to the same topic with different group IDs, each group receives every record published to that topic.
+
 TIP: You can make the consumer group configurable using a placeholder: `@KafkaListener("${my.consumer.group:myGroup}")`
 
 To allow the records to be consumed by all the consumer instances (each instance will be part of a unique consumer group), `uniqueGroupId` can be set to `true`:

--- a/src/main/docs/guide/kafkaListener/kafkaListenerMethods.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerMethods.adoc
@@ -22,6 +22,13 @@ You can also specify one or many regular expressions to listen for:
 
 snippet::io.micronaut.kafka.docs.consumer.topics.ProductListener[tags=patternTopics, indent=0]
 
+== Handling Multiple Payload Types on One Topic
+
+Kafka does not route records by `@MessageBody` type. If a topic intentionally carries multiple event types, prefer a single listener method that consumes a common supertype and branches on the concrete payload in application code.
+
+.Consuming a common supertype
+
+snippet::io.micronaut.kafka.docs.consumer.topics.FavoriteEventListener[tags=commonSupertype, indent=0]
 
 == Available Annotations
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.groovy
@@ -13,18 +13,12 @@ class FavoriteEventListener {
     @Topic('favorites-events')
     void receive(@KafkaKey String customerId, FavoriteEvent event) {
         if (event instanceof FavoriteSaved) {
-            handleSaved(customerId, event)
+            // process the save event for this customer
         } else if (event instanceof FavoriteDeleted) {
-            handleDeleted(customerId, event)
+            // process the delete event for this customer
         }
     }
     // end::commonSupertype[]
-
-    private void handleSaved(String customerId, FavoriteSaved favoriteSaved) {
-    }
-
-    private void handleDeleted(String customerId, FavoriteDeleted favoriteDeleted) {
-    }
 
     static abstract class FavoriteEvent {
     }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.kafka.docs.consumer.topics
+
+import io.micronaut.configuration.kafka.annotation.KafkaKey
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = 'spec.name', value = 'FavoriteEventListenerTest')
+@KafkaListener
+class FavoriteEventListener {
+
+    // tag::commonSupertype[]
+    @Topic('favorites-events')
+    void receive(@KafkaKey String customerId, FavoriteEvent event) {
+        if (event instanceof FavoriteSaved) {
+            handleSaved(customerId, event)
+        } else if (event instanceof FavoriteDeleted) {
+            handleDeleted(customerId, event)
+        }
+    }
+    // end::commonSupertype[]
+
+    private void handleSaved(String customerId, FavoriteSaved favoriteSaved) {
+    }
+
+    private void handleDeleted(String customerId, FavoriteDeleted favoriteDeleted) {
+    }
+
+    static abstract class FavoriteEvent {
+    }
+
+    static final class FavoriteSaved extends FavoriteEvent {
+    }
+
+    static final class FavoriteDeleted extends FavoriteEvent {
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.kt
@@ -13,17 +13,15 @@ class FavoriteEventListener {
     @Topic("favorites-events")
     fun receive(@KafkaKey customerId: String, event: FavoriteEvent) {
         when (event) {
-            is FavoriteSaved -> handleSaved(customerId, event)
-            is FavoriteDeleted -> handleDeleted(customerId, event)
+            is FavoriteSaved -> {
+                // process the save event for this customer
+            }
+            is FavoriteDeleted -> {
+                // process the delete event for this customer
+            }
         }
     }
     // end::commonSupertype[]
-
-    private fun handleSaved(customerId: String, favoriteSaved: FavoriteSaved) {
-    }
-
-    private fun handleDeleted(customerId: String, favoriteDeleted: FavoriteDeleted) {
-    }
 }
 
 sealed interface FavoriteEvent

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.kt
@@ -1,0 +1,33 @@
+package io.micronaut.kafka.docs.consumer.topics
+
+import io.micronaut.configuration.kafka.annotation.KafkaKey
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = "spec.name", value = "FavoriteEventListenerTest")
+@KafkaListener
+class FavoriteEventListener {
+
+    // tag::commonSupertype[]
+    @Topic("favorites-events")
+    fun receive(@KafkaKey customerId: String, event: FavoriteEvent) {
+        when (event) {
+            is FavoriteSaved -> handleSaved(customerId, event)
+            is FavoriteDeleted -> handleDeleted(customerId, event)
+        }
+    }
+    // end::commonSupertype[]
+
+    private fun handleSaved(customerId: String, favoriteSaved: FavoriteSaved) {
+    }
+
+    private fun handleDeleted(customerId: String, favoriteDeleted: FavoriteDeleted) {
+    }
+}
+
+sealed interface FavoriteEvent
+
+class FavoriteSaved : FavoriteEvent
+
+class FavoriteDeleted : FavoriteEvent

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.java
@@ -12,19 +12,13 @@ public class FavoriteEventListener {
     // tag::commonSupertype[]
     @Topic("favorites-events")
     public void receive(@KafkaKey String customerId, FavoriteEvent event) {
-        if (event instanceof FavoriteSaved favoriteSaved) {
-            handleSaved(customerId, favoriteSaved);
-        } else if (event instanceof FavoriteDeleted favoriteDeleted) {
-            handleDeleted(customerId, favoriteDeleted);
+        if (event instanceof FavoriteSaved) {
+            // process the save event for this customer
+        } else if (event instanceof FavoriteDeleted) {
+            // process the delete event for this customer
         }
     }
     // end::commonSupertype[]
-
-    private void handleSaved(String customerId, FavoriteSaved favoriteSaved) {
-    }
-
-    private void handleDeleted(String customerId, FavoriteDeleted favoriteDeleted) {
-    }
 
     abstract static class FavoriteEvent {
     }

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/topics/FavoriteEventListener.java
@@ -1,0 +1,37 @@
+package io.micronaut.kafka.docs.consumer.topics;
+
+import io.micronaut.configuration.kafka.annotation.KafkaKey;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "FavoriteEventListenerTest")
+@KafkaListener
+public class FavoriteEventListener {
+
+    // tag::commonSupertype[]
+    @Topic("favorites-events")
+    public void receive(@KafkaKey String customerId, FavoriteEvent event) {
+        if (event instanceof FavoriteSaved favoriteSaved) {
+            handleSaved(customerId, favoriteSaved);
+        } else if (event instanceof FavoriteDeleted favoriteDeleted) {
+            handleDeleted(customerId, favoriteDeleted);
+        }
+    }
+    // end::commonSupertype[]
+
+    private void handleSaved(String customerId, FavoriteSaved favoriteSaved) {
+    }
+
+    private void handleDeleted(String customerId, FavoriteDeleted favoriteDeleted) {
+    }
+
+    abstract static class FavoriteEvent {
+    }
+
+    static final class FavoriteSaved extends FavoriteEvent {
+    }
+
+    static final class FavoriteDeleted extends FavoriteEvent {
+    }
+}


### PR DESCRIPTION
## Summary
- clarify that Kafka delivers records per consumer group before Micronaut binds listener method arguments
- document the supported pattern for heterogeneous payloads on one topic using a single listener and a common supertype
- add Java, Groovy, and Kotlin snippet sources for the new guide example

## Verification
- ./gradlew spotlessCheck :test-suite:compileTestJava :test-suite-groovy:compileTestGroovy :test-suite-kotlin:compileTestKotlin publishGuide -q -x japiCmp -x checkVersionCatalogCompatibility

Resolves #889
