### PR TITLE
Fix Kafka Streams SHUTDOWN_APPLICATION shutdown

### DIFF
--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -185,10 +185,16 @@ public class KafkaStreamsFactory implements Closeable, GracefulShutdownCapable {
         if (currentShutdown != null) {
             return currentShutdown;
         }
-        CompletableFuture<Void> newShutdown = CompletableFuture.runAsync(() ->
-            streams.forEach(this::closeStream)
-        );
+        CompletableFuture<Void> newShutdown = new CompletableFuture<>();
         if (gracefulShutdown.compareAndSet(null, newShutdown)) {
+            CompletableFuture.runAsync(() -> streams.forEach(this::closeStream))
+                .whenComplete((v, e) -> {
+                    if (e != null) {
+                        newShutdown.completeExceptionally(e);
+                    } else {
+                        newShutdown.complete(null);
+                    }
+                });
             return newShutdown;
         }
         return gracefulShutdown.get();

--- a/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
+++ b/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/KafkaStreamsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@ package io.micronaut.configuration.kafka.streams;
 
 import io.micronaut.configuration.kafka.streams.event.AfterKafkaStreamsStart;
 import io.micronaut.configuration.kafka.streams.event.BeforeKafkaStreamStart;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.*;
 import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -40,8 +42,12 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
 import static java.util.function.Predicate.not;
@@ -54,24 +60,29 @@ import static java.util.function.Predicate.not;
  */
 @Factory
 @Requires(property = KafkaStreamsConfiguration.ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
-public class KafkaStreamsFactory implements Closeable {
+public class KafkaStreamsFactory implements Closeable, GracefulShutdownCapable {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaStreamsFactory.class);
 
     private static final String START_KAFKA_STREAMS_PROPERTY = "start-kafka-streams";
     private static final String UNCAUGHT_EXCEPTION_HANDLER_PROPERTY = "uncaught-exception-handler";
+    private static final String SHUTDOWN_THREAD_NAME = "micronaut-kafka-streams-shutdown";
 
     private final Map<KafkaStreams, ConfiguredStreamBuilder> streams = new ConcurrentHashMap<>();
-
     private final ApplicationEventPublisher eventPublisher;
+    private final ApplicationContext applicationContext;
+    private final AtomicBoolean applicationShutdownRequested = new AtomicBoolean();
+    private final AtomicReference<CompletableFuture<Void>> gracefulShutdown = new AtomicReference<>();
 
     /**
      * Default constructor.
      *
      * @param eventPublisher The event publisher
+     * @param applicationContext The application context
      */
-    public KafkaStreamsFactory(ApplicationEventPublisher eventPublisher) {
+    public KafkaStreamsFactory(ApplicationEventPublisher eventPublisher, ApplicationContext applicationContext) {
         this.eventPublisher = eventPublisher;
+        this.applicationContext = applicationContext;
     }
 
     /**
@@ -169,21 +180,32 @@ public class KafkaStreamsFactory implements Closeable {
     }
 
     @Override
+    public CompletableFuture<Void> shutdownGracefully() {
+        CompletableFuture<Void> currentShutdown = gracefulShutdown.get();
+        if (currentShutdown != null) {
+            return currentShutdown;
+        }
+        CompletableFuture<Void> newShutdown = CompletableFuture.runAsync(() ->
+            streams.forEach(this::closeStream)
+        );
+        if (gracefulShutdown.compareAndSet(null, newShutdown)) {
+            return newShutdown;
+        }
+        return gracefulShutdown.get();
+    }
+
+    @Override
+    public OptionalLong reportActiveTasks() {
+        return OptionalLong.of(streams.keySet().stream()
+            .filter(stream -> !stream.state().hasCompletedShutdown())
+            .count());
+    }
+
+    @Override
     @PreDestroy
     public void close() {
-        streams.forEach((stream, builder) -> {
-            try {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Shutting down kafka stream {} ", builder.getName());
-                }
-                boolean success = stream.close(builder.getCloseTimeout());
-                if (!success) {
-                    LOG.warn("Timeout was exceeded while attempting to close kafka stream {}", builder.getName());
-                }
-            } catch (Exception e) {
-                // ignore
-            }
-        });
+        shutdownGracefully().join();
+        streams.clear();
     }
 
     /**
@@ -202,6 +224,9 @@ public class KafkaStreamsFactory implements Closeable {
                         if (LOG.isWarnEnabled()) {
                             LOG.warn("Responding with {} to unexpected exception thrown by kafka stream thread", response, exception);
                         }
+                        if (response == StreamThreadExceptionResponse.SHUTDOWN_APPLICATION) {
+                            requestApplicationShutdown();
+                        }
                         return response;
                     };
                 } catch (IllegalArgumentException e) {
@@ -212,5 +237,38 @@ public class KafkaStreamsFactory implements Closeable {
                     return null;
                 }
             });
+    }
+
+    private void requestApplicationShutdown() {
+        if (!applicationShutdownRequested.compareAndSet(false, true)) {
+            return;
+        }
+        Thread shutdownThread = new Thread(() -> {
+            try {
+                if (applicationContext.isRunning()) {
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Stopping Micronaut application because kafka streams requested {}", StreamThreadExceptionResponse.SHUTDOWN_APPLICATION);
+                    }
+                    applicationContext.stop();
+                }
+            } catch (Exception e) {
+                LOG.warn("Error stopping Micronaut application after kafka streams requested {}", StreamThreadExceptionResponse.SHUTDOWN_APPLICATION, e);
+            }
+        }, SHUTDOWN_THREAD_NAME);
+        shutdownThread.start();
+    }
+
+    private void closeStream(KafkaStreams stream, ConfiguredStreamBuilder builder) {
+        try {
+            if (LOG.isInfoEnabled()) {
+                LOG.info("Shutting down kafka stream {} ", builder.getName());
+            }
+            boolean success = stream.close(builder.getCloseTimeout());
+            if (!success) {
+                LOG.warn("Timeout was exceeded while attempting to close kafka stream {}", builder.getName());
+            }
+        } catch (Exception e) {
+            // ignore
+        }
     }
 }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsFactorySpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsFactorySpec.groovy
@@ -73,7 +73,7 @@ class KafkaStreamsFactorySpec extends Specification {
                 true
             }
         }
-        kafkaStreamsFactory.streams.put(stream, new ConfiguredStreamBuilder(new Properties(), "test", Duration.ofSeconds(1)))
+        kafkaStreamsFactory.getStreams().put(stream, new ConfiguredStreamBuilder(new Properties(), "test", Duration.ofSeconds(1)))
 
         expect:
         kafkaStreamsFactory.reportActiveTasks().asLong == 1L

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsFactorySpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsFactorySpec.groovy
@@ -1,15 +1,23 @@
 package io.micronaut.configuration.kafka.streams
 
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.event.ApplicationEventPublisher
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
+import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.*
 
-class KafkaStreamsFactorySpec extends AbstractTestContainersSpec {
+class KafkaStreamsFactorySpec extends Specification {
 
     void "set exception handler when no config is given"() {
         given:
-        KafkaStreamsFactory kafkaStreamsFactory = context.getBean(KafkaStreamsFactory)
+        KafkaStreamsFactory kafkaStreamsFactory = newKafkaStreamsFactory()
         Properties props = new Properties()
 
         when:
@@ -21,7 +29,7 @@ class KafkaStreamsFactorySpec extends AbstractTestContainersSpec {
 
     void "set exception handler when no valid config is given"() {
         given:
-        KafkaStreamsFactory kafkaStreamsFactory = context.getBean(KafkaStreamsFactory)
+        KafkaStreamsFactory kafkaStreamsFactory = newKafkaStreamsFactory()
         Properties props = ['uncaught-exception-handler': config]
 
         when:
@@ -37,7 +45,7 @@ class KafkaStreamsFactorySpec extends AbstractTestContainersSpec {
     @Unroll
     void "set exception handler when given config is #config"(String config) {
         given:
-        KafkaStreamsFactory kafkaStreamsFactory = context.getBean(KafkaStreamsFactory)
+        KafkaStreamsFactory kafkaStreamsFactory = newKafkaStreamsFactory()
         Properties props = ['uncaught-exception-handler': config]
 
         when:
@@ -52,5 +60,59 @@ class KafkaStreamsFactorySpec extends AbstractTestContainersSpec {
         'replace_thread'       | REPLACE_THREAD
         'shutdown_CLIENT'      | SHUTDOWN_CLIENT
         'SHUTDOWN_APPLICATION' | SHUTDOWN_APPLICATION
+    }
+
+    void "shutdownGracefully closes active streams and updates active task count"() {
+        given:
+        KafkaStreamsFactory kafkaStreamsFactory = newKafkaStreamsFactory()
+        def closed = new AtomicBoolean(false)
+        def stream = Mock(org.apache.kafka.streams.KafkaStreams) {
+            state() >> { closed.get() ? org.apache.kafka.streams.KafkaStreams.State.NOT_RUNNING : org.apache.kafka.streams.KafkaStreams.State.RUNNING }
+            close(Duration.ofSeconds(1)) >> {
+                closed.set(true)
+                true
+            }
+        }
+        kafkaStreamsFactory.streams.put(stream, new ConfiguredStreamBuilder(new Properties(), "test", Duration.ofSeconds(1)))
+
+        expect:
+        kafkaStreamsFactory.reportActiveTasks().asLong == 1L
+
+        when:
+        kafkaStreamsFactory.shutdownGracefully().get()
+
+        then:
+        kafkaStreamsFactory.reportActiveTasks().asLong == 0L
+    }
+
+    void "SHUTDOWN_APPLICATION handler requests Micronaut shutdown"() {
+        given:
+        CountDownLatch stopCalled = new CountDownLatch(1)
+        KafkaStreamsFactory kafkaStreamsFactory = new KafkaStreamsFactory(
+            Stub(ApplicationEventPublisher),
+            Stub(ApplicationContext) {
+                isRunning() >> true
+                stop() >> {
+                    stopCalled.countDown()
+                    null
+                }
+            }
+        )
+        Properties props = ['uncaught-exception-handler': 'SHUTDOWN_APPLICATION']
+
+        when:
+        kafkaStreamsFactory.makeUncaughtExceptionHandler(props).orElseThrow().handle(new RuntimeException("boom"))
+
+        then:
+        stopCalled.await(5, TimeUnit.SECONDS)
+    }
+
+    private KafkaStreamsFactory newKafkaStreamsFactory() {
+        new KafkaStreamsFactory(
+            Stub(ApplicationEventPublisher),
+            Stub(ApplicationContext) {
+                isRunning() >> true
+            }
+        )
     }
 }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaTestInitializer.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaTestInitializer.java
@@ -47,6 +47,8 @@ public class KafkaTestInitializer implements BootstrapPropertySourceLocator {
             OnErrorStreamFactory.ON_ERROR_NO_CONFIG_OUTPUT,
             OnErrorStreamFactory.ON_ERROR_REPLACE_INPUT,
             OnErrorStreamFactory.ON_ERROR_REPLACE_OUTPUT,
+            OnErrorStreamFactory.ON_ERROR_SHUTDOWN_INPUT,
+            OnErrorStreamFactory.ON_ERROR_SHUTDOWN_OUTPUT,
             CustomUncaughtHandlerStreamFactory.CUSTOM_HANDLER_INPUT,
             CustomUncaughtHandlerStreamFactory.CUSTOM_HANDLER_OUTPUT,
             StartKafkaStreamsOff.STREAMS_OFF_INPUT,

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/UncaughtExceptionsSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/UncaughtExceptionsSpec.groovy
@@ -5,7 +5,10 @@ import io.micronaut.configuration.kafka.streams.uncaught.OnErrorNoConfigClient
 import io.micronaut.configuration.kafka.streams.uncaught.OnErrorNoConfigListener
 import io.micronaut.configuration.kafka.streams.uncaught.OnErrorReplaceClient
 import io.micronaut.configuration.kafka.streams.uncaught.OnErrorReplaceListener
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.Topic
 import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.qualifiers.Qualifiers
 import org.apache.kafka.streams.KafkaStreams
 import spock.lang.Shared
@@ -20,15 +23,26 @@ class UncaughtExceptionsSpec extends AbstractTestContainersSpec {
     @Shared
     String onErrorReplaceAppId = 'kafka-on-error-replace-' + UUID.randomUUID().toString()
 
+    @Shared
+    String onErrorShutdownAppId = 'kafka-on-error-shutdown-' + UUID.randomUUID().toString()
+
+    @Shared
+    String streamsStateDir = "${System.getProperty('java.io.tmpdir')}/uncaught-exceptions-${UUID.randomUUID()}"
+
     protected Map<String, Object> getConfiguration() {
         return super.getConfiguration() + [
+                'kafka.streams.default.state.dir': streamsStateDir,
                 'kafka.streams.on-error-no-config.client.id': UUID.randomUUID(),
                 'kafka.streams.on-error-no-config.application.id': onErrorNoConfigAppId,
                 'kafka.streams.on-error-no-config.group.id': UUID.randomUUID(),
                 'kafka.streams.on-error-replace.client.id': UUID.randomUUID(),
                 'kafka.streams.on-error-replace.application.id': onErrorReplaceAppId,
                 'kafka.streams.on-error-replace.group.id': UUID.randomUUID(),
-                'kafka.streams.on-error-replace.uncaught-exception-handler': 'REPLACE_THREAD']
+                'kafka.streams.on-error-replace.uncaught-exception-handler': 'REPLACE_THREAD',
+                'kafka.streams.on-error-shutdown.client.id': UUID.randomUUID(),
+                'kafka.streams.on-error-shutdown.application.id': onErrorShutdownAppId,
+                'kafka.streams.on-error-shutdown.group.id': UUID.randomUUID(),
+                'kafka.streams.on-error-shutdown.uncaught-exception-handler': 'SHUTDOWN_APPLICATION']
     }
 
     void "test uncaught exception with no exception handler"() {
@@ -65,5 +79,27 @@ class UncaughtExceptionsSpec extends AbstractTestContainersSpec {
         }
         stream.state() == KafkaStreams.State.RUNNING
         stream.metadataForLocalThreads().empty == false
+    }
+
+    void "test uncaught exception with SHUTDOWN_APPLICATION stops the app"() {
+        given: "a stream configured with SHUTDOWN_APPLICATION"
+        def stream = context.getBean(KafkaStreams, Qualifiers.byName("on-error-shutdown"))
+        def client = context.getBean(OnErrorShutdownClient)
+
+        when: "the stream thread throws an uncaught exception"
+        client.send('ERROR')
+
+        then: "the Micronaut application shuts down"
+        conditions.eventually {
+            !embeddedServer.isRunning()
+        }
+        stream.state().hasStartedOrFinishedShuttingDown()
+    }
+
+    @Requires(property = "spec.name", value = "UncaughtExceptionsSpec")
+    @KafkaClient
+    static interface OnErrorShutdownClient {
+        @Topic('on-error-shutdown-input')
+        void send(String message)
     }
 }

--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/uncaught/OnErrorStreamFactory.java
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/uncaught/OnErrorStreamFactory.java
@@ -23,6 +23,9 @@ public class OnErrorStreamFactory {
     public static final String ON_ERROR_REPLACE = "on-error-replace";
     public static final String ON_ERROR_REPLACE_INPUT = "on-error-replace-input";
     public static final String ON_ERROR_REPLACE_OUTPUT = "on-error-replace-output";
+    public static final String ON_ERROR_SHUTDOWN = "on-error-shutdown";
+    public static final String ON_ERROR_SHUTDOWN_INPUT = "on-error-shutdown-input";
+    public static final String ON_ERROR_SHUTDOWN_OUTPUT = "on-error-shutdown-output";
 
     @Singleton
     @Named(ON_ERROR_NO_CONFIG)
@@ -41,6 +44,16 @@ public class OnErrorStreamFactory {
             .stream(ON_ERROR_REPLACE_INPUT, Consumed.with(Serdes.String(), Serdes.String()))
             .mapValues(makeErrorValueMapper());
         source.to(ON_ERROR_REPLACE_OUTPUT, Produced.with(Serdes.String(), Serdes.String()));
+        return source;
+    }
+
+    @Singleton
+    @Named(ON_ERROR_SHUTDOWN)
+    KStream<String, String> createOnErrorShutdownApplicationStream(@Named(ON_ERROR_SHUTDOWN) ConfiguredStreamBuilder builder) {
+        final KStream<String, String> source = builder
+            .stream(ON_ERROR_SHUTDOWN_INPUT, Consumed.with(Serdes.String(), Serdes.String()))
+            .mapValues(makeErrorValueMapper());
+        source.to(ON_ERROR_SHUTDOWN_OUTPUT, Produced.with(Serdes.String(), Serdes.String()));
         return source;
     }
 

--- a/src/main/docs/guide/kafkaStreams.adoc
+++ b/src/main/docs/guide/kafkaStreams.adoc
@@ -73,7 +73,9 @@ kafka:
 
 The above configuration example sets the `processing.guarantee` and `auto.offset.reset` setting of the `default` Stream. Most of the configuration properties pass directly through to the `KafkaStreams` instance being initialized.
 
-In addition to those standard properties, you may want to customize how long you wait for Kafka Streams to shut down (this is mostly useful during testing), with `close-timeout`.
+In addition to those standard properties, you may want to customize how long you wait for Kafka Streams to shut down with `close-timeout`.
+
+Micronaut Kafka integrates Kafka Streams with Micronaut's graceful shutdown lifecycle. When the application is stopping, Micronaut waits for the configured streams to close, and `close-timeout` defines how long Micronaut waits for each stream before logging a timeout.
 
 For example, this will make Micronaut Kafka wait for up to 10 seconds to shut down the default stream:
 

--- a/src/main/docs/guide/kafkaStreams/kafkaStreamExceptions.adoc
+++ b/src/main/docs/guide/kafkaStreams/kafkaStreamExceptions.adoc
@@ -16,6 +16,8 @@ kafka:
             uncaught-exception-handler: REPLACE_THREAD
 ----
 
+If the handler returns `SHUTDOWN_APPLICATION`, Micronaut requests application shutdown and Kafka Streams participates in Micronaut's graceful shutdown phase. This means the application lifecycle is stopped, health endpoints can transition accordingly, and Micronaut waits for the configured streams to close using each stream's `close-timeout`.
+
 To implement your own handler, you can listen to the application event api:io.micronaut.configuration.kafka.streams.event.BeforeKafkaStreamStart[] and configure the streams with your own business logic:
 
 [source,java]


### PR DESCRIPTION
## Summary
- integrate Kafka Streams `SHUTDOWN_APPLICATION` handling with Micronaut graceful shutdown
- close Kafka Streams through `GracefulShutdownCapable` and report active shutdown work to Micronaut
- document the graceful shutdown behavior for Kafka Streams and uncaught exception handlers

## Verification
- `./gradlew :micronaut-kafka-streams:test --tests io.micronaut.configuration.kafka.streams.KafkaStreamsFactorySpec`
- `./gradlew publishGuide docs`
- attempted `./gradlew :micronaut-kafka-streams:test --tests io.micronaut.configuration.kafka.streams.UncaughtExceptionsSpec` but local Testcontainers startup timed out in this environment

Resolves #1170
