### PR TITLE
Introduce id for KafkaListener

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ public @interface KafkaListener {
 
     /**
      * Sets the consumer group id of the Kafka consumer. If not specified the group id is configured
-     * to be the value of {@link io.micronaut.runtime.ApplicationConfiguration#getName()} otherwise
-     * the name of the class is used.
+     * from {@link #id()} when present, otherwise to the value of
+     * {@link io.micronaut.runtime.ApplicationConfiguration#getName()} and finally the name of the class.
      *
      * @return The group id
      */
@@ -56,6 +56,14 @@ public @interface KafkaListener {
      */
     @AliasFor(member = "value")
     String groupId() default "";
+
+    /**
+     * Sets the listener identifier used to resolve consumer configuration from {@code kafka.consumers.*}.
+     * If not specified, the {@link #groupId()} is used.
+     *
+     * @return The listener identifier
+     */
+    String id() default "";
 
     /**
      * A unique string (UUID) can be appended to the group ID.

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -303,24 +303,41 @@ class KafkaConsumerProcessor
         if (CollectionUtils.isEmpty(topicAnnotations)) {
             return; // No topics to consume
         }
-        String groupId = consumerAnnotation.stringValue("groupId")
-                .filter(StringUtils::isNotEmpty)
-                .orElseGet(() -> applicationConfiguration.getName().orElse(beanType.getName()));
+        final Optional<String> listenerId = consumerAnnotation.stringValue("id")
+            .filter(StringUtils::isNotEmpty);
+        final Optional<String> annotationGroupId = consumerAnnotation.stringValue("groupId")
+            .filter(StringUtils::isNotEmpty);
         final String clientId = consumerAnnotation.stringValue("clientId")
                 .filter(StringUtils::isNotEmpty)
                 .orElseGet(() -> applicationConfiguration.getName().map(s -> s + '-' + NameUtils.hyphenate(beanType.getSimpleName())).orElse(null));
         final OffsetStrategy offsetStrategy = consumerAnnotation.enumValue("offsetStrategy", OffsetStrategy.class)
                 .orElse(OffsetStrategy.AUTO);
-        final AbstractKafkaConsumerConfiguration<?, ?> consumerConfigurationDefaults = getConsumerConfigurationDefaults(groupId);
+        final String defaultId = applicationConfiguration.getName().orElse(beanType.getName());
+        final String fallbackGroupId = annotationGroupId
+            .or(() -> listenerId)
+            .orElse(defaultId);
+        final String configId = listenerId
+            .or(() -> annotationGroupId)
+            .orElse(defaultId);
+        final AbstractKafkaConsumerConfiguration<?, ?> consumerConfigurationDefaults = getConsumerConfigurationDefaults(configId);
         boolean uniqueGroupIdDeleteOnShutdown = false;
+        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
+        final Properties properties = createConsumerProperties(
+            consumerAnnotation,
+            consumerConfiguration,
+            clientId,
+            fallbackGroupId,
+            annotationGroupId.isPresent(),
+            offsetStrategy
+        );
+        String groupId = properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG, fallbackGroupId);
         if (consumerAnnotation.isTrue("uniqueGroupId")) {
             groupId = groupId + "_" + UUID.randomUUID();
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
             if (consumerAnnotation.isTrue("uniqueGroupIdDeleteOnShutdown")) {
                 uniqueGroupIdDeleteOnShutdown = true;
             }
         }
-        final DefaultKafkaConsumerConfiguration<?, ?> consumerConfiguration = new DefaultKafkaConsumerConfiguration<>(consumerConfigurationDefaults);
-        final Properties properties = createConsumerProperties(consumerAnnotation, consumerConfiguration, clientId, groupId, offsetStrategy);
         final ExecutableMethod<?, ?> primaryMethod = methods.get(0);
         configureDeserializers(methods, consumerConfiguration);
         submitConsumerThreads(primaryMethod, clientId, groupId, offsetStrategy, topicAnnotations,
@@ -489,6 +506,7 @@ class KafkaConsumerProcessor
                                                 final DefaultKafkaConsumerConfiguration consumerConfiguration,
                                                 final String clientId,
                                                 final String groupId,
+                                                final boolean overrideGroupId,
                                                 final OffsetStrategy offsetStrategy) {
         final Properties properties = consumerConfiguration.getConfig();
 
@@ -512,7 +530,11 @@ class KafkaConsumerProcessor
         consumerAnnotation.enumValue("isolation", IsolationLevel.class)
                 .ifPresent(isolation -> properties.putIfAbsent(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation.toString().toLowerCase(Locale.ROOT)));
 
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        if (overrideGroupId) {
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        } else {
+            properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        }
 
         if (clientId != null) {
             properties.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.configuration.kafka
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class KafkaListenerIdSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext applicationContext
+
+    void "test listener id controls config lookup and group id fallback"() {
+        given:
+        applicationContext = ApplicationContext.run(
+            'spec.name': 'KafkaListenerIdSpec',
+            'micronaut.application.name': 'test-app',
+            ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): 'localhost:1111',
+            ('kafka.consumers.default.' + ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+            ('kafka.consumers.default.' + ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG): StringDeserializer.name,
+            ('kafka.consumers.with-id-and-group.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_1',
+            ('kafka.consumers.with-id.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_2',
+            ('kafka.consumers.group-id-only.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_3',
+            ('kafka.consumers.test-app.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_4'
+        )
+
+        expect:
+        applicationContext.getBean(ConsumerWithIdAndGroupId).kafkaConsumer.groupMetadata().groupId() == 'ANNOTATION_GROUP'
+        applicationContext.getBean(ConsumerWithId).kafkaConsumer.groupMetadata().groupId() == 'CONFIGURED_GROUP_2'
+        applicationContext.getBean(ConsumerWithIdFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'ID_FALLBACK_GROUP'
+        applicationContext.getBean(ConsumerWithGroupId).kafkaConsumer.groupMetadata().groupId() == 'GROUP_ID_ONLY'
+        applicationContext.getBean(ConsumerWithFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'CONFIGURED_GROUP_4'
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'WITH_ID_AND_GROUP', groupId = 'ANNOTATION_GROUP', autoStartup = false)
+    static class ConsumerWithIdAndGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'WITH_ID', autoStartup = false)
+    static class ConsumerWithId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(id = 'ID_FALLBACK_GROUP', autoStartup = false)
+    static class ConsumerWithIdFallbackGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(groupId = 'GROUP_ID_ONLY', autoStartup = false)
+    static class ConsumerWithGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(autoStartup = false)
+    static class ConsumerWithFallbackGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaListenerIdSpec.groovy
@@ -26,7 +26,8 @@ class KafkaListenerIdSpec extends Specification {
             ('kafka.consumers.with-id-and-group.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_1',
             ('kafka.consumers.with-id.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_2',
             ('kafka.consumers.group-id-only.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_3',
-            ('kafka.consumers.test-app.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_4'
+            ('kafka.consumers.test-app.' + ConsumerConfig.GROUP_ID_CONFIG): 'CONFIGURED_GROUP_4',
+            ('kafka.consumers.VALUE_AS_GROUP.' + ConsumerConfig.GROUP_ID_CONFIG): 'SHOULD_NOT_BE_USED'
         )
 
         expect:
@@ -35,6 +36,8 @@ class KafkaListenerIdSpec extends Specification {
         applicationContext.getBean(ConsumerWithIdFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'ID_FALLBACK_GROUP'
         applicationContext.getBean(ConsumerWithGroupId).kafkaConsumer.groupMetadata().groupId() == 'GROUP_ID_ONLY'
         applicationContext.getBean(ConsumerWithFallbackGroupId).kafkaConsumer.groupMetadata().groupId() == 'CONFIGURED_GROUP_4'
+        // @KafkaListener("VALUE_AS_GROUP") uses the value alias for groupId; annotation value must win over configured group.id
+        applicationContext.getBean(ConsumerWithValueGroupId).kafkaConsumer.groupMetadata().groupId() == 'VALUE_AS_GROUP'
     }
 
     @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
@@ -80,6 +83,16 @@ class KafkaListenerIdSpec extends Specification {
     @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
     @KafkaListener(autoStartup = false)
     static class ConsumerWithFallbackGroupId implements ConsumerAware<String, String> {
+        Consumer<String, String> kafkaConsumer
+
+        @Topic('foo')
+        void consume(String value) {
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'KafkaListenerIdSpec')
+    @KafkaListener(value = 'VALUE_AS_GROUP', autoStartup = false)
+    static class ConsumerWithValueGroupId implements ConsumerAware<String, String> {
         Consumer<String, String> kafkaConsumer
 
         @Topic('foo')

--- a/src/main/docs/guide/kafkaListener.adoc
+++ b/src/main/docs/guide/kafkaListener.adoc
@@ -48,6 +48,6 @@ kafka:
               servers: localhost:9098
 ----
 
-Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the listener `id`, or `groupId` when `id` is not set. The above example will enable the consumer to create a topic if it doesn't exist for the `default` listener and set a custom bootstrap server for a listener declared with `@KafkaListener(id = "product")`.
+Properties under `kafka.consumers.default` serve as shared defaults applied to all link:{kafkaapi}/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig]-compatible consumers, while properties under `kafka.consumers.<id>` apply only to the consumer whose `id` matches (falling back to `groupId` when `id` is not set). The above example enables topic auto-creation for all consumers via the `default` key and sets a custom bootstrap server only for a listener declared with `@KafkaListener(id = "product")`.
 
 TIP: See the guide for https://guides.micronaut.io/latest/testing-micronaut-kafka-listener-using-testcontainers.html[Testing Kafka Listener using Testcontainers with the Micronaut Framework] to learn more.

--- a/src/main/docs/guide/kafkaListener.adoc
+++ b/src/main/docs/guide/kafkaListener.adoc
@@ -48,6 +48,6 @@ kafka:
               servers: localhost:9098
 ----
 
-Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the . The above example will enable the consumer to create a topic if it doesn't exist for the `default` (`@KafkaListener`) client and set a custom bootstrap server for the `product` client (`@KafkaListener(value = "product")`)
+Any property in the link:{kafkaapi}\/org/apache/kafka/clients/consumer/ConsumerConfig.html[ConsumerConfig] class can be set for all `@KafkaListener` beans based on the listener `id`, or `groupId` when `id` is not set. The above example will enable the consumer to create a topic if it doesn't exist for the `default` listener and set a custom bootstrap server for a listener declared with `@KafkaListener(id = "product")`.
 
 TIP: See the guide for https://guides.micronaut.io/latest/testing-micronaut-kafka-listener-using-testcontainers.html[Testing Kafka Listener using Testcontainers with the Micronaut Framework] to learn more.

--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -1,6 +1,6 @@
 === @KafkaListener and Consumer Groups
 
-Kafka consumers created with `@KafkaListener` will by default run within a consumer group that is the value of `micronaut.application.name` unless you explicitly specify a value to the `@KafkaListener` annotation. For example:
+Kafka consumers created with `@KafkaListener` will by default run within a consumer group that is the value of `micronaut.application.name` unless you explicitly specify `groupId` or `value`, or provide an `id` to use as the group fallback. For example:
 
 .Specifying a Consumer Group
 
@@ -18,6 +18,10 @@ In this case, each record will be consumed by one consumer instance of the consu
 NOTE: Kafka delivers records per consumer group before Micronaut binds listener method arguments. If multiple `@KafkaListener` methods subscribe to the same topic with different group IDs, each group receives every record published to that topic.
 
 TIP: You can make the consumer group configurable using a placeholder: `@KafkaListener("${my.consumer.group:myGroup}")`
+
+The `id` member is used to resolve consumer-specific configuration from `kafka.consumers.*`.
+If `id` is not specified, Micronaut falls back to `groupId`.
+If `groupId` is not specified, Micronaut uses `id` as the Kafka consumer group unless `group.id` is already defined in configuration.
 
 To allow the records to be consumed by all the consumer instances (each instance will be part of a unique consumer group), `uniqueGroupId` can be set to `true`:
 
@@ -50,7 +54,7 @@ kafka:
 
 The above example will set the default `session.timeout.ms` that Kafka uses to decide whether a consumer is alive or not and applies it to all created `KafkaConsumer` instances.
 
-You can also provide configuration specific to a consumer group. For example consider the following configuration:
+You can also provide configuration specific to a listener id. For example consider the following configuration:
 
 .Applying Consumer Group Specific config
 [configuration]
@@ -63,7 +67,7 @@ kafka:
                     ms: 30000
 ----
 
-The above configuration will pass properties to only the `@KafkaListener` beans that apply to the consumer group `myGroup`.
+The above configuration will pass properties to only the `@KafkaListener` beans with `id = "myGroup"`, or listeners whose `groupId` is `myGroup` when `id` is not specified.
 
 Finally, the ann:configuration.kafka.annotation.KafkaListener[] annotation itself provides a `properties` member that you can use to set consumer specific properties:
 

--- a/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaListenerConfiguration.adoc
@@ -56,7 +56,7 @@ The above example will set the default `session.timeout.ms` that Kafka uses to d
 
 You can also provide configuration specific to a listener id. For example consider the following configuration:
 
-.Applying Consumer Group Specific config
+.Applying Listener-Specific Config
 [configuration]
 ----
 kafka:


### PR DESCRIPTION
Introduce `id` for `@KafkaListener` so consumer configuration can be resolved independently from the Kafka consumer group.

The change also preserves fallback behavior by using `groupId` when `id` is not set, and only falling back to listener or application defaults when `group.id` is not already configured.

It includes regression coverage for listener id lookup and updates the listener configuration docs.

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/1179
