### PR TITLE
Synchronize ConsumerRegistry access to Kafka consumers

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/ConsumerRegistry.java
@@ -32,8 +32,9 @@ import java.util.Set;
 public interface ConsumerRegistry {
 
     /**
-     * Returns a managed Consumer. Note that the consumer should not be interacted with directly from a
-     * different thread to the poll loop!
+     * Returns a managed Consumer. Access to the returned consumer is synchronized with Micronaut's poll loop so
+     * that consumer operations can be invoked from another thread without overlapping framework-managed access.
+     * Callers are still responsible for coordinating their own multi-step interactions with the consumer.
      *
      * @param id The id of the producer.
      * @param <K> The key generic type

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -76,6 +76,8 @@ abstract class ConsumerState {
     protected boolean failed;
     final ConsumerInfo info;
     final Consumer<?, ?> kafkaConsumer;
+    private final Object consumerAccessMonitor = new Object();
+    final Consumer<?, ?> synchronizedKafkaConsumer;
     final Set<String> subscriptions;
     Set<TopicPartition> assignments;
     private Set<TopicPartition> pausedTopicPartitions;
@@ -96,6 +98,7 @@ abstract class ConsumerState {
         this.kafkaConsumerProcessor = kafkaConsumerProcessor;
         this.info = info;
         this.kafkaConsumer = consumer;
+        this.synchronizedKafkaConsumer = SynchronizedConsumer.wrap(consumer, consumerAccessMonitor);
         this.consumerBean = consumerBean;
         this.subscriptions = Collections.unmodifiableSet(kafkaConsumer.subscription());
         this.startupLatch = info.autoStartup ? null : new CountDownLatch(1);
@@ -150,7 +153,7 @@ abstract class ConsumerState {
     }
 
     void wakeUp() {
-        kafkaConsumer.wakeup();
+        synchronizedKafkaConsumer.wakeup();
         synchronized (this) {
             if (startupLatch != null) {
                 startupLatch.countDown();
@@ -191,7 +194,7 @@ abstract class ConsumerState {
     }
 
     void threadPollLoop() {
-        try (kafkaConsumer) {
+        try (Consumer<?, ?> ignored = synchronizedKafkaConsumer) {
             holdStartup();
             while (!shutdownRequested) {
                 refreshAssignmentsPollAndProcessRecords();
@@ -222,7 +225,7 @@ abstract class ConsumerState {
         } catch (WakeupException e) {
             try {
                 if (!failed && info.offsetStrategy != OffsetStrategy.DISABLED) {
-                    kafkaConsumer.commitSync();
+                    synchronizedKafkaConsumer.commitSync();
                 }
             } catch (Exception ex) {
                 LOG.warn("Error committing Kafka offsets on shutdown: {}", ex.getMessage(), ex);
@@ -234,7 +237,7 @@ abstract class ConsumerState {
     }
 
     private void refreshAssignments() {
-        final Set<TopicPartition> newAssignments = kafkaConsumer.assignment();
+        final Set<TopicPartition> newAssignments = synchronizedKafkaConsumer.assignment();
         if (!newAssignments.equals(assignments)) {
             LOG.info("Consumer [{}] assignments changed: {} -> {}", info.clientId, assignments, newAssignments);
             assignments = Collections.unmodifiableSet(newAssignments);
@@ -263,12 +266,12 @@ abstract class ConsumerState {
         }
         if (info.offsetStrategy == OffsetStrategy.SYNC) {
             try {
-                kafkaConsumer.commitSync();
+                synchronizedKafkaConsumer.commitSync();
             } catch (CommitFailedException e) {
                 handleException(e, consumerRecords, null);
             }
         } else if (info.offsetStrategy == OffsetStrategy.ASYNC) {
-            kafkaConsumer.commitAsync(resolveCommitCallback());
+            synchronizedKafkaConsumer.commitAsync(resolveCommitCallback());
         }
     }
 
@@ -294,8 +297,8 @@ abstract class ConsumerState {
             return;
         }
         LOG.trace("Pausing Kafka consumption for Consumer [{}] from topic partition: {}", info.clientId, validPauseRequests);
-        kafkaConsumer.pause(validPauseRequests);
-        LOG.debug("Paused Kafka consumption for Consumer [{}] from topic partition: {}", info.clientId, kafkaConsumer.paused());
+        synchronizedKafkaConsumer.pause(validPauseRequests);
+        LOG.debug("Paused Kafka consumption for Consumer [{}] from topic partition: {}", info.clientId, synchronizedKafkaConsumer.paused());
         if (pausedTopicPartitions == null) {
             pausedTopicPartitions = new HashSet<>();
         }
@@ -303,7 +306,7 @@ abstract class ConsumerState {
     }
 
     private synchronized void resumeTopicPartitions() {
-        Set<TopicPartition> paused = kafkaConsumer.paused();
+        Set<TopicPartition> paused = synchronizedKafkaConsumer.paused();
         if (paused.isEmpty()) {
             return;
         }
@@ -312,7 +315,7 @@ abstract class ConsumerState {
             .toList();
         if (!toResume.isEmpty()) {
             LOG.debug("Resuming Kafka consumption for Consumer [{}] from topic partition: {}", info.clientId, toResume);
-            kafkaConsumer.resume(toResume);
+            synchronizedKafkaConsumer.resume(toResume);
         }
         if (pausedTopicPartitions != null) {
             toResume.forEach(pausedTopicPartitions::remove);
@@ -522,6 +525,11 @@ abstract class ConsumerState {
     protected void handleException(Throwable e, @Nullable ConsumerRecords<?, ?> consumerRecords,
         @Nullable ConsumerRecord<?, ?> consumerRecord) {
         handleException(e.getMessage(), e, consumerRecords, consumerRecord);
+    }
+
+    @SuppressWarnings("unchecked")
+    <K, V> Consumer<K, V> getThreadSafeKafkaConsumer() {
+        return (Consumer<K, V>) synchronizedKafkaConsumer;
     }
 
     protected void publishToDlq(Throwable e, @Nullable ConsumerRecords<?, ?> consumerRecords,

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -76,10 +76,10 @@ abstract class ConsumerState {
     protected boolean failed;
     final ConsumerInfo info;
     final Consumer<?, ?> kafkaConsumer;
-    private final Object consumerAccessMonitor = new Object();
     final Consumer<?, ?> synchronizedKafkaConsumer;
     final Set<String> subscriptions;
     Set<TopicPartition> assignments;
+    private final Object consumerAccessMonitor = new Object();
     private Set<TopicPartition> pausedTopicPartitions;
     private Set<TopicPartition> pauseRequests;
     private CountDownLatch startupLatch;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateBatch.java
@@ -65,20 +65,20 @@ final class ConsumerStateBatch extends ConsumerState {
     @Nullable
     protected Map<TopicPartition, OffsetAndMetadata> getCurrentOffsets() {
         return info.errorStrategy.isRetry() ?
-            kafkaConsumer.assignment().stream().collect(Collectors.toMap(identity(), this::getCurrentOffset)) : null;
+            synchronizedKafkaConsumer.assignment().stream().collect(Collectors.toMap(identity(), this::getCurrentOffset)) : null;
     }
 
     @Override
     protected ConsumerRecords<?, ?> pollRecords(
         @Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
-            return kafkaConsumer.poll(info.pollTimeout);
+            return synchronizedKafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             }
             if (info.offsetStrategy != OffsetStrategy.DISABLED) {
-                kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
+                synchronizedKafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             }
             resolveWithErrorStrategy(null, reconstructCurrentOffsetsIfAbsent(currentOffsets, ex), makeConsumerRecord(ex), ex);
             return null;
@@ -93,9 +93,9 @@ final class ConsumerStateBatch extends ConsumerState {
                 final ExecutableMethod<Object, ?> method = info.methodForTopic(topic);
                 Optional.ofNullable(info.ackArg(topic)).ifPresent(argument -> {
                     final Map<TopicPartition, OffsetAndMetadata> batchOffsets = getAckOffsets(topicRecords);
-                    boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(batchOffsets));
+                    boundArguments.put(argument, (KafkaAcknowledgement) () -> synchronizedKafkaConsumer.commitSync(batchOffsets));
                 });
-                Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
+                Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, synchronizedKafkaConsumer));
                 if (method.isSuspend()) {
                     Argument<?> lastArgument = method.getArguments()[method.getArguments().length - 1];
                     boundArguments.put(lastArgument, null);
@@ -167,7 +167,7 @@ final class ConsumerStateBatch extends ConsumerState {
                     if (info.shouldHandleAllExceptions) {
                         handleException(e, consumerRecords, null);
                     }
-                    partitions.forEach(tp -> kafkaConsumer.seek(tp, reconstructedOffsets.get(tp).offset()));
+                    partitions.forEach(tp -> synchronizedKafkaConsumer.seek(tp, reconstructedOffsets.get(tp).offset()));
                     delayRetry(currentRetryCount, partitions);
                     return true;
                 }
@@ -191,7 +191,7 @@ final class ConsumerStateBatch extends ConsumerState {
     }
 
     private OffsetAndMetadata getCurrentOffset(TopicPartition tp) {
-        return new OffsetAndMetadata(kafkaConsumer.position(tp), null);
+        return new OffsetAndMetadata(synchronizedKafkaConsumer.position(tp), null);
     }
 
     private Map<TopicPartition, OffsetAndMetadata> reconstructCurrentOffsetsIfAbsent(

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,14 +58,14 @@ final class ConsumerStateSingle extends ConsumerState {
     protected ConsumerRecords<?, ?> pollRecords(@Nullable Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         // Deserialization errors can happen while polling
         try {
-            return kafkaConsumer.poll(info.pollTimeout);
+            return synchronizedKafkaConsumer.poll(info.pollTimeout);
         } catch (RecordDeserializationException ex) {
             // Try to honor the configured error strategy
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Kafka consumer [{}] failed to deserialize value while polling", info.logMethod(ex.topicPartition().topic()), ex);
             }
             // By default, seek past the record to continue consumption
-            kafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
+            synchronizedKafkaConsumer.seek(ex.topicPartition(), ex.offset() + 1);
             // The error strategy and the exception handler can still decide what to do about this record
             resolveWithErrorStrategy(null, makeConsumerRecord(ex), ex);
             // By now, it's been decided whether this record should be retried and the exception may have been handled
@@ -117,8 +117,8 @@ final class ConsumerStateSingle extends ConsumerState {
             boundArguments.put(seekArgument, seek);
         }
         Optional.ofNullable(info.ackArg(topic))
-            .ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> kafkaConsumer.commitSync(currentOffsets)));
-        Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, kafkaConsumer));
+            .ifPresent(argument -> boundArguments.put(argument, (KafkaAcknowledgement) () -> synchronizedKafkaConsumer.commitSync(currentOffsets)));
+        Optional.ofNullable(info.consumerArg(topic)).ifPresent(argument -> boundArguments.put(argument, synchronizedKafkaConsumer));
         return seek;
     }
 
@@ -144,7 +144,7 @@ final class ConsumerStateSingle extends ConsumerState {
         if (info.offsetStrategy == OffsetStrategy.SYNC_PER_RECORD) {
             commitSync(consumerRecords, consumerRecord, currentOffsets);
         } else if (info.offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD) {
-            kafkaConsumer.commitAsync(currentOffsets, this::resolveCommitCallback);
+            synchronizedKafkaConsumer.commitAsync(currentOffsets, this::resolveCommitCallback);
         }
     }
 
@@ -188,7 +188,7 @@ final class ConsumerStateSingle extends ConsumerState {
                         handleException(e, consumerRecords, consumerRecord);
                     }
                     // Move back to the previous position
-                    kafkaConsumer.seek(topicPartition, consumerRecord.offset());
+                    synchronizedKafkaConsumer.seek(topicPartition, consumerRecord.offset());
                     // Decide how long should we wait to retry this batch again
                     delayRetry(currentRetryCount, Collections.singleton(topicPartition));
                     return true;
@@ -205,7 +205,7 @@ final class ConsumerStateSingle extends ConsumerState {
 
     private void commitSync(ConsumerRecords<?, ?> consumerRecords, ConsumerRecord<?, ?> consumerRecord, Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         try {
-            kafkaConsumer.commitSync(currentOffsets);
+            synchronizedKafkaConsumer.commitSync(currentOffsets);
         } catch (CommitFailedException e) {
             handleException(e, consumerRecords, consumerRecord);
         }
@@ -229,7 +229,7 @@ final class ConsumerStateSingle extends ConsumerState {
             if (!processedPartitions.add(topicPartition)) {
                 continue;
             }
-            kafkaConsumer.seek(topicPartition, consumerRecord.offset());
+            synchronizedKafkaConsumer.seek(topicPartition, consumerRecord.offset());
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -219,7 +219,7 @@ class KafkaConsumerProcessor
     public <K, V> Consumer<K, V> getConsumer(@NonNull String id) {
         ArgumentUtils.requireNonNull("id", id);
         @SuppressWarnings("rawtypes")
-        final Consumer consumer = getConsumerState(id).kafkaConsumer;
+        final Consumer consumer = getConsumerState(id).getThreadSafeKafkaConsumer();
         if (consumer == null) {
             throw new IllegalArgumentException("No consumer found for ID: " + id);
         }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/SynchronizedConsumer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/SynchronizedConsumer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.core.annotation.Internal;
+import org.apache.kafka.clients.consumer.Consumer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+
+/**
+ * Creates a synchronized {@link Consumer} view that shares a monitor with Micronaut's poll loop.
+ * The {@code wakeup} method remains unsynchronized because Kafka documents it as the only thread-safe method.
+ *
+ * @author graemerocher
+ * @since 5.7.0
+ */
+@Internal
+final class SynchronizedConsumer {
+
+    private SynchronizedConsumer() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, V> Consumer<K, V> wrap(Consumer<K, V> consumer, Object monitor) {
+        return (Consumer<K, V>) Proxy.newProxyInstance(
+            consumer.getClass().getClassLoader(),
+            new Class<?>[] { Consumer.class },
+            (proxy, method, args) -> {
+                if (method.getDeclaringClass() == Object.class || method.getName().equals("wakeup")) {
+                    return invoke(consumer, method, args);
+                }
+                synchronized (monitor) {
+                    return invoke(consumer, method, args);
+                }
+            }
+        );
+    }
+
+    private static Object invoke(Consumer<?, ?> consumer, java.lang.reflect.Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(consumer, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/SynchronizedConsumer.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/SynchronizedConsumer.java
@@ -16,10 +16,29 @@
 package io.micronaut.configuration.kafka.processor;
 
 import io.micronaut.core.annotation.Internal;
+import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.SubscriptionPattern;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Creates a synchronized {@link Consumer} view that shares a monitor with Micronaut's poll loop.
@@ -34,27 +53,378 @@ final class SynchronizedConsumer {
     private SynchronizedConsumer() {
     }
 
-    @SuppressWarnings("unchecked")
     static <K, V> Consumer<K, V> wrap(Consumer<K, V> consumer, Object monitor) {
-        return (Consumer<K, V>) Proxy.newProxyInstance(
-            consumer.getClass().getClassLoader(),
-            new Class<?>[] { Consumer.class },
-            (proxy, method, args) -> {
-                if (method.getDeclaringClass() == Object.class || method.getName().equals("wakeup")) {
-                    return invoke(consumer, method, args);
-                }
-                synchronized (monitor) {
-                    return invoke(consumer, method, args);
-                }
-            }
-        );
+        return new Wrapper<>(consumer, monitor);
     }
 
-    private static Object invoke(Consumer<?, ?> consumer, java.lang.reflect.Method method, Object[] args) throws Throwable {
-        try {
-            return method.invoke(consumer, args);
-        } catch (InvocationTargetException e) {
-            throw e.getCause();
+    private static final class Wrapper<K, V> implements Consumer<K, V> {
+
+        private final Consumer<K, V> delegate;
+        private final Object monitor;
+
+        Wrapper(Consumer<K, V> delegate, Object monitor) {
+            this.delegate = delegate;
+            this.monitor = monitor;
+        }
+
+        @Override
+        public Set<TopicPartition> assignment() {
+            synchronized (monitor) {
+                return delegate.assignment();
+            }
+        }
+
+        @Override
+        public Set<String> subscription() {
+            synchronized (monitor) {
+                return delegate.subscription();
+            }
+        }
+
+        @Override
+        public void subscribe(Collection<String> topics) {
+            synchronized (monitor) {
+                delegate.subscribe(topics);
+            }
+        }
+
+        @Override
+        public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+            synchronized (monitor) {
+                delegate.subscribe(topics, callback);
+            }
+        }
+
+        @Override
+        public void assign(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                delegate.assign(partitions);
+            }
+        }
+
+        @Override
+        public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+            synchronized (monitor) {
+                delegate.subscribe(pattern, callback);
+            }
+        }
+
+        @Override
+        public void subscribe(Pattern pattern) {
+            synchronized (monitor) {
+                delegate.subscribe(pattern);
+            }
+        }
+
+        @Override
+        public void subscribe(SubscriptionPattern pattern, ConsumerRebalanceListener callback) {
+            synchronized (monitor) {
+                delegate.subscribe(pattern, callback);
+            }
+        }
+
+        @Override
+        public void subscribe(SubscriptionPattern pattern) {
+            synchronized (monitor) {
+                delegate.subscribe(pattern);
+            }
+        }
+
+        @Override
+        public void unsubscribe() {
+            synchronized (monitor) {
+                delegate.unsubscribe();
+            }
+        }
+
+        @Override
+        public ConsumerRecords<K, V> poll(Duration timeout) {
+            synchronized (monitor) {
+                return delegate.poll(timeout);
+            }
+        }
+
+        @Override
+        public void commitSync() {
+            synchronized (monitor) {
+                delegate.commitSync();
+            }
+        }
+
+        @Override
+        public void commitSync(Duration timeout) {
+            synchronized (monitor) {
+                delegate.commitSync(timeout);
+            }
+        }
+
+        @Override
+        public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+            synchronized (monitor) {
+                delegate.commitSync(offsets);
+            }
+        }
+
+        @Override
+        public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+            synchronized (monitor) {
+                delegate.commitSync(offsets, timeout);
+            }
+        }
+
+        @Override
+        public void commitAsync() {
+            synchronized (monitor) {
+                delegate.commitAsync();
+            }
+        }
+
+        @Override
+        public void commitAsync(OffsetCommitCallback callback) {
+            synchronized (monitor) {
+                delegate.commitAsync(callback);
+            }
+        }
+
+        @Override
+        public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+            synchronized (monitor) {
+                delegate.commitAsync(offsets, callback);
+            }
+        }
+
+        @Override
+        public void registerMetricForSubscription(KafkaMetric metric) {
+            synchronized (monitor) {
+                delegate.registerMetricForSubscription(metric);
+            }
+        }
+
+        @Override
+        public void unregisterMetricFromSubscription(KafkaMetric metric) {
+            synchronized (monitor) {
+                delegate.unregisterMetricFromSubscription(metric);
+            }
+        }
+
+        @Override
+        public void seek(TopicPartition partition, long offset) {
+            synchronized (monitor) {
+                delegate.seek(partition, offset);
+            }
+        }
+
+        @Override
+        public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
+            synchronized (monitor) {
+                delegate.seek(partition, offsetAndMetadata);
+            }
+        }
+
+        @Override
+        public void seekToBeginning(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                delegate.seekToBeginning(partitions);
+            }
+        }
+
+        @Override
+        public void seekToEnd(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                delegate.seekToEnd(partitions);
+            }
+        }
+
+        @Override
+        public long position(TopicPartition partition) {
+            synchronized (monitor) {
+                return delegate.position(partition);
+            }
+        }
+
+        @Override
+        public long position(TopicPartition partition, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.position(partition, timeout);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions) {
+            synchronized (monitor) {
+                return delegate.committed(partitions);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.committed(partitions, timeout);
+            }
+        }
+
+        @Override
+        public Uuid clientInstanceId(Duration timeout) {
+            synchronized (monitor) {
+                return delegate.clientInstanceId(timeout);
+            }
+        }
+
+        @Override
+        public Map<MetricName, ? extends Metric> metrics() {
+            synchronized (monitor) {
+                return delegate.metrics();
+            }
+        }
+
+        @Override
+        public List<PartitionInfo> partitionsFor(String topic) {
+            synchronized (monitor) {
+                return delegate.partitionsFor(topic);
+            }
+        }
+
+        @Override
+        public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.partitionsFor(topic, timeout);
+            }
+        }
+
+        @Override
+        public Map<String, List<PartitionInfo>> listTopics() {
+            synchronized (monitor) {
+                return delegate.listTopics();
+            }
+        }
+
+        @Override
+        public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
+            synchronized (monitor) {
+                return delegate.listTopics(timeout);
+            }
+        }
+
+        @Override
+        public Set<TopicPartition> paused() {
+            synchronized (monitor) {
+                return delegate.paused();
+            }
+        }
+
+        @Override
+        public void pause(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                delegate.pause(partitions);
+            }
+        }
+
+        @Override
+        public void resume(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                delegate.resume(partitions);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+            synchronized (monitor) {
+                return delegate.offsetsForTimes(timestampsToSearch);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.offsetsForTimes(timestampsToSearch, timeout);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                return delegate.beginningOffsets(partitions);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.beginningOffsets(partitions, timeout);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+            synchronized (monitor) {
+                return delegate.endOffsets(partitions);
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+            synchronized (monitor) {
+                return delegate.endOffsets(partitions, timeout);
+            }
+        }
+
+        @Override
+        public OptionalLong currentLag(TopicPartition topicPartition) {
+            synchronized (monitor) {
+                return delegate.currentLag(topicPartition);
+            }
+        }
+
+        @Override
+        public ConsumerGroupMetadata groupMetadata() {
+            synchronized (monitor) {
+                return delegate.groupMetadata();
+            }
+        }
+
+        @Override
+        public void enforceRebalance() {
+            synchronized (monitor) {
+                delegate.enforceRebalance();
+            }
+        }
+
+        @Override
+        public void enforceRebalance(String reason) {
+            synchronized (monitor) {
+                delegate.enforceRebalance(reason);
+            }
+        }
+
+        @Override
+        public void close() {
+            synchronized (monitor) {
+                delegate.close();
+            }
+        }
+
+        /**
+         * @deprecated Use {@link #close(CloseOptions)} instead.
+         */
+        @Override
+        @Deprecated
+        public void close(Duration timeout) {
+            synchronized (monitor) {
+                delegate.close(timeout);
+            }
+        }
+
+        @Override
+        public void close(CloseOptions option) {
+            synchronized (monitor) {
+                delegate.close(option);
+            }
+        }
+
+        @Override
+        public void wakeup() {
+            // wakeup() is the only thread-safe KafkaConsumer method; intentionally not synchronized
+            delegate.wakeup();
         }
     }
 }

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessorSynchronizationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessorSynchronizationSpec.groovy
@@ -1,0 +1,209 @@
+package io.micronaut.configuration.kafka.processor
+
+import io.micronaut.configuration.kafka.ProducerRegistry
+import io.micronaut.configuration.kafka.TransactionalProducerRegistry
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry
+import io.micronaut.configuration.kafka.bind.batch.BatchConsumerRecordsBinderRegistry
+import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration
+import io.micronaut.configuration.kafka.event.KafkaConsumerStartedPollingEvent
+import io.micronaut.configuration.kafka.event.KafkaConsumerSubscribedEvent
+import io.micronaut.configuration.kafka.exceptions.KafkaListenerExceptionHandler
+import io.micronaut.configuration.kafka.retry.ConditionalRetryBehaviourHandler
+import io.micronaut.configuration.kafka.serde.SerdeRegistry
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanProvider
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.ReturnType
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.runtime.ApplicationConfiguration
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
+import spock.lang.Specification
+
+import java.lang.reflect.Proxy
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class KafkaConsumerProcessorSynchronizationSpec extends Specification {
+
+    void "getConsumer serializes access with the poll loop"() {
+        given:
+        KafkaConsumerProcessor processor = newKafkaConsumerProcessor()
+        BlockingConsumerHandler handler = new BlockingConsumerHandler()
+        Consumer<?, ?> kafkaConsumer = handler.consumer()
+        ConsumerStateSingle state = new ConsumerStateSingle(processor, consumerInfo(), kafkaConsumer, new Object())
+        processor.@consumers.put('test-client', state)
+        Thread pollThread = new Thread(state.&threadPollLoop, 'kafka-consumer-poll')
+
+        when:
+        pollThread.start()
+
+        then:
+        handler.awaitPollStarted()
+
+        when:
+        CompletableFuture<Set<TopicPartition>> assignmentFuture = CompletableFuture.supplyAsync {
+            processor.getConsumer('test-client').assignment()
+        }
+        sleep(200)
+
+        then:
+        !assignmentFuture.isDone()
+
+        when:
+        state.requestShutdown()
+        state.wakeUp()
+
+        then:
+        assignmentFuture.get(5, TimeUnit.SECONDS) == BlockingConsumerHandler.ASSIGNMENT
+        pollThread.join(5000)
+        !pollThread.isAlive()
+        handler.maxConcurrentAccess.get() == 1
+    }
+
+    private KafkaConsumerProcessor newKafkaConsumerProcessor() {
+        BeanContext beanContext = Stub() {
+            getBeanDefinitions(_) >> ([] as Collection<BeanDefinition<?>>)
+        }
+        new KafkaConsumerProcessor(
+            Stub(ExecutorService),
+            Stub(ApplicationConfiguration),
+            Stub(BeanProvider<KafkaConsumerGroupManager>),
+            beanContext,
+            Stub(AbstractKafkaConsumerConfiguration),
+            Stub(ConsumerRecordBinderRegistry),
+            Stub(BatchConsumerRecordsBinderRegistry),
+            Stub(SerdeRegistry),
+            Stub(ProducerRegistry),
+            Stub(KafkaListenerExceptionHandler),
+            Stub(ScheduledExecutorService),
+            Stub(TransactionalProducerRegistry),
+            Stub(ApplicationEventPublisher<KafkaConsumerStartedPollingEvent>),
+            Stub(ApplicationEventPublisher<KafkaConsumerSubscribedEvent>),
+            Stub(ConditionalRetryBehaviourHandler)
+        )
+    }
+
+    private ConsumerInfo consumerInfo() {
+        ReturnType<?> returnType = Stub() {
+            getType() >> void
+            isAsyncOrReactive() >> false
+            getFirstTypeVariable() >> Optional.empty()
+        }
+        ExecutableMethod<?, ?> method = Stub() {
+            getDeclaringType() >> KafkaConsumerProcessorSynchronizationSpec
+            getName() >> 'receive'
+            isTrue(KafkaListener, 'batch') >> false
+            hasAnnotation(_ as Class) >> false
+            getValue(KafkaListener, 'pollTimeout', Duration) >> Optional.of(Duration.ofSeconds(5))
+            getArguments() >> Argument.ZERO_ARGUMENTS
+            stringValues(_ as Class) >> ([] as String[])
+            getReturnType() >> returnType
+        }
+        new ConsumerInfo(
+            'test-client',
+            'test-group',
+            OffsetStrategy.DISABLED,
+            AnnotationValue.builder(KafkaListener).build(),
+            new Properties(),
+            method
+        )
+    }
+
+    private static final class BlockingConsumerHandler {
+        static final Set<TopicPartition> ASSIGNMENT = Collections.singleton(new TopicPartition('topic', 0))
+
+        final CountDownLatch pollStarted = new CountDownLatch(1)
+        final CountDownLatch releasePoll = new CountDownLatch(1)
+        final AtomicBoolean wakeupRequested = new AtomicBoolean()
+        final AtomicInteger activeCalls = new AtomicInteger()
+        final AtomicInteger maxConcurrentAccess = new AtomicInteger()
+
+        Consumer<?, ?> consumer() {
+            Proxy.newProxyInstance(
+                BlockingConsumerHandler.classLoader,
+                [Consumer] as Class<?>[],
+                { _, method, args ->
+                    if (method.name == 'wakeup') {
+                        wakeupRequested.set(true)
+                        releasePoll.countDown()
+                        return null
+                    }
+                    int current = activeCalls.incrementAndGet()
+                    maxConcurrentAccess.accumulateAndGet(current, Math::max)
+                    if (current > 1) {
+                        activeCalls.decrementAndGet()
+                        throw new ConcurrentModificationException('Concurrent KafkaConsumer access detected')
+                    }
+                    try {
+                        switch (method.name) {
+                            case 'subscription':
+                                return Collections.emptySet()
+                            case 'assignment':
+                                return ASSIGNMENT
+                            case 'poll':
+                                pollStarted.countDown()
+                                releasePoll.await(5, TimeUnit.SECONDS)
+                                if (wakeupRequested.get()) {
+                                    throw new WakeupException()
+                                }
+                                return ConsumerRecords.empty()
+                            case 'commitSync':
+                            case 'close':
+                                return null
+                            default:
+                                return defaultValue(method.returnType)
+                        }
+                    } finally {
+                        activeCalls.decrementAndGet()
+                    }
+                }
+            ) as Consumer<?, ?>
+        }
+
+        void awaitPollStarted() {
+            assert pollStarted.await(5, TimeUnit.SECONDS)
+        }
+
+        private static Object defaultValue(Class<?> returnType) {
+            if (returnType == boolean) {
+                return false
+            }
+            if (returnType == byte) {
+                return (byte) 0
+            }
+            if (returnType == short) {
+                return (short) 0
+            }
+            if (returnType == int) {
+                return 0
+            }
+            if (returnType == long) {
+                return 0L
+            }
+            if (returnType == float) {
+                return 0f
+            }
+            if (returnType == double) {
+                return 0d
+            }
+            if (returnType == char) {
+                return (char) 0
+            }
+            null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- synchronize `ConsumerRegistry#getConsumer` access with the framework poll loop
- route framework-owned Kafka consumer operations through the same synchronized consumer view
- add a focused regression test for concurrent access between the poll thread and external callers

## Verification
- `./gradlew :micronaut-kafka:test --tests io.micronaut.configuration.kafka.processor.KafkaConsumerProcessorSynchronizationSpec --tests io.micronaut.configuration.kafka.processor.ConsumerStateSingleSpec --tests io.micronaut.configuration.kafka.processor.ConsumerStateBatchSpec --tests io.micronaut.configuration.kafka.processor.KafkaConsumerProcessorGracefulShutdownSpec`
- `./gradlew :micronaut-kafka:spotlessCheck`

Resolves #613
