### PR TITLE
Default async KafkaClient methods to TaskExecutors.BLOCKING

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -773,9 +773,11 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
             ContextSupplier<Integer> partitionSupplier = ctx -> finalPartitionFromProducerFn.apply(ctx, producer);
 
             String executor = context.stringValue(KafkaClient.class, "executor")
-                .orElseGet(() -> newConfiguration.getExecutor().orElseGet(() ->
-                    context.getReturnType().asArgument().isAsyncOrReactive() ? TaskExecutors.BLOCKING : ""
-                ));
+                .orElseGet(() -> newConfiguration.getExecutor()
+                    .filter(StringUtils::isNotEmpty)
+                    .orElseGet(() ->
+                        context.getReturnType().asArgument().isAsyncOrReactive() ? TaskExecutors.BLOCKING : ""
+                    ));
 
             ExecutorService executorService = StringUtils.isNotEmpty(executor)
                 ? beanContext.findBean(ExecutorService.class, Qualifiers.byName(executor)).orElse(null)

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/intercept/KafkaClientIntroductionAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.messaging.annotation.MessageBody;
 import io.micronaut.messaging.annotation.MessageHeader;
 import io.micronaut.messaging.exceptions.MessagingClientException;
+import io.micronaut.scheduling.TaskExecutors;
 import jakarta.annotation.PreDestroy;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -771,9 +772,14 @@ class KafkaClientIntroductionAdvice implements MethodInterceptor<Object, Object>
             BiFunction<MethodInvocationContext<?, ?>, Producer, Integer> finalPartitionFromProducerFn = partitionFromProducerFn;
             ContextSupplier<Integer> partitionSupplier = ctx -> finalPartitionFromProducerFn.apply(ctx, producer);
 
-            String executor = context.stringValue(KafkaClient.class, "executor").orElseGet(() -> newConfiguration.getExecutor().orElse(""));
+            String executor = context.stringValue(KafkaClient.class, "executor")
+                .orElseGet(() -> newConfiguration.getExecutor().orElseGet(() ->
+                    context.getReturnType().asArgument().isAsyncOrReactive() ? TaskExecutors.BLOCKING : ""
+                ));
 
-            ExecutorService executorService = beanContext.findBean(ExecutorService.class, Qualifiers.byName(executor)).orElse(null);
+            ExecutorService executorService = StringUtils.isNotEmpty(executor)
+                ? beanContext.findBean(ExecutorService.class, Qualifiers.byName(executor)).orElse(null)
+                : null;
 
             return new ProducerState(producer, keySupplier, topicSupplier[0], valueSupplier, timestampSupplier, partitionSupplier, headersSupplier,
                     transactional, transactionalId, maxBlock, isBatchSend, bodyArgument, executorService);

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientWithExecutorSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientWithExecutorSpec.groovy
@@ -42,13 +42,13 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
                     ex -> {
                         int currentCount = failureCount.incrementAndGet()
                         LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
                     })
-        }).toList()
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -68,13 +68,13 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
                     ex -> {
                         int currentCount = failureCount.incrementAndGet()
                         LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
                     })
-        }).toList()
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -95,13 +95,13 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
                     ex -> {
                         int currentCount = failureCount.incrementAndGet()
                         LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
                     })
-        }).toList()
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -121,17 +121,46 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
                     ex -> {
                         int currentCount = failureCount.incrementAndGet()
                         LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
                     })
-        }).toList()
+        })
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
-        elapsedMillis < 1000
+        elapsedMillis < 1500
+        failureCount.get() == 0
+    }
+
+    void "test reactive send message with empty executor in config does not look up a named executor or block when Kafka is not available"() {
+        given: "executor is explicitly configured as empty string"
+        ctx = ApplicationContext.run(
+                getConfiguration() +
+                        ['kafka.bootstrap.servers': LOCALHOST + ':' + SocketUtils.findAvailableTcpPort(),
+                         'kafka.producers.default.executor': ''])
+        MyDefaultExecutorClient client = ctx.getBean(MyDefaultExecutorClient)
+
+        when: "client operations are invoked while Kafka is unavailable"
+        long start = System.nanoTime()
+        AtomicInteger failureCount = new AtomicInteger(0)
+        List<Mono<String>> sendOps = new ArrayList<>()
+        for (int x=0; x<3; x++) {
+            sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
+        }
+        sendOps.forEach(sendOp -> {
+            sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
+                    ex -> {
+                        int currentCount = failureCount.incrementAndGet()
+                        LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
+                    })
+        })
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+
+        then: "no named executor is looked up and the calls do not block for the maxBlock timeout"
+        elapsedMillis < 1500
         failureCount.get() == 0
     }
 
@@ -149,11 +178,12 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendSentence("test", "hello-world"))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.exceptionally {
                 int currentCount = failureCount.incrementAndGet()
                 LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
-            }}).toList()
+            }
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -173,11 +203,12 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendSentence("test", "hello-world"))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.exceptionally {
                 int currentCount = failureCount.incrementAndGet()
                 LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
-            }}).toList()
+            }
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -196,11 +227,12 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendSentence("test", "hello-world"))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.exceptionally {
                 int currentCount = failureCount.incrementAndGet()
                 LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
-            }}).toList()
+            }
+        })
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
         failureCount.get() == 0
