### PR TITLE
Add global Kafka Streams disable configuration

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/DefaultKafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/DefaultKafkaStreamsConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -36,6 +37,7 @@ import java.util.Properties;
 @Requires(missingProperty = KafkaStreamsConfiguration.PREFIX + ".default")
 @Singleton
 @Requires(beans = KafkaDefaultConfiguration.class)
+@Requires(property = KafkaStreamsConfiguration.ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @Named(AbstractKafkaStreamsConfiguration.DEFAULT_NAME)
 @Primary
 public class DefaultKafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfiguration<K, V> {

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
@@ -65,6 +66,9 @@ public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfigu
             ApplicationConfiguration applicationConfiguration,
             Environment environment) {
         super(defaultConfiguration);
+        if ("enabled".equals(streamName)) {
+            throw new DisabledBeanException("Global property " + ENABLED + " is not a stream configuration");
+        }
         setName(streamName);
         Properties config = getConfig();
         String propertyKey = PREFIX + '.' + NameUtils.hyphenate(streamName, true);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsConfiguration.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 
 import java.util.Properties;
@@ -37,12 +38,18 @@ import static io.micronaut.configuration.kafka.streams.KafkaStreamsConfiguration
 @EachProperty(value = PREFIX, primary = "default")
 @ConfigurationProperties(PREFIX)
 @Requires(beans = KafkaDefaultConfiguration.class)
+@Requires(property = KafkaStreamsConfiguration.ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class KafkaStreamsConfiguration<K, V> extends AbstractKafkaStreamsConfiguration<K, V> {
 
     /**
      * The default streams configuration.
      */
     public static final String PREFIX = "kafka.streams";
+
+    /**
+     * Global property used to disable Kafka Streams bean creation.
+     */
+    public static final String ENABLED = PREFIX + ".enabled";
 
     /**
      * Construct a new {@link KafkaStreamsConfiguration} for the given defaults.

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -21,6 +21,7 @@ import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.*;
 import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.util.StringUtils;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -52,6 +53,7 @@ import static java.util.function.Predicate.not;
  * @since 1.0
  */
 @Factory
+@Requires(property = KafkaStreamsConfiguration.ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class KafkaStreamsFactory implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaStreamsFactory.class);

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/health/KafkaStreamsHealth.java
@@ -53,6 +53,7 @@ import java.util.stream.Stream;
  */
 @Singleton
 @Requires(classes = HealthIndicator.class)
+@Requires(beans = KafkaStreamsFactory.class)
 @Requires(property = KafkaStreamsHealth.ENABLED_PROPERTY, value = "true", defaultValue = "true")
 public class KafkaStreamsHealth implements HealthIndicator {
 

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/GlobalKTableOnlySpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/GlobalKTableOnlySpec.groovy
@@ -37,6 +37,31 @@ class GlobalKTableOnlySpec extends AbstractKafkaSpec {
         topologyDescription.contains(GlobalTableOnlyFactory.STORE)
     }
 
+    void "global kafka streams enabled property is not treated as a stream name"() {
+        given:
+        ApplicationContext enabledContext = ApplicationContext.run([
+                'spec.name'                                           : 'GlobalKTableOnlySpec',
+                'kafka.test.initializer.enabled'                      : false,
+                'kafka.bootstrap.servers'                             : 'localhost:9092',
+                'kafka.streams.enabled'                               : true,
+                'kafka.streams.default.application.id'                : 'default-enabled-' + UNIQUE_SUFFIX,
+                'kafka.streams.default.start-kafka-streams'           : false,
+                'kafka.streams.default.state.dir'                     : TMP_DIR + '/enabled-property-default-' + UNIQUE_SUFFIX,
+                'kafka.streams.global-table-only.application.id'      : 'global-table-only-' + UNIQUE_SUFFIX,
+                'kafka.streams.global-table-only.start-kafka-streams' : false,
+                'kafka.streams.global-table-only.state.dir'           : TMP_DIR + '/enabled-property-global-' + UNIQUE_SUFFIX
+        ])
+
+        when:
+        List<String> streamNames = enabledContext.getBeansOfType(ConfiguredStreamBuilder)*.name.sort()
+
+        then:
+        !streamNames.contains('enabled')
+
+        cleanup:
+        enabledContext.close()
+    }
+
     @Override
     protected Map<String, Object> getConfiguration() {
         super.getConfiguration() + [

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsDisabledSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsDisabledSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.configuration.kafka.streams
+
+import io.micronaut.configuration.kafka.streams.health.KafkaStreamsHealth
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+
+class KafkaStreamsDisabledSpec extends AbstractKafkaSpec {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run([
+            'spec.name'              : 'KafkaStreamsDisabledSpec',
+            'kafka.test.initializer.enabled': false,
+            'kafka.bootstrap.servers': 'localhost:9092',
+            'kafka.streams.enabled'  : false
+    ])
+
+    void "global kafka streams disable removes streams beans"() {
+        expect:
+        !context.findBean(DefaultKafkaStreamsConfiguration).present
+        !context.findBean(ConfiguredStreamBuilder).present
+        !context.findBean(KafkaStreamsFactory).present
+        !context.findBean(KafkaStreamsHealth).present
+    }
+}

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -126,6 +126,10 @@ NOTE: The `@Named` qualifier must be applied to the injected `ConfiguredStreamBu
 
 snippet::io.micronaut.kafka.docs.streams.WordCountStream[tags="namedStream", indent=0]
 
+.Disabling Kafka Streams integration
+
+If an application includes the `kafka-streams` module but should not initialize any Kafka Streams beans in a given environment, set `kafka.streams.enabled` to `false`.
+
 .Configuring Kafka Streams for testing
 When writing a test without starting the actual Kafka server, you can instruct Micronaut not to start Kafka Streams. To do this create a config file suffixed with an environment name, such as `application-test.yml` and set the `kafka.streams.[STREAM-NAME].start-kafka-streams` to `false`.
 

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/MyTest.java
@@ -12,10 +12,11 @@ import io.micronaut.testcontainers.kafka.Kafka;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Property(name = "spec.name", value = "MyTest")
 @MicronautTest
@@ -28,10 +29,10 @@ class MyTest implements TestPropertyProvider {
     }
 
     @Test
-    void testKafkaRunning(MyProducer producer, MyConsumer consumer) {
+    void testKafkaRunning(MyProducer producer, MyConsumer consumer) throws InterruptedException {
         final String message = "hello";
         producer.produce(message);
-        await().atMost(5, SECONDS).until(() -> message.equals(consumer.consumed));
+        assertEquals(message, consumer.awaitMessage(15, TimeUnit.SECONDS));
     }
 
     @Requires(property = "spec.name", value = "MyTest")
@@ -44,10 +45,15 @@ class MyTest implements TestPropertyProvider {
     @Requires(property = "spec.name", value = "MyTest")
     @KafkaListener(offsetReset = OffsetReset.EARLIEST)
     static class MyConsumer {
-        String consumed;
+        private final LinkedBlockingQueue<String> consumedMessages = new LinkedBlockingQueue<>();
+
         @Topic("my-topic")
         public void consume(String message) {
-            consumed = message;
+            consumedMessages.offer(message);
+        }
+
+        String awaitMessage(long timeout, TimeUnit timeUnit) throws InterruptedException {
+            return consumedMessages.poll(timeout, timeUnit);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a global `kafka.streams.enabled` switch to disable Kafka Streams bean creation
- avoid creating the health indicator when Kafka Streams is globally disabled
- document the global disable option and cover it with a focused regression test

## Verification
- `ulimit -n 65536`
- `./gradlew --no-daemon :micronaut-kafka-streams:test --tests io.micronaut.configuration.kafka.streams.KafkaStreamsDisabledSpec --tests io.micronaut.configuration.kafka.streams.KafkaStreamsSpec --tests io.micronaut.configuration.kafka.streams.health.KafkaStreamsHealthSpec`

Resolves #942
