### PR TITLE
Make AdminClient optional

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/admin/AdminClientFactory.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/admin/AdminClientFactory.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.configuration.kafka.admin;
 
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 
 import jakarta.inject.Singleton;
@@ -31,6 +33,7 @@ import jakarta.inject.Singleton;
  */
 @Factory
 @Requires(beans = KafkaDefaultConfiguration.class)
+@Requires(property = AbstractKafkaConfiguration.PREFIX + ".admin.enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class AdminClientFactory {
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/health/KafkaHealthIndicator.java
@@ -68,7 +68,7 @@ public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceLis
     private static final String DETAILS_BROKER_ID = "brokerId";
     private static final String DETAILS_CLUSTER_ID = "clusterId";
     private static final String DETAILS_NODES = "nodes";
-    private final Supplier<AdminClient> adminClientSupplier;
+    private final Supplier<Optional<AdminClient>> adminClientSupplier;
     private final KafkaDefaultConfiguration defaultConfiguration;
 
     private final Supplier<NetworkClient> networkClientSupplier;
@@ -90,7 +90,7 @@ public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceLis
                                 KafkaDefaultConfiguration defaultConfiguration,
                                 NetworkClientCreator networkClientCreator,
                                 KafkaHealthConfiguration kafkaHealthConfiguration) {
-        this.adminClientSupplier = SupplierUtil.memoized(() -> beanContext.getBean(AdminClient.class));
+        this.adminClientSupplier = SupplierUtil.memoized(() -> beanContext.findBean(AdminClient.class));
         this.defaultConfiguration = defaultConfiguration;
         this.networkClientSupplier = SupplierUtil.memoized(() -> networkClientCreator.create(this));
         this.kafkaHealthConfiguration = kafkaHealthConfiguration;
@@ -106,7 +106,7 @@ public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceLis
     @Deprecated(forRemoval = true)
     public KafkaHealthIndicator(AdminClient adminClient,
                                 KafkaDefaultConfiguration defaultConfiguration) {
-        this.adminClientSupplier = () -> adminClient;
+        this.adminClientSupplier = () -> Optional.of(adminClient);
         this.defaultConfiguration = defaultConfiguration;
         this.networkClientSupplier = SupplierUtil.memoized(() -> new DefaultNetworkClientCreator(defaultConfiguration).create(this));
         this.kafkaHealthConfiguration = new KafkaHealthConfigurationProperties();
@@ -153,8 +153,13 @@ public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceLis
             }
         }
 
-        AdminClient adminClient = adminClientSupplier.get();
-        DescribeClusterResult result = adminClient.describeCluster(
+        Optional<AdminClient> adminClient = adminClientSupplier.get();
+        if (adminClient.isEmpty()) {
+            return Flux.just(failure(new IllegalStateException(
+                "Kafka health indicator requires an AdminClient bean. Enable kafka.admin.enabled or set kafka.health.restricted=true."
+            ), Collections.emptyMap()));
+        }
+        DescribeClusterResult result = adminClient.get().describeCluster(
                 new DescribeClusterOptions().timeoutMs(
                         (int) defaultConfiguration.getHealthTimeout().toMillis()
                 )
@@ -167,7 +172,7 @@ public class KafkaHealthIndicator implements HealthIndicator, ClusterResourceLis
         return controller.flux().switchMap(node -> {
             String brokerId = node.idString();
             ConfigResource configResource = new ConfigResource(ConfigResource.Type.BROKER, brokerId);
-            DescribeConfigsResult configResult = adminClient.describeConfigs(Collections.singletonList(configResource));
+            DescribeConfigsResult configResult = adminClient.get().describeConfigs(Collections.singletonList(configResource));
             Mono<Map<ConfigResource, Config>> configs = KafkaReactorUtil.fromKafkaFuture(configResult::all);
             return configs.flux().switchMap(resources -> {
                 Config config = resources.get(configResource);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -14,6 +14,7 @@ import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.qualifiers.Qualifiers
+import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.CommonClientConfigs
@@ -148,6 +149,18 @@ class KafkaConfigurationSpec extends Specification {
 
         then:
         config.config[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] == 'localhost:1111'
+    }
+
+    void "test admin client can be disabled"() {
+        given:
+        applicationContext = ApplicationContext.run(
+                'kafka.admin.enabled': false,
+                'kafka.consumers.primary.bootstrap.servers': 'localhost:1111',
+                'kafka.producers.secondary.bootstrap.servers': 'localhost:2222'
+        )
+
+        expect:
+        applicationContext.findBean(AdminClient).isEmpty()
     }
 
     void "test null kafka property reports the failing property path"() {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaHealthIndicatorSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaHealthIndicatorSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.configuration.kafka.health
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.core.util.StringUtils
 import io.micronaut.management.health.indicator.HealthResult
 import io.micronaut.testcontainers.kafka.Kafka
 import org.apache.kafka.clients.admin.Config
@@ -50,6 +51,26 @@ class KafkaHealthIndicatorSpec extends Specification {
 
         then:
         result.status == DOWN
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test kafka health indicator reports missing admin client when disabled"() {
+        given:
+        Map config = [
+            "kafka.bootstrap.servers": "localhost:${SocketUtils.findAvailableTcpPort()}",
+            "kafka.admin.enabled": StringUtils.FALSE
+        ]
+        ApplicationContext ctx = ApplicationContext.run(config)
+
+        when:
+        KafkaHealthIndicator healthIndicator = ctx.getBean(KafkaHealthIndicator)
+        HealthResult result = healthIndicator.result.next().block()
+
+        then:
+        result.status == DOWN
+        result.details.error.contains("AdminClient")
 
         cleanup:
         ctx.close()


### PR DESCRIPTION
## Summary

- add `kafka.admin.enabled` to make the default `AdminClient` bean optional
- make unrestricted Kafka health checks report a clear `DOWN` result when admin support is disabled
- add regression coverage for the new opt-out and health behavior

## Verification

- `bash -lc 'ulimit -n 4096; ./gradlew --no-daemon :micronaut-kafka:test --tests "io.micronaut.configuration.kafka.KafkaConfigurationSpec.test admin client can be disabled" --tests "io.micronaut.configuration.kafka.health.KafkaHealthIndicatorSpec.test kafka health indicator reports missing admin client when disabled"'`

Resolves #1222
