### PR TITLE
Document schema registry overrides for named clients

### DIFF
--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/KafkaConfigurationSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
 import io.micronaut.configuration.kafka.config.AbstractKafkaConsumerConfiguration
 import io.micronaut.configuration.kafka.config.AbstractKafkaProducerConfiguration
 import io.micronaut.configuration.kafka.config.KafkaConsumerConfiguration
+import io.micronaut.configuration.kafka.config.KafkaProducerConfiguration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.EnvironmentPropertySource
@@ -261,6 +262,35 @@ class KafkaConfigurationSpec extends Specification {
 
         cleanup:
         consumer.close()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-kafka/issues/1160')
+    void "test named producer and consumer schema registry urls override the shared default"() {
+        given:
+        applicationContext = ApplicationContext.run(
+                ('kafka.' + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG): "localhost:1111",
+                'kafka.schema.registry.url': 'mock://shared-registry',
+                'kafka.producers.books.schema.registry.url': 'mock://books-registry',
+                'kafka.producers.orders.schema.registry.url': 'mock://orders-registry',
+                'kafka.consumers.book-group.schema.registry.url': 'mock://books-registry',
+                'kafka.consumers.order-group.schema.registry.url': 'mock://orders-registry'
+        )
+
+        when:
+        AbstractKafkaProducerConfiguration defaultProducer = applicationContext.getBean(AbstractKafkaProducerConfiguration)
+        KafkaProducerConfiguration booksProducer = applicationContext.getBean(KafkaProducerConfiguration, Qualifiers.byName('books'))
+        KafkaProducerConfiguration ordersProducer = applicationContext.getBean(KafkaProducerConfiguration, Qualifiers.byName('orders'))
+        AbstractKafkaConsumerConfiguration defaultConsumer = applicationContext.getBean(AbstractKafkaConsumerConfiguration)
+        KafkaConsumerConfiguration bookGroupConsumer = applicationContext.getBean(KafkaConsumerConfiguration, Qualifiers.byName('book-group'))
+        KafkaConsumerConfiguration orderGroupConsumer = applicationContext.getBean(KafkaConsumerConfiguration, Qualifiers.byName('order-group'))
+
+        then:
+        defaultProducer.config['schema.registry.url'] == 'mock://shared-registry'
+        booksProducer.config['schema.registry.url'] == 'mock://books-registry'
+        ordersProducer.config['schema.registry.url'] == 'mock://orders-registry'
+        defaultConsumer.config['schema.registry.url'] == 'mock://shared-registry'
+        bookGroupConsumer.config['schema.registry.url'] == 'mock://books-registry'
+        orderGroupConsumer.config['schema.registry.url'] == 'mock://orders-registry'
     }
 
     void "test consumer with camel-case group id"() {

--- a/src/main/docs/guide/kafkaSerialization.adoc
+++ b/src/main/docs/guide/kafkaSerialization.adoc
@@ -93,3 +93,38 @@ kafka:
 ----
 
 That setup is often enough for tests that verify producer and listener wiring with generated Avro or Protobuf types. If you also want to validate registry compatibility rules or schema lifecycle behavior, run a real Schema Registry alongside Kafka in your integration tests.
+
+When the same test suite needs multiple isolated registries, keep the shared Kafka settings under `kafka.*` and override the registry URL per producer id and consumer group id:
+
+.Configuring multiple mock schema registries in one test suite
+[configuration]
+----
+kafka:
+  bootstrap:
+    servers: localhost:9092
+  schema:
+    registry:
+      url: mock://shared-registry
+  producers:
+    books:
+      schema:
+        registry:
+          url: mock://books-registry
+    documents:
+      schema:
+        registry:
+          url: mock://documents-registry
+  consumers:
+    book-group:
+      schema:
+        registry:
+          url: mock://books-registry
+    document-group:
+      schema:
+        registry:
+          url: mock://documents-registry
+----
+
+Use the same producer ids that you assign to `@KafkaClient` and the same consumer group ids that you assign to `@KafkaListener`. The matching producer and consumer should point at the same registry URL, while unrelated clients can use a different mock scope or a different local registry endpoint entirely.
+
+The same scoping pattern also works with other schema registry implementations. Replace the serializer and deserializer classes with the equivalents from your chosen library and point each producer or consumer configuration at the corresponding test endpoint.


### PR DESCRIPTION
## Summary

- document how to override schema registry URLs per producer id and consumer group id
- add regression coverage proving named clients override the shared default registry URL

## Validation

- Not run (not requested)

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/1160
