### PR TITLE
Align Kafka metrics with Micrometer naming

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetrics.java
@@ -38,6 +38,14 @@ import java.util.Properties;
 public abstract class AbstractKafkaMetrics<T extends AbstractKafkaConfiguration> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractKafkaMetrics.class);
+    private final KafkaMetricsConfigurationProperties kafkaMetricsConfiguration;
+
+    /**
+     * @param kafkaMetricsConfiguration The Kafka metrics configuration
+     */
+    protected AbstractKafkaMetrics(KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {
+        this.kafkaMetricsConfiguration = kafkaMetricsConfiguration;
+    }
 
     /**
      * Method to add a default metric reporter if not otherwise defined.
@@ -67,6 +75,7 @@ public abstract class AbstractKafkaMetrics<T extends AbstractKafkaConfiguration>
         if (meterRegistry != null) {
             props.put("meter.registry", meterRegistry);
         }
+        props.put(AbstractKafkaMetricsReporter.METRIC_NAME_STYLE_CONFIG, kafkaMetricsConfiguration.getMetricNameStyle().name());
         return event.getBean();
     }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetrics.java
@@ -41,6 +41,13 @@ public abstract class AbstractKafkaMetrics<T extends AbstractKafkaConfiguration>
     private final KafkaMetricsConfigurationProperties kafkaMetricsConfiguration;
 
     /**
+     * Default constructor.
+     */
+    protected AbstractKafkaMetrics() {
+        this(new KafkaMetricsConfigurationProperties());
+    }
+
+    /**
      * @param kafkaMetricsConfiguration The Kafka metrics configuration
      */
     protected AbstractKafkaMetrics(KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -208,6 +208,15 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         return metricNameStyle;
     }
 
+    /**
+     * @param metric The Kafka metric
+     * @return Whether the metric is the generic Kafka client count metric
+     */
+    protected final boolean isClientCountMetric(KafkaMetric metric) {
+        return "count".equals(metric.metricName().name())
+                && "kafka-metrics-count".equals(metric.metricName().group());
+    }
+
     private static List<Tag> getTags(MetricName metricName, List<String> sortedIncludedTags, boolean includeEmptyTags) {
         List<Tag> tags = new ArrayList<>(sortedIncludedTags.size());
         for (String tagName : sortedIncludedTags) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -45,7 +45,7 @@ import java.util.function.Function;
 @Internal
 public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, MeterBinder, Closeable {
 
-    public static final String METRIC_NAME_STYLE_CONFIG = "micronaut.metric.name.style";
+    public static final String METRIC_NAME_STYLE_CONFIG = KafkaMetricsConfigurationProperties.PREFIX + ".metric-name-style";
     public static final String CLIENT_ID_TAG = "client-id";
     public static final String TOPIC_TAG = "topic";
     public static final String NODE_ID_TAG = "node-id";
@@ -69,7 +69,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     private final Map<MeterRegistry, Map<Meter.Id, Meter>> registeredMeters = new ConcurrentHashMap<>();
 
     private List<KafkaMetric> metrics;
-    private MetricNameStyle metricNameStyle = MetricNameStyle.SPRING;
+    private MetricNameStyle metricNameStyle = MetricNameStyle.MICROMETER;
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
@@ -110,7 +110,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         }
         Object configuredMetricNameStyle = configs.get(METRIC_NAME_STYLE_CONFIG);
         if (configuredMetricNameStyle != null) {
-            metricNameStyle = MetricNameStyle.valueOf(configuredMetricNameStyle.toString().toUpperCase(java.util.Locale.ENGLISH));
+            metricNameStyle = MetricNameStyle.parse(configuredMetricNameStyle.toString());
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporter.java
@@ -45,6 +45,7 @@ import java.util.function.Function;
 @Internal
 public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, MeterBinder, Closeable {
 
+    public static final String METRIC_NAME_STYLE_CONFIG = "micronaut.metric.name.style";
     public static final String CLIENT_ID_TAG = "client-id";
     public static final String TOPIC_TAG = "topic";
     public static final String NODE_ID_TAG = "node-id";
@@ -68,6 +69,7 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
     private final Map<MeterRegistry, Map<Meter.Id, Meter>> registeredMeters = new ConcurrentHashMap<>();
 
     private List<KafkaMetric> metrics;
+    private MetricNameStyle metricNameStyle = MetricNameStyle.SPRING;
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
@@ -106,6 +108,10 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         if (meterRegistry != null) {
             meterRegistries.add((MeterRegistry) meterRegistry);
         }
+        Object configuredMetricNameStyle = configs.get(METRIC_NAME_STYLE_CONFIG);
+        if (configuredMetricNameStyle != null) {
+            metricNameStyle = MetricNameStyle.valueOf(configuredMetricNameStyle.toString().toUpperCase(java.util.Locale.ENGLISH));
+        }
     }
 
     @PreDestroy
@@ -139,9 +145,9 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
             return;
         }
 
+        String meterName = getMetricPrefix() + "." + getMetricName(metric);
         List<String> sortedIncludedTags = getIncludedTags().stream().sorted().toList();
         boolean includeEmptyTags = isPrometheusRegistry(meterRegistry);
-        String meterName = getMetricPrefix() + "." + metric.metricName().name();
         Set<Tag> expectedTags = Set.copyOf(getTags(metric.metricName(), sortedIncludedTags, includeEmptyTags));
         for (var iterator = meters.entrySet().iterator(); iterator.hasNext(); ) {
             var meterEntry = iterator.next();
@@ -174,6 +180,32 @@ public abstract class AbstractKafkaMetricsReporter implements MetricsReporter, M
         List<String> sortedIncludedTags = getIncludedTags().stream().sorted().toList();
         boolean includeEmptyTags = isPrometheusRegistry(meterRegistry);
         return metricName -> getTags(metricName, sortedIncludedTags, includeEmptyTags);
+    }
+
+    /**
+     * Resolve the Micrometer-style metric name for the supplied Kafka metric group and name.
+     *
+     * @param metric The Kafka metric
+     * @return The normalized metric name
+     */
+    protected final String getMicrometerMetricName(KafkaMetric metric) {
+        String group = metric.metricName().group();
+        String name = normalizeMetricName(metric.metricName().name());
+        if (group == null || group.isEmpty()) {
+            return name;
+        }
+        return normalizeMetricName(group) + "." + name;
+    }
+
+    private static String normalizeMetricName(String name) {
+        return name.replace("-metrics", "").replace('-', '.');
+    }
+
+    /**
+     * @return The configured metric name style
+     */
+    protected final MetricNameStyle getMetricNameStyle() {
+        return metricNameStyle;
     }
 
     private static List<Tag> getTags(MetricName metricName, List<String> sortedIncludedTags, boolean includeEmptyTags) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ConsumerKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ConsumerKafkaMetricsReporter.java
@@ -50,6 +50,9 @@ public class ConsumerKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
         if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
             return super.getMetricName(metric);
         }
+        if (isClientCountMetric(metric)) {
+            return "consumer.count";
+        }
         return getMicrometerMetricName(metric);
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ConsumerKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ConsumerKafkaMetricsReporter.java
@@ -19,6 +19,8 @@ import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.TypeHint;
 import jakarta.annotation.PreDestroy;
+import org.apache.kafka.common.metrics.KafkaMetric;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -30,15 +32,25 @@ import java.util.Set;
 public class ConsumerKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
 
     public static final String PARTITION_TAG = "partition";
-
-    private static final String CONSUMER_PREFIX = AbstractKafkaConfiguration.PREFIX + ".consumer";
+    private static final String LEGACY_CONSUMER_PREFIX = AbstractKafkaConfiguration.PREFIX + ".consumer";
 
     /**
      * {@inheritDoc}
      */
     @Override
     protected String getMetricPrefix() {
-        return CONSUMER_PREFIX;
+        if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
+            return LEGACY_CONSUMER_PREFIX;
+        }
+        return AbstractKafkaConfiguration.PREFIX;
+    }
+
+    @Override
+    protected String getMetricName(KafkaMetric metric) {
+        if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
+            return super.getMetricName(metric);
+        }
+        return getMicrometerMetricName(metric);
     }
 
     @Override

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaConsumerMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaConsumerMetrics.java
@@ -42,8 +42,10 @@ public class KafkaConsumerMetrics extends AbstractKafkaMetrics<AbstractKafkaCons
     /**
      * Default constructor.
      * @param beanLocator The bean locator
+     * @param kafkaMetricsConfiguration The Kafka metrics configuration
      */