@@ -220,15 +252,44 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         for (int x=0; x<3; x++) {
             sendOps.add(client.sendSentence("test", "hello-world"))
         }
-        sendOps.stream().map(sendOp -> {
+        sendOps.forEach(sendOp -> {
             sendOp.exceptionally {
                 int currentCount = failureCount.incrementAndGet()
                 LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
-            }}).toList()
+            }
+        })
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
-        elapsedMillis < 1000
+        elapsedMillis < 1500
+        failureCount.get() == 0
+    }
+
+    void "test future send message with empty executor in config does not look up a named executor or block when Kafka is not available"() {
+        given: "executor is explicitly configured as empty string"
+        ctx = ApplicationContext.run(
+                getConfiguration() +
+                        ['kafka.bootstrap.servers': LOCALHOST + ':' + SocketUtils.findAvailableTcpPort(),
+                         'kafka.producers.default.executor': ''])
+        MyDefaultExecutorClient client = ctx.getBean(MyDefaultExecutorClient)
+
+        when: "client operations are invoked while Kafka is unavailable"
+        long start = System.nanoTime()
+        AtomicInteger failureCount = new AtomicInteger(0)
+        List<CompletableFuture<String>> sendOps = new ArrayList<>()
+        for (int x=0; x<3; x++) {
+            sendOps.add(client.sendSentence("test", "hello-world"))
+        }
+        sendOps.forEach(sendOp -> {
+            sendOp.exceptionally {
+                int currentCount = failureCount.incrementAndGet()
+                LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
+            }
+        })
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+
+        then: "no named executor is looked up and the calls do not block for the maxBlock timeout"
+        elapsedMillis < 1500
         failureCount.get() == 0
     }
 

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientWithExecutorSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientWithExecutorSpec.groovy
@@ -15,6 +15,7 @@ import spock.lang.AutoCleanup
 import spock.util.concurrent.PollingConditions
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import static io.micronaut.configuration.kafka.annotation.KafkaClient.Acknowledge.ALL
@@ -106,6 +107,34 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
         failureCount.get() == 0
     }
 
+    void "test reactive send message uses the blocking executor by default when Kafka is not available"() {
+        given: "no executor is specified"
+        ctx = ApplicationContext.run(
+                getConfiguration() +
+                        ['kafka.bootstrap.servers': LOCALHOST + ':' + SocketUtils.findAvailableTcpPort()])
+        MyDefaultExecutorClient client = ctx.getBean(MyDefaultExecutorClient)
+
+        when: "client operations are invoked while Kafka is unavailable"
+        long start = System.nanoTime()
+        AtomicInteger failureCount = new AtomicInteger(0)
+        List<Mono<String>> sendOps = new ArrayList<>()
+        for (int x=0; x<3; x++) {
+            sendOps.add(client.sendRx("test", "hello-world", new RecordHeaders([new RecordHeader("hello", "world".bytes)])))
+        }
+        sendOps.stream().map(sendOp -> {
+            sendOp.subscribe(s -> { throw new IllegalStateException("Unexpected result") },
+                    ex -> {
+                        int currentCount = failureCount.incrementAndGet()
+                        LOG.debug("Subscriber failure # {} : {}", currentCount, ex.getMessage())
+                    })
+        }).toList()
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+
+        then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
+        elapsedMillis < 1000
+        failureCount.get() == 0
+    }
+
     void "test future send message with executor set via default config props does not block the calling thread when Kafka is not available"() {
         given: "the default executor is specified"
         ctx = ApplicationContext.run(
@@ -174,6 +203,32 @@ class KafkaClientWithExecutorSpec extends AbstractKafkaSpec {
             }}).toList()
 
         then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
+        failureCount.get() == 0
+    }
+
+    void "test future send message uses the blocking executor by default when Kafka is not available"() {
+        given: "no executor is specified"
+        ctx = ApplicationContext.run(
+                getConfiguration() +
+                        ['kafka.bootstrap.servers': LOCALHOST + ':' + SocketUtils.findAvailableTcpPort()])
+        MyDefaultExecutorClient client = ctx.getBean(MyDefaultExecutorClient)
+
+        when: "client operations are invoked while Kafka is unavailable"
+        long start = System.nanoTime()
+        AtomicInteger failureCount = new AtomicInteger(0)
+        List<CompletableFuture<String>> sendOps = new ArrayList<>()
+        for (int x=0; x<3; x++) {
+            sendOps.add(client.sendSentence("test", "hello-world"))
+        }
+        sendOps.stream().map(sendOp -> {
+            sendOp.exceptionally {
+                int currentCount = failureCount.incrementAndGet()
+                LOG.debug("Subscriber failure # {} : {}", currentCount, it.getMessage())
+            }}).toList()
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
+
+        then: "the operations should not block the calling thread while waiting for the maxBlock timeout"
+        elapsedMillis < 1000
         failureCount.get() == 0
     }
 


### PR DESCRIPTION
## Summary
- default `@KafkaClient` reactive and `CompletableFuture` methods to `TaskExecutors.BLOCKING` when no executor is configured
- keep explicit executor configuration unchanged and avoid looking up an executor bean for an empty executor name
- add regression coverage showing async client calls return immediately when Kafka is unavailable

## Validation
- added regression tests in `KafkaClientWithExecutorSpec`

Resolves https://github.com/micronaut-projects/micronaut-kafka/issues/956