-    public KafkaConsumerMetrics(BeanLocator beanLocator) {
+    public KafkaConsumerMetrics(BeanLocator beanLocator, KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {
+        super(kafkaMetricsConfiguration);
         this.beanLocator = beanLocator;
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaConsumerMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaConsumerMetrics.java
@@ -23,6 +23,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
+import jakarta.inject.Inject;
 import java.util.Optional;
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
 
@@ -42,8 +43,18 @@ public class KafkaConsumerMetrics extends AbstractKafkaMetrics<AbstractKafkaCons
     /**
      * Default constructor.
      * @param beanLocator The bean locator
+     */
+    public KafkaConsumerMetrics(BeanLocator beanLocator) {
+        super();
+        this.beanLocator = beanLocator;
+    }
+
+    /**
+     * Default constructor.
+     * @param beanLocator The bean locator
      * @param kafkaMetricsConfiguration The Kafka metrics configuration
      */
+    @Inject
     public KafkaConsumerMetrics(BeanLocator beanLocator, KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {
         super(kafkaMetricsConfiguration);
         this.beanLocator = beanLocator;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationProperties.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationProperties.java
@@ -33,10 +33,10 @@ public class KafkaMetricsConfigurationProperties {
      */
     public static final String PREFIX = MICRONAUT_METRICS_BINDERS + ".kafka";
 
-    private MetricNameStyle metricNameStyle = MetricNameStyle.SPRING;
+    private MetricNameStyle metricNameStyle = MetricNameStyle.MICROMETER;
 
     /**
-     * @return The metric naming style. Defaults to {@link MetricNameStyle#SPRING}.
+     * @return The metric naming style. Defaults to {@link MetricNameStyle#MICROMETER}.
      */
     public MetricNameStyle getMetricNameStyle() {
         return metricNameStyle;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationProperties.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.metrics;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+
+/**
+ * Configuration for Kafka client metric binding.
+ *
+ * @author graemerocher
+ * @since 5.0
+ */
+@ConfigurationProperties(KafkaMetricsConfigurationProperties.PREFIX)
+public class KafkaMetricsConfigurationProperties {
+
+    /**
+     * Prefix for Kafka metrics binder configuration.
+     */
+    public static final String PREFIX = MICRONAUT_METRICS_BINDERS + ".kafka";
+
+    private MetricNameStyle metricNameStyle = MetricNameStyle.SPRING;
+
+    /**
+     * @return The metric naming style. Defaults to {@link MetricNameStyle#SPRING}.
+     */
+    public MetricNameStyle getMetricNameStyle() {
+        return metricNameStyle;
+    }
+
+    /**
+     * @param metricNameStyle The metric naming style
+     */
+    public void setMetricNameStyle(MetricNameStyle metricNameStyle) {
+        if (metricNameStyle != null) {
+            this.metricNameStyle = metricNameStyle;
+        }
+    }
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
@@ -24,6 +24,7 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
+import jakarta.inject.Inject;
 
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".kafka.enabled", value = "true", defaultValue = "true")
 @Context
-// Producer metrics are primary since Grails/Boot only support a single metric provider
+// Producer metrics are primary because only one metric provider should be active.
 @Primary
 public class KafkaProducerMetrics extends AbstractKafkaMetrics<AbstractKafkaProducerConfiguration> implements BeanCreatedEventListener<AbstractKafkaProducerConfiguration> {
 
@@ -45,8 +46,18 @@ public class KafkaProducerMetrics extends AbstractKafkaMetrics<AbstractKafkaProd
     /**
      * Default constructor.
      * @param beanLocator The bean locator
+     */
+    protected KafkaProducerMetrics(BeanLocator beanLocator) {
+        super();
+        this.beanLocator = beanLocator;
+    }
+
+    /**
+     * Default constructor.
+     * @param beanLocator The bean locator
      * @param kafkaMetricsConfiguration The Kafka metrics configuration
      */
+    @Inject
     protected KafkaProducerMetrics(BeanLocator beanLocator, KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {
         super(kafkaMetricsConfiguration);
         this.beanLocator = beanLocator;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/KafkaProducerMetrics.java
@@ -45,8 +45,10 @@ public class KafkaProducerMetrics extends AbstractKafkaMetrics<AbstractKafkaProd
     /**
      * Default constructor.
      * @param beanLocator The bean locator
+     * @param kafkaMetricsConfiguration The Kafka metrics configuration
      */
-    protected KafkaProducerMetrics(BeanLocator beanLocator) {
+    protected KafkaProducerMetrics(BeanLocator beanLocator, KafkaMetricsConfigurationProperties kafkaMetricsConfiguration) {
+        super(kafkaMetricsConfiguration);
         this.beanLocator = beanLocator;
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/MetricNameStyle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/MetricNameStyle.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.metrics;
+
+/**
+ * Supported Kafka client metric naming styles.
+ *
+ * @author graemerocher
+ * @since 5.0
+ */
+public enum MetricNameStyle {
+    /**
+     * Use Spring / Micrometer compatible metric names such as
+     * {@code kafka.consumer.fetch.manager.bytes.consumed.total}.
+     */
+    SPRING,
+    /**
+     * Preserve the legacy Micronaut metric names such as
+     * {@code kafka.consumer.bytes-consumed-total}.
+     */
+    LEGACY
+}

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/MetricNameStyle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/MetricNameStyle.java
@@ -15,6 +15,10 @@
  */
 package io.micronaut.configuration.kafka.metrics;
 
+import io.micronaut.context.exceptions.ConfigurationException;
+
+import java.util.Locale;
+
 /**
  * Supported Kafka client metric naming styles.
  *
@@ -23,13 +27,25 @@ package io.micronaut.configuration.kafka.metrics;
  */
 public enum MetricNameStyle {
     /**
-     * Use Spring / Micrometer compatible metric names such as
+     * Use Micrometer compatible metric names such as
      * {@code kafka.consumer.fetch.manager.bytes.consumed.total}.
      */
-    SPRING,
+    MICROMETER,
     /**
      * Preserve the legacy Micronaut metric names such as
      * {@code kafka.consumer.bytes-consumed-total}.
      */
-    LEGACY
+    LEGACY;
+
+    /**
+     * @param value The configured value
+     * @return The matching metric name style
+     */
+    public static MetricNameStyle parse(String value) {
+        try {
+            return valueOf(value.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException("Invalid Kafka metric name style [" + value + "]. Valid values: micrometer, legacy", e);
+        }
+    }
 }

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ProducerKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ProducerKafkaMetricsReporter.java
@@ -19,6 +19,7 @@ import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.TypeHint;
 import jakarta.annotation.PreDestroy;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
 /**
  * A {@link org.apache.kafka.common.metrics.MetricsReporter} class for producer metrics.
@@ -27,14 +28,25 @@ import jakarta.annotation.PreDestroy;
 @TypeHint(ProducerKafkaMetricsReporter.class)
 public class ProducerKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
 
-    private static final String PRODUCER_PREFIX = AbstractKafkaConfiguration.PREFIX + ".producer";
+    private static final String LEGACY_PRODUCER_PREFIX = AbstractKafkaConfiguration.PREFIX + ".producer";
 
     /**
      * {@inheritDoc}
      */
     @Override
     protected String getMetricPrefix() {
-        return PRODUCER_PREFIX;
+        if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
+            return LEGACY_PRODUCER_PREFIX;
+        }
+        return AbstractKafkaConfiguration.PREFIX;
+    }
+
+    @Override
+    protected String getMetricName(KafkaMetric metric) {
+        if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
+            return super.getMetricName(metric);
+        }
+        return getMicrometerMetricName(metric);
     }
 
     /**

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ProducerKafkaMetricsReporter.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/ProducerKafkaMetricsReporter.java
@@ -46,6 +46,9 @@ public class ProducerKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
         if (getMetricNameStyle() == MetricNameStyle.LEGACY) {
             return super.getMetricName(metric);
         }
+        if (isClientCountMetric(metric)) {
+            return "producer.count";
+        }
         return getMicrometerMetricName(metric);
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/metrics/builder/KafkaMetricMeterTypeBuilder.java
@@ -124,11 +124,12 @@ public class KafkaMetricMeterTypeBuilder {
             return Optional.empty();
         }
 
+        String kafkaMetricName = kafkaMetric.metricName().name();
         if (StringUtils.isEmpty(name)) {
-            name = kafkaMetric.metricName().name();
+            name = kafkaMetricName;
         }
 
-        KafkaMetricMeterType kafkaMetricMeterType = KAFKA_METRIC_METER_TYPE_REGISTRY.lookup(this.name);
+        KafkaMetricMeterType kafkaMetricMeterType = KAFKA_METRIC_METER_TYPE_REGISTRY.lookup(kafkaMetricName);
         List<Tag> tags = tagFunction.apply(kafkaMetric.metricName());
 
         if (kafkaMetricMeterType.getMeterType() == MeterType.GAUGE && this.kafkaMetric.metricValue() instanceof Number) {

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaConsumerMetricsSpec.groovy
@@ -52,19 +52,19 @@ class KafkaConsumerMetricsSpec extends AbstractEmbeddedServerSpec {
         conditions.eventually {
             HttpResponse<Map> response = Mono.from(httpClient.exchange("/metrics", Map)).block()
             Map result = response.body()
-            result.names.contains("kafka.consumer.bytes-consumed-total")
-            !result.names.contains("kafka.consumer.record-error-rate")
+            result.names.contains("kafka.consumer.fetch.manager.bytes.consumed.total")
+            !result.names.contains("kafka.consumer.record.error.rate")
             !result.names.contains("kafka.producer.count")
-            !result.names.contains("kafka.producer.record-error-rate")
-            !result.names.contains("kafka.producer.bytes-consumed-total")
+            !result.names.contains("kafka.producer.record.error.rate")
+            !result.names.contains("kafka.producer.bytes.consumed.total")
             !result.names.contains("kafka.count")
 
-            def preferredReadReplica = Mono.from(httpClient.exchange("/metrics/kafka.consumer.records-lead-avg", Map)).block()
+            def preferredReadReplica = Mono.from(httpClient.exchange("/metrics/kafka.consumer.fetch.manager.records.lead.avg", Map)).block()
             Map metricBody = preferredReadReplica.body()
             metricBody.availableTags.size() == 3
             metricBody.availableTags*.tag == [ConsumerKafkaMetricsReporter.PARTITION_TAG, ConsumerKafkaMetricsReporter.TOPIC_TAG, ConsumerKafkaMetricsReporter.CLIENT_ID_TAG]
 
-            def requestRate = Mono.from(httpClient.exchange("/metrics/kafka.consumer.request-rate", Map)).block()
+            def requestRate = Mono.from(httpClient.exchange("/metrics/kafka.consumer.node.request.rate", Map)).block()
             Map requestRateBody = requestRate.body()
             requestRateBody.availableTags.size() == 2
             requestRateBody.availableTags*.tag == [ConsumerKafkaMetricsReporter.NODE_ID_TAG, ConsumerKafkaMetricsReporter.CLIENT_ID_TAG]

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
@@ -53,13 +53,13 @@ class KafkaProducerMetricsSpec extends AbstractEmbeddedServerSpec {
         conditions.eventually {
             HttpResponse<Map> response = Mono.from(httpClient.exchange("/metrics", Map)).block()
             Map result = response.body()
-            !result.names.contains("kafka.consumer.record-error-rate")
+            !result.names.contains("kafka.consumer.record.error.rate")
             result.names.contains("kafka.producer.count")
-            result.names.contains("kafka.producer.record-error-rate")
-            !result.names.contains("kafka.producer.bytes-consumed-total")
+            result.names.contains("kafka.producer.record.error.rate")
+            !result.names.contains("kafka.producer.bytes.consumed.total")
             !result.names.contains("kafka.count")
 
-            def recordSendTotal = Mono.from(httpClient.exchange("/metrics/kafka.producer.record-send-total", Map)).block()
+            def recordSendTotal = Mono.from(httpClient.exchange("/metrics/kafka.producer.record.send.total", Map)).block()
             Map metricBody = recordSendTotal.body()
             metricBody.availableTags.size() == 2
             metricBody.availableTags*.tag == [ConsumerKafkaMetricsReporter.TOPIC_TAG, ConsumerKafkaMetricsReporter.CLIENT_ID_TAG]

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/health/KafkaProducerMetricsSpec.groovy
@@ -59,7 +59,7 @@ class KafkaProducerMetricsSpec extends AbstractEmbeddedServerSpec {
             !result.names.contains("kafka.producer.bytes.consumed.total")
             !result.names.contains("kafka.count")
 
-            def recordSendTotal = Mono.from(httpClient.exchange("/metrics/kafka.producer.record.send.total", Map)).block()
+            def recordSendTotal = Mono.from(httpClient.exchange("/metrics/kafka.producer.topic.record.send.total", Map)).block()
             Map metricBody = recordSendTotal.body()
             metricBody.availableTags.size() == 2
             metricBody.availableTags*.tag == [ConsumerKafkaMetricsReporter.TOPIC_TAG, ConsumerKafkaMetricsReporter.CLIENT_ID_TAG]

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.configuration.kafka.metrics
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.micronaut.context.exceptions.ConfigurationException
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics.KafkaMetric
 import org.apache.kafka.common.metrics.MetricConfig
@@ -78,7 +79,7 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         ])
     }
 
-    void "consumer metrics use boot aligned names"() {
+    void "consumer metrics use micrometer aligned names"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
         def reporter = new ConsumerKafkaMetricsReporter()
@@ -96,7 +97,7 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.find("kafka.consumer.bytes-consumed-total").meter() == null
     }
 
-    void "consumer node metrics use boot aligned names"() {
+    void "consumer node metrics use micrometer aligned names"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
         def reporter = new ConsumerKafkaMetricsReporter()
@@ -129,7 +130,7 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.find("kafka.kafka.count.count").meter() == null
     }
 
-    void "producer topic metrics use boot aligned names"() {
+    void "producer topic metrics use micrometer aligned names"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
         def reporter = new ProducerKafkaMetricsReporter()
@@ -183,7 +184,23 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.find("kafka.consumer.fetch.manager.bytes.consumed.total").meter() == null
     }
 
-    void "consumer metric removal removes boot aligned meters from registry"() {
+    void "invalid metric style reports valid values"() {
+        given:
+        def reporter = new ConsumerKafkaMetricsReporter()
+
+        when:
+        reporter.configure([
+                (AbstractKafkaMetricsReporter.METRIC_NAME_STYLE_CONFIG): "unknown"
+        ])
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.message.contains("Invalid Kafka metric name style [unknown]")
+        e.message.contains("micrometer")
+        e.message.contains("legacy")
+    }
+
+    void "consumer metric removal removes micrometer aligned meters from registry"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
         def reporter = new ConsumerKafkaMetricsReporter()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -78,6 +78,98 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         ])
     }
 
+    void "consumer metrics use boot aligned names"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createConsumerMetric("bytes-consumed-total", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
+                (ConsumerKafkaMetricsReporter.PARTITION_TAG): "0",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.consumer.fetch.manager.bytes.consumed.total").meter() != null
+        meterRegistry.find("kafka.consumer.bytes-consumed-total").meter() == null
+    }
+
+    void "consumer node metrics use boot aligned names"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createMetric("request-rate", "consumer-node-metrics", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.NODE_ID_TAG)  : "node-1",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.consumer.node.request.rate").meter() != null
+        meterRegistry.find("kafka.consumer.request-rate").meter() == null
+    }
+
+    void "producer metrics use boot aligned names"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ProducerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createProducerMetric("record-send-total", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "producer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.producer.record.send.total").meter() != null
+        meterRegistry.find("kafka.producer.record-send-total").meter() == null
+    }
+
+    void "legacy metric style preserves consumer metric names"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+        reporter.configure([
+                (AbstractKafkaMetricsReporter.METRIC_NAME_STYLE_CONFIG): MetricNameStyle.LEGACY.name()
+        ])
+
+        when:
+        reporter.metricChange(createConsumerMetric("bytes-consumed-total", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
+                (ConsumerKafkaMetricsReporter.PARTITION_TAG): "0",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.consumer.bytes-consumed-total").meter() != null
+        meterRegistry.find("kafka.consumer.fetch.manager.bytes.consumed.total").meter() == null
+    }
+
+    void "consumer metric removal removes boot aligned meters from registry"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+        def metric = createConsumerMetric("records-lag", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
+                (ConsumerKafkaMetricsReporter.PARTITION_TAG): "0",
+        ])
+
+        when:
+        reporter.metricChange(metric)
+        reporter.metricRemoval(metric)
+
+        then:
+        meterRegistry.meters.isEmpty()
+    }
+
     void "metric removal removes meters from registry"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
@@ -170,17 +262,40 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
     }
 
     private static KafkaMetric createMetric(int partition) {
+        return createConsumerMetric("records-lag", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+                (AbstractKafkaMetricsReporter.TOPIC_TAG): "topic-${partition}".toString(),
+                (ConsumerKafkaMetricsReporter.PARTITION_TAG): Integer.toString(partition),
+        ])
+    }
+
+    private static KafkaMetric createConsumerMetric(String name, Map<String, String> tags) {
+        return createMetric(name, "consumer-fetch-manager-metrics", tags)
+    }
+
+    private static KafkaMetric createMetric(String name, String group, Map<String, String> tags) {
         new KafkaMetric(
                 new Object(),
                 new MetricName(
-                        "records-lag",
-                        "consumer-fetch-manager-metrics",
+                        name,
+                        group,
                         "description",
-                        [
-                                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
-                                (AbstractKafkaMetricsReporter.TOPIC_TAG): "topic-${partition}".toString(),
-                                (ConsumerKafkaMetricsReporter.PARTITION_TAG): Integer.toString(partition),
-                        ]
+                        tags
+                ),
+                new Avg(),
+                new MetricConfig(),
+                Time.SYSTEM
+        )
+    }
+
+    private static KafkaMetric createProducerMetric(String name, Map<String, String> tags) {
+        new KafkaMetric(
+                new Object(),
+                new MetricName(
+                        name,
+                        "producer-metrics",
+                        "description",
+                        tags
                 ),
                 new Avg(),
                 new MetricConfig(),

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/AbstractKafkaMetricsReporterSpec.groovy
@@ -113,21 +113,53 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
         meterRegistry.find("kafka.consumer.request-rate").meter() == null
     }
 
-    void "producer metrics use boot aligned names"() {
+    void "consumer count metric keeps the consumer prefix"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ConsumerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createMetric("count", "kafka-metrics-count", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "consumer-1",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.consumer.count").meter() != null
+        meterRegistry.find("kafka.kafka.count.count").meter() == null
+    }
+
+    void "producer topic metrics use boot aligned names"() {
         given:
         def meterRegistry = new SimpleMeterRegistry()
         def reporter = new ProducerKafkaMetricsReporter()
         reporter.bindTo(meterRegistry)
 
         when:
-        reporter.metricChange(createProducerMetric("record-send-total", [
+        reporter.metricChange(createMetric("record-send-total", "producer-topic-metrics", [
                 (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "producer-1",
                 (AbstractKafkaMetricsReporter.TOPIC_TAG)    : "topic-1",
         ]))
 
         then:
-        meterRegistry.find("kafka.producer.record.send.total").meter() != null
+        meterRegistry.find("kafka.producer.topic.record.send.total").meter() != null
         meterRegistry.find("kafka.producer.record-send-total").meter() == null
+    }
+
+    void "producer count metric keeps the producer prefix"() {
+        given:
+        def meterRegistry = new SimpleMeterRegistry()
+        def reporter = new ProducerKafkaMetricsReporter()
+        reporter.bindTo(meterRegistry)
+
+        when:
+        reporter.metricChange(createMetric("count", "kafka-metrics-count", [
+                (AbstractKafkaMetricsReporter.CLIENT_ID_TAG): "producer-1",
+        ]))
+
+        then:
+        meterRegistry.find("kafka.producer.count").meter() != null
+        meterRegistry.find("kafka.kafka.count.count").meter() == null
     }
 
     void "legacy metric style preserves consumer metric names"() {
@@ -287,22 +319,6 @@ class AbstractKafkaMetricsReporterSpec extends Specification {
                 Time.SYSTEM
         )
     }
-
-    private static KafkaMetric createProducerMetric(String name, Map<String, String> tags) {
-        new KafkaMetric(
-                new Object(),
-                new MetricName(
-                        name,
-                        "producer-metrics",
-                        "description",
-                        tags
-                ),
-                new Avg(),
-                new MetricConfig(),
-                Time.SYSTEM
-        )
-    }
-
     private static final class TestKafkaMetricsReporter extends AbstractKafkaMetricsReporter {
 
         @Override

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.configuration.kafka.metrics
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class KafkaMetricsConfigurationSpec extends Specification {
+
+    void "metric name style defaults to spring"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:
+        def configuration = context.getBean(KafkaMetricsConfigurationProperties)
+
+        then:
+        configuration.metricNameStyle == MetricNameStyle.SPRING
+
+        cleanup:
+        context.close()
+    }
+
+    void "metric name style can be configured"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                (KafkaMetricsConfigurationProperties.PREFIX + ".metric-name-style"): "legacy"
+        )
+
+        when:
+        def configuration = context.getBean(KafkaMetricsConfigurationProperties)
+
+        then:
+        configuration.metricNameStyle == MetricNameStyle.LEGACY
+
+        cleanup:
+        context.close()
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/metrics/KafkaMetricsConfigurationSpec.groovy
@@ -5,7 +5,7 @@ import spock.lang.Specification
 
 class KafkaMetricsConfigurationSpec extends Specification {
 
-    void "metric name style defaults to spring"() {
+    void "metric name style defaults to micrometer"() {
         given:
         ApplicationContext context = ApplicationContext.run()
 
@@ -13,7 +13,7 @@ class KafkaMetricsConfigurationSpec extends Specification {
         def configuration = context.getBean(KafkaMetricsConfigurationProperties)
 
         then:
-        configuration.metricNameStyle == MetricNameStyle.SPRING
+        configuration.metricNameStyle == MetricNameStyle.MICROMETER
 
         cleanup:
         context.close()

--- a/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
@@ -3,7 +3,7 @@ You can enable Kafka Metrics collection by enabling https://micronaut-projects.g
 If you do not wish to collect Kafka metrics, you can set `micronaut.metrics.binders.kafka.enabled` to `false` in `application.yml`.
 In the case of Kafka Streams metrics, you can use `micronaut.metrics.binders.kafka.streams.enabled` instead.
 
-For consumer and producer client metrics, Micronaut Kafka 5 uses Spring / Micrometer compatible metric names by default. For example, `bytes-consumed-total` is exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
+For consumer and producer client metrics, Micronaut Kafka 5 uses Micrometer compatible metric names by default. For example, `bytes-consumed-total` is exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
 
 This is a breaking change from earlier Micronaut Kafka versions, which exported legacy names such as `kafka.consumer.bytes-consumed-total`.
 

--- a/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
+++ b/src/main/docs/guide/kafkaApplications/kafkaMetrics.adoc
@@ -2,3 +2,18 @@ You can enable Kafka Metrics collection by enabling https://micronaut-projects.g
 
 If you do not wish to collect Kafka metrics, you can set `micronaut.metrics.binders.kafka.enabled` to `false` in `application.yml`.
 In the case of Kafka Streams metrics, you can use `micronaut.metrics.binders.kafka.streams.enabled` instead.
+
+For consumer and producer client metrics, Micronaut Kafka 5 uses Spring / Micrometer compatible metric names by default. For example, `bytes-consumed-total` is exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
+
+This is a breaking change from earlier Micronaut Kafka versions, which exported legacy names such as `kafka.consumer.bytes-consumed-total`.
+
+If you need to preserve the legacy Micronaut metric names during migration, configure the metric name style explicitly:
+
+[configuration]
+----
+micronaut:
+  metrics:
+    binders:
+      kafka:
+        metric-name-style: legacy
+----

--- a/src/main/docs/guide/releaseHistory.adoc
+++ b/src/main/docs/guide/releaseHistory.adoc
@@ -22,9 +22,9 @@ Previous versions of Micronaut Kafka used the meta-annotation https://docs.micro
 
 Micronaut Kafka 5 no longer supports Open Tracing (which is deprecated and no longer maintained) and if you need distributed tracing you should instead https://micronaut-projects.github.io/micronaut-tracing/latest/guide/#kafka[use Open Telemetry].
 
-=== Kafka metric names now default to Spring style
+=== Kafka metric names now default to Micrometer style
 
-Micronaut Kafka 5 changes the default naming for consumer and producer Micrometer metrics to match Spring / Micrometer conventions. For example, `kafka.consumer.bytes-consumed-total` is now exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
+Micronaut Kafka 5 changes the default naming for consumer and producer Micrometer metrics to use Micrometer compatible names. For example, `kafka.consumer.bytes-consumed-total` is now exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
 
 This is a breaking change if you have dashboards, alerts, or scraping rules that depend on the previous names.
 

--- a/src/main/docs/guide/releaseHistory.adoc
+++ b/src/main/docs/guide/releaseHistory.adoc
@@ -21,3 +21,11 @@ Previous versions of Micronaut Kafka used the meta-annotation https://docs.micro
 === Open Tracing No Longer Supported
 
 Micronaut Kafka 5 no longer supports Open Tracing (which is deprecated and no longer maintained) and if you need distributed tracing you should instead https://micronaut-projects.github.io/micronaut-tracing/latest/guide/#kafka[use Open Telemetry].
+
+=== Kafka metric names now default to Spring style
+
+Micronaut Kafka 5 changes the default naming for consumer and producer Micrometer metrics to match Spring / Micrometer conventions. For example, `kafka.consumer.bytes-consumed-total` is now exported as `kafka.consumer.fetch.manager.bytes.consumed.total`.
+
+This is a breaking change if you have dashboards, alerts, or scraping rules that depend on the previous names.
+
+To preserve the previous Micronaut naming during migration, set `micronaut.metrics.binders.kafka.metric-name-style=legacy`.


### PR DESCRIPTION
## Summary
- align Kafka consumer and producer metric names with Micrometer-compatible names by default
- add `micronaut.metrics.binders.kafka.metric-name-style` so applications can preserve the legacy metric names during migration
- cover the new naming behavior with tests and document the breaking change in the metrics guide and release history

## Breaking Changes
- dashboards, alerts, and scrapers that depend on the previous metric names need to be updated or configured with `micronaut.metrics.binders.kafka.metric-name-style=legacy`

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/108
