### PR TITLE
Support non-blocking retry topics

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategy.java
@@ -120,12 +120,38 @@ public @interface ErrorStrategy {
 
     /**
      * The dead letter topic to publish failed records to when using
-     * {@link ErrorStrategyValue#LOG_AND_RESUME_AT_NEXT_RECORD}.
+     * {@link ErrorStrategyValue#LOG_AND_RESUME_AT_NEXT_RECORD} or
+     * {@link ErrorStrategyValue#RETRY_TOPIC_ON_ERROR} after retry topics are exhausted.
      *
      * @return The dead letter topic name
      * @since 5.8
      */
     String dlq() default "";
+
+    /**
+     * The suffixes used to derive retry topics from the original topic name when using
+     * {@link ErrorStrategyValue#RETRY_TOPIC_ON_ERROR}.
+     *
+     * <p>For example, with an original topic {@code orders} and suffixes
+     * {@code -retry-5s} and {@code -retry-30s}, Micronaut will use the retry topics
+     * {@code orders-retry-5s} and {@code orders-retry-30s}.</p>
+     *
+     * @return The retry topic suffixes
+     * @since 6.0.0
+     */
+    String[] retryTopicSuffixes() default {};
+
+    /**
+     * The delays to apply before consuming records from the retry topics declared in
+     * {@link #retryTopicSuffixes()} when using
+     * {@link ErrorStrategyValue#RETRY_TOPIC_ON_ERROR}.
+     *
+     * <p>The number of configured delays must match the number of configured retry topic suffixes.</p>
+     *
+     * @return The retry topic delays
+     * @since 6.0.0
+     */
+    String[] retryTopicDelays() default {};
 
     /**
      * The types of exceptions to retry, used with RETRY_ON_ERROR and RETRY_EXPONENTIALLY_ON_ERROR,

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/annotation/ErrorStrategyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,16 @@ public enum ErrorStrategyValue {
     LOG_AND_RESUME_AT_NEXT_RECORD,
 
     /**
+     * This strategy will publish the failed record to retry topics so the original topic can continue
+     * processing while the failed record is retried asynchronously after the configured delay.
+     * When no retry topics remain, the record is optionally published to the configured dead letter
+     * topic and the listener exception is handled.
+     *
+     * @since 6.0.0
+     */
+    RETRY_TOPIC_ON_ERROR,
+
+    /**
      * This strategy will stop consuming subsequent records in the case of an error and will
      * attempt to re-consume or skip the current according to the behaviour defined by the
      * {@link ConditionalRetryBehaviourHandler}.
@@ -94,6 +104,14 @@ public enum ErrorStrategyValue {
             this == RETRY_EXPONENTIALLY_ON_ERROR ||
             this == RETRY_CONDITIONALLY_ON_ERROR ||
             this == RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR;
+    }
+
+    /**
+     * @return Whether this strategy uses non-blocking retry topics.
+     * @since 6.0.0
+     */
+    public boolean isRetryTopic() {
+        return this == RETRY_TOPIC_ON_ERROR;
     }
 
     public boolean isConditionalRetry() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -41,7 +41,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +110,7 @@ final class ConsumerInfo {
         AnnotationValue<KafkaListener> kafkaListener,
         Properties properties,
         ExecutableMethod<?, ?> method,
-        Collection<ConsumerRecordInterceptor<?, ?>> consumerRecordInterceptors
+        Object values
     ) {
         this(
             clientId,
@@ -120,20 +119,9 @@ final class ConsumerInfo {
             kafkaListener,
             properties,
             List.of(method),
-            Map.of(method, List.copyOf(consumerRecordInterceptors))
+            topicAnnotations(values, method),
+            Map.of(method, List.copyOf(interceptors(values)))
         );
-    }
-
-    ConsumerInfo(
-        String clientId,
-        String groupId,
-        OffsetStrategy offsetStrategy,
-        AnnotationValue<KafkaListener> kafkaListener,
-        Properties properties,
-        ExecutableMethod<?, ?> method,
-        List<AnnotationValue<Topic>> topicAnnotations
-    ) {
-        this(clientId, groupId, offsetStrategy, kafkaListener, properties, List.of(method), topicAnnotations, Map.of());
     }
 
     ConsumerInfo(
@@ -228,6 +216,20 @@ final class ConsumerInfo {
                 throw new MessagingSystemException("Redelivery not supported for transactions in combination with @SendTo");
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<AnnotationValue<Topic>> topicAnnotations(Object values, ExecutableMethod<?, ?> method) {
+        return values instanceof List<?> list && (list.isEmpty() || list.get(0) instanceof AnnotationValue)
+            ? (List<AnnotationValue<Topic>>) values
+            : method.getDeclaredAnnotationValuesByType(Topic.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<ConsumerRecordInterceptor<?, ?>> interceptors(Object values) {
+        return values instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof ConsumerRecordInterceptor
+            ? (List<ConsumerRecordInterceptor<?, ?>>) values
+            : List.of();
     }
 
     boolean routesByTopic() {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -142,6 +142,9 @@ final class ConsumerInfo {
         this.offsetStrategy = offsetStrategy;
         final Optional<AnnotationValue<ErrorStrategy>> errorStrategyAnnotation = kafkaListener.getAnnotation("errorStrategy", ErrorStrategy.class);
         this.errorStrategy = errorStrategyAnnotation.map(a -> a.getRequiredValue(ErrorStrategyValue.class)).orElse(ErrorStrategyValue.NONE); // NOSONAR
+        if (this.errorStrategy.isRetryTopic() && offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' cannot be used with offset strategy 'SEND_TO_TRANSACTION'");
+        }
         this.dlq = errorStrategyAnnotation.flatMap(a -> a.stringValue("dlq")).filter(StringUtils::isNotEmpty).orElse(null);
         if (this.errorStrategy == ErrorStrategyValue.LOG_AND_RESUME_AT_NEXT_RECORD && this.dlq == null) {
             throw new MessagingSystemException("Error strategy 'LOG_AND_RESUME_AT_NEXT_RECORD' requires setting a non-empty dead letter topic with 'dlq'");

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerInfo.java
@@ -78,6 +78,7 @@ final class ConsumerInfo {
     final boolean trackPartitions;
     final boolean shouldSendOffsetsToTransaction;
     final boolean cooperativeStickyAssignmentStrategy;
+    @Nullable final NonBlockingRetryTopics nonBlockingRetryTopics;
     private final List<ExecutableMethod<Object, ?>> listenerMethods;
     private final Map<String, ExecutableMethod<Object, ?>> topicMethods = new HashMap<>();
     private final List<PatternMethod> patternMethods;
@@ -97,7 +98,19 @@ final class ConsumerInfo {
         Properties properties,
         ExecutableMethod<?, ?> method
     ) {
-        this(clientId, groupId, offsetStrategy, kafkaListener, properties, List.of(method));
+        this(clientId, groupId, offsetStrategy, kafkaListener, properties, method, method.getDeclaredAnnotationValuesByType(Topic.class));
+    }
+
+    ConsumerInfo(
+        String clientId,
+        String groupId,
+        OffsetStrategy offsetStrategy,
+        AnnotationValue<KafkaListener> kafkaListener,
+        Properties properties,
+        ExecutableMethod<?, ?> method,
+        List<AnnotationValue<Topic>> topicAnnotations
+    ) {
+        this(clientId, groupId, offsetStrategy, kafkaListener, properties, List.of(method), topicAnnotations);
     }
 
     @SuppressWarnings("unchecked")
@@ -108,6 +121,20 @@ final class ConsumerInfo {
         AnnotationValue<KafkaListener> kafkaListener,
         Properties properties,
         List<ExecutableMethod<?, ?>> methods
+    ) {
+        this(clientId, groupId, offsetStrategy, kafkaListener, properties, methods, methods.stream()
+            .flatMap(executableMethod -> executableMethod.getDeclaredAnnotationValuesByType(Topic.class).stream())
+            .toList());
+    }
+
+    ConsumerInfo(
+        String clientId,
+        String groupId,
+        OffsetStrategy offsetStrategy,
+        AnnotationValue<KafkaListener> kafkaListener,
+        Properties properties,
+        List<ExecutableMethod<?, ?>> methods,
+        List<AnnotationValue<Topic>> topicAnnotations
     ) {
         this.clientId = clientId;
         this.groupId = groupId;
@@ -137,9 +164,10 @@ final class ConsumerInfo {
         }
         this.listenerMethods = List.copyOf(resolvedListenerMethods);
         this.method = this.listenerMethods.get(0);
+        this.isBatch = method.isTrue(KafkaListener.class, "batch");
+        this.nonBlockingRetryTopics = NonBlockingRetryTopics.create(kafkaListener, topicAnnotations, this.isBatch);
         this.patternMethods = resolveTopicMethods(this.listenerMethods);
         this.autoStartup = kafkaListener.booleanValue("autoStartup").orElse(true);
-        this.isBatch = method.isTrue(KafkaListener.class, "batch");
         this.pollTimeout = method.getValue(KafkaListener.class, "pollTimeout", Duration.class).orElseGet(() -> Duration.ofMillis(100));
         this.trackPartitions = anyMethodHasAckArg() || offsetStrategy == OffsetStrategy.SYNC_PER_RECORD || offsetStrategy == OffsetStrategy.ASYNC_PER_RECORD;
         this.shouldSendOffsetsToTransaction = offsetStrategy == OffsetStrategy.SEND_TO_TRANSACTION;
@@ -282,10 +310,21 @@ final class ConsumerInfo {
 
     private void registerDirectTopics(ExecutableMethod<Object, ?> executableMethod, AnnotationValue<Topic> topicAnnotation) {
         for (String topic : topicAnnotation.stringValues()) {
-            ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
-            if (previous != null && previous != executableMethod) {
-                throw new MessagingSystemException("Duplicate topic [" + topic + "] found for listener [" + executableMethod.getDeclaringType().getName() + ']');
+            registerDirectTopic(topic, executableMethod);
+            if (nonBlockingRetryTopics != null) {
+                for (String retryTopic : nonBlockingRetryTopics.expandTopics(new String[] { topic })) {
+                    if (!retryTopic.equals(topic)) {
+                        registerDirectTopic(retryTopic, executableMethod);
+                    }
+                }
             }
+        }
+    }
+
+    private void registerDirectTopic(String topic, ExecutableMethod<Object, ?> executableMethod) {
+        ExecutableMethod<Object, ?> previous = topicMethods.putIfAbsent(topic, executableMethod);
+        if (previous != null && previous != executableMethod) {
+            throw new MessagingSystemException("Duplicate topic [" + topic + "] found for listener [" + executableMethod.getDeclaringType().getName() + ']');
         }
     }
 

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -38,6 +38,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -77,11 +78,14 @@ abstract class ConsumerState {
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerProcessor.class); // NOSONAR
     private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration DLQ_PUBLISH_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration RETRY_TOPIC_PUBLISH_RETRY_DELAY = Duration.ofSeconds(1);
     private static final String DLQ_EXCEPTION_CLASS_HEADER = "micronaut-kafka-exception-class";
     private static final String DLQ_EXCEPTION_MESSAGE_HEADER = "micronaut-kafka-exception-message";
     private static final String DLQ_ORIGINAL_TOPIC_HEADER = "micronaut-kafka-original-topic";
     private static final String DLQ_ORIGINAL_PARTITION_HEADER = "micronaut-kafka-original-partition";
     private static final String DLQ_ORIGINAL_OFFSET_HEADER = "micronaut-kafka-original-offset";
+    private static final String RETRY_TOPIC_ATTEMPT_HEADER = "micronaut-kafka-retry-attempt";
+    private static final String RETRY_TOPIC_DUE_TIMESTAMP_HEADER = "micronaut-kafka-retry-due-timestamp";
 
     protected final KafkaConsumerProcessor kafkaConsumerProcessor;
     protected final Object consumerBean;
@@ -523,6 +527,12 @@ abstract class ConsumerState {
         final Duration retryDelay = info.errorStrategy.computeRetryDelay(info.retryDelay,
             currentRetryCount);
         if (retryDelay != null) {
+            delayRetry(retryDelay, partitions);
+        }
+    }
+
+    protected void delayRetry(Duration retryDelay, Set<TopicPartition> partitions) {
+        if (retryDelay != null) {
             pause(partitions);
             kafkaConsumerProcessor.scheduleTask(retryDelay, () -> resume(partitions));
         }
@@ -554,6 +564,24 @@ abstract class ConsumerState {
         return retryState;
     }
 
+    protected boolean retryTopicNotDue(ConsumerRecord<?, ?> consumerRecord) {
+        if (info.nonBlockingRetryTopics == null || !info.nonBlockingRetryTopics.isRetryTopic(consumerRecord.topic())) {
+            return false;
+        }
+        Instant due = retryTopicDueTimestamp(consumerRecord);
+        if (due == null) {
+            return false;
+        }
+        Instant now = Instant.now();
+        if (!due.isAfter(now)) {
+            return false;
+        }
+        TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+        kafkaConsumer.seek(topicPartition, consumerRecord.offset());
+        delayRetry(Duration.between(now, due), Collections.singleton(topicPartition));
+        return true;
+    }
+
     protected void handleException(Throwable e, @Nullable ConsumerRecords<?, ?> consumerRecords,
         @Nullable ConsumerRecord<?, ?> consumerRecord) {
         handleException(String.valueOf(e.getMessage()), e, consumerRecords, consumerRecord);
@@ -561,7 +589,11 @@ abstract class ConsumerState {
 
     protected void publishToDlq(Throwable e, @Nullable ConsumerRecords<?, ?> consumerRecords,
         @Nullable ConsumerRecord<?, ?> consumerRecord) {
-        if (info.errorStrategy != io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.LOG_AND_RESUME_AT_NEXT_RECORD || info.dlq == null) {
+        if (info.dlq == null) {
+            return;
+        }
+        if (info.errorStrategy != io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.LOG_AND_RESUME_AT_NEXT_RECORD &&
+            !info.errorStrategy.isRetryTopic()) {
             return;
         }
         if (consumerRecord != null) {
@@ -588,11 +620,7 @@ abstract class ConsumerState {
             (Class<?>) (value != null ? value.getClass() : byte[].class)
         );
         final Headers headers = new RecordHeaders(consumerRecord.headers());
-        addDlqHeader(headers, DLQ_EXCEPTION_CLASS_HEADER, error.getClass().getName());
-        addDlqHeader(headers, DLQ_EXCEPTION_MESSAGE_HEADER, error.getMessage());
-        addDlqHeader(headers, DLQ_ORIGINAL_TOPIC_HEADER, consumerRecord.topic());
-        addDlqHeader(headers, DLQ_ORIGINAL_PARTITION_HEADER, Integer.toString(consumerRecord.partition()));
-        addDlqHeader(headers, DLQ_ORIGINAL_OFFSET_HEADER, Long.toString(consumerRecord.offset()));
+        populateFailureHeaders(headers, consumerRecord, error, shouldPreserveOriginalHeaders(consumerRecord));
         final Long timestamp = consumerRecord.timestamp() >= 0 ? consumerRecord.timestamp() : null;
         final ProducerRecord producerRecord = new ProducerRecord(info.dlq, null, timestamp, key, value, headers);
         final long dlqPublishTimeoutSeconds = DLQ_PUBLISH_TIMEOUT.toSeconds();
@@ -633,6 +661,77 @@ abstract class ConsumerState {
                 dlqError
             );
         }
+    }
+
+    protected boolean publishToRetryTopic(ConsumerRecord<?, ?> consumerRecord, Throwable error, NonBlockingRetryTopics.RetryDispatch retryDispatch) {
+        final Object key = consumerRecord.key();
+        final Object value = consumerRecord.value();
+        final Producer<?, ?> kafkaProducer = kafkaConsumerProcessor.getProducer(
+            Optional.ofNullable(info.producerClientId).orElse(info.groupId),
+            (Class<?>) (key != null ? key.getClass() : byte[].class),
+            (Class<?>) (value != null ? value.getClass() : byte[].class)
+        );
+        final Headers headers = new RecordHeaders(consumerRecord.headers());
+        populateFailureHeaders(headers, consumerRecord, error, shouldPreserveOriginalHeaders(consumerRecord));
+        addDlqHeader(headers, RETRY_TOPIC_ATTEMPT_HEADER, Integer.toString(retryDispatch.attempt()));
+        addDlqHeader(headers, RETRY_TOPIC_DUE_TIMESTAMP_HEADER, Long.toString(Instant.now().plus(retryDispatch.delay()).toEpochMilli()));
+        final Long timestamp = consumerRecord.timestamp() >= 0 ? consumerRecord.timestamp() : null;
+        final ProducerRecord producerRecord = new ProducerRecord(retryDispatch.retryTopic(), null, timestamp, key, value, headers);
+        try {
+            kafkaProducer.send(producerRecord).get(DLQ_PUBLISH_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            return true;
+        } catch (Exception publishError) {
+            LOG.error(
+                "Error publishing record [topic={}, partition={}, offset={}] to retry topic [{}]: {}",
+                consumerRecord.topic(),
+                consumerRecord.partition(),
+                consumerRecord.offset(),
+                retryDispatch.retryTopic(),
+                publishError.getMessage(),
+                publishError
+            );
+            return false;
+        }
+    }
+
+    protected Duration retryTopicPublishRetryDelay() {
+        return RETRY_TOPIC_PUBLISH_RETRY_DELAY;
+    }
+
+    @Nullable
+    private static Instant retryTopicDueTimestamp(ConsumerRecord<?, ?> consumerRecord) {
+        Header header = consumerRecord.headers().lastHeader(RETRY_TOPIC_DUE_TIMESTAMP_HEADER);
+        if (header == null || header.value() == null) {
+            return null;
+        }
+        try {
+            return Instant.ofEpochMilli(Long.parseLong(new String(header.value(), StandardCharsets.UTF_8)));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void populateFailureHeaders(Headers headers, ConsumerRecord<?, ?> consumerRecord, Throwable error, boolean preserveOriginalHeaders) {
+        addDlqHeader(headers, DLQ_EXCEPTION_CLASS_HEADER, error.getClass().getName());
+        addDlqHeader(headers, DLQ_EXCEPTION_MESSAGE_HEADER, error.getMessage());
+        addDlqHeader(headers, DLQ_ORIGINAL_TOPIC_HEADER, originalHeaderValue(consumerRecord, DLQ_ORIGINAL_TOPIC_HEADER, consumerRecord.topic(), preserveOriginalHeaders));
+        addDlqHeader(headers, DLQ_ORIGINAL_PARTITION_HEADER, originalHeaderValue(consumerRecord, DLQ_ORIGINAL_PARTITION_HEADER, Integer.toString(consumerRecord.partition()), preserveOriginalHeaders));
+        addDlqHeader(headers, DLQ_ORIGINAL_OFFSET_HEADER, originalHeaderValue(consumerRecord, DLQ_ORIGINAL_OFFSET_HEADER, Long.toString(consumerRecord.offset()), preserveOriginalHeaders));
+    }
+
+    private boolean shouldPreserveOriginalHeaders(ConsumerRecord<?, ?> consumerRecord) {
+        return info.nonBlockingRetryTopics != null && info.nonBlockingRetryTopics.isRetryTopic(consumerRecord.topic());
+    }
+
+    private static String originalHeaderValue(ConsumerRecord<?, ?> consumerRecord, String name, String fallback, boolean preserveOriginalHeaders) {
+        if (!preserveOriginalHeaders) {
+            return fallback;
+        }
+        Header header = consumerRecord.headers().lastHeader(name);
+        if (header == null || header.value() == null) {
+            return fallback;
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
     }
 
     private static void addDlqHeader(Headers headers, String name, @Nullable String value) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerState.java
@@ -680,6 +680,18 @@ abstract class ConsumerState {
         try {
             kafkaProducer.send(producerRecord).get(DLQ_PUBLISH_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             return true;
+        } catch (InterruptedException publishError) {
+            Thread.currentThread().interrupt();
+            LOG.error(
+                "Error publishing record [topic={}, partition={}, offset={}] to retry topic [{}]: {}",
+                consumerRecord.topic(),
+                consumerRecord.partition(),
+                consumerRecord.offset(),
+                retryDispatch.retryTopic(),
+                publishError.getMessage(),
+                publishError
+            );
+            return false;
         } catch (Exception publishError) {
             LOG.error(
                 "Error publishing record [topic={}, partition={}, offset={}] to retry topic [{}]: {}",

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -92,6 +92,11 @@ final class ConsumerStateSingle extends ConsumerState {
             final ConsumerRecord<?, ?> consumerRecord = iterator.next();
             final String topic = consumerRecord.topic();
             logRecord(topic, consumerRecord);
+            if (retryTopicNotDue(consumerRecord)) {
+                resetTheFollowingPartitions(consumerRecord, iterator);
+                failed = true;
+                return;
+            }
             trackCurrentOffset(consumerRecord, currentOffsets);
             final KafkaSeekOperations seek = bindRecordArguments(topic, currentOffsets);
             if (withKafkaScope(() -> processRecord(topic, consumerRecords, currentOffsets, iterator, consumerRecord, seek))) {
@@ -204,6 +209,23 @@ final class ConsumerStateSingle extends ConsumerState {
     @SuppressWarnings("java:S1874") // ErrorStrategyValue.NONE is deprecated
     private boolean resolveWithErrorStrategy(@Nullable ConsumerRecords<?, ?> consumerRecords,
         ConsumerRecord<?, ?> consumerRecord, Throwable e) {
+        if (info.nonBlockingRetryTopics != null) {
+            NonBlockingRetryTopics.RetryDispatch retryDispatch = shouldRetryException(e, consumerRecords, consumerRecord)
+                ? info.nonBlockingRetryTopics.nextRetry(consumerRecord.topic())
+                : null;
+            if (retryDispatch != null) {
+                if (publishToRetryTopic(consumerRecord, e, retryDispatch)) {
+                    if (info.shouldHandleAllExceptions) {
+                        handleException(e, consumerRecords, consumerRecord);
+                    }
+                    return false;
+                }
+                final TopicPartition topicPartition = getTopicPartition(consumerRecord);
+                kafkaConsumer.seek(topicPartition, consumerRecord.offset());
+                delayRetry(retryTopicPublishRetryDelay(), Collections.singleton(topicPartition));
+                return true;
+            }
+        }
         if (info.errorStrategy.isRetry()) {
             final TopicPartition topicPartition = getTopicPartition(consumerRecord);
             final boolean retryable = shouldRetryException(e, consumerRecords, consumerRecord);

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/ConsumerStateSingle.java
@@ -175,6 +175,7 @@ final class ConsumerStateSingle extends ConsumerState {
         failed = true;
         return true;
     }
+
     private void commitOffsets(ConsumerRecords<?, ?> consumerRecords,
         ConsumerRecord<?, ?> consumerRecord,
         Map<TopicPartition, OffsetAndMetadata> currentOffsets) {

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/KafkaConsumerProcessor.java
@@ -349,7 +349,9 @@ class KafkaConsumerProcessor
             }
         }
         final ExecutableMethod<?, ?> primaryMethod = methods.get(0);
-        configureDeserializers(methods, consumerConfiguration);
+        final boolean batch = primaryMethod.isTrue(KafkaListener.class, "batch");
+        final NonBlockingRetryTopics nonBlockingRetryTopics = NonBlockingRetryTopics.create(consumerAnnotation, topicAnnotations, batch);
+        configureDeserializers(methods, consumerConfiguration, nonBlockingRetryTopics);
         submitConsumerThreads(primaryMethod, clientId, groupId, offsetStrategy, topicAnnotations,
             consumerAnnotation, consumerConfiguration, properties, beanType, methods, uniqueGroupIdDeleteOnShutdown);
     }
@@ -609,9 +611,9 @@ class KafkaConsumerProcessor
                 //noinspection unchecked
                 ca.setKafkaConsumer(kafkaConsumer);
             }
-            setupConsumerSubscription(method, topicAnnotations, consumerBean, kafkaConsumer);
+            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, properties, methods, topicAnnotations);
+            setupConsumerSubscription(method, topicAnnotations, consumerInfo, consumerBean, kafkaConsumer);
             kafkaConsumerSubscribedEventPublisher.publishEvent(new KafkaConsumerSubscribedEvent(kafkaConsumer));
-            final ConsumerInfo consumerInfo = new ConsumerInfo(finalClientId, groupId, offsetStrategy, consumerAnnotation, properties, methods);
             final ConsumerState consumerState = consumerInfo.isBatch ?
                 new ConsumerStateBatch(this, consumerInfo, kafkaConsumer, consumerBean) :
                 new ConsumerStateSingle(this, consumerInfo, kafkaConsumer, consumerBean);
@@ -628,15 +630,69 @@ class KafkaConsumerProcessor
     private static void setupConsumerSubscription(
         ExecutableMethod<?, ?> method,
         List<AnnotationValue<Topic>> topicAnnotations,
+        ConsumerInfo consumerInfo,
         Object consumerBean,
         Consumer<?, ?> kafkaConsumer
     ) {
-        final List<String> topicNames = topicAnnotations.stream()
+        java.util.stream.Stream<String> directTopics = topicAnnotations.stream()
             .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues()))
+            .filter(StringUtils::isNotEmpty);
+        if (consumerInfo.nonBlockingRetryTopics != null) {
+            directTopics = java.util.stream.Stream.concat(directTopics, consumerInfo.nonBlockingRetryTopics.additionalRetryTopics().stream());
+        }
+        final List<String> topicNames = directTopics.collect(java.util.stream.Collectors.collectingAndThen(
+            java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+            List::copyOf
+        ));
+        final List<String> patterns = topicAnnotations.stream()
+            .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues("patterns")))
             .collect(java.util.stream.Collectors.collectingAndThen(
                 java.util.stream.Collectors.toCollection(LinkedHashSet::new),
                 List::copyOf
             ));
+        final boolean hasTopics = !topicNames.isEmpty();
+        final boolean hasPatterns = !patterns.isEmpty();
+        final String logMethod = LOG.isInfoEnabled() ? logMethod(method) : null;
+
+        if (!hasTopics && !hasPatterns) {
+            throw new MessagingSystemException("Either topics or topic patterns must be specified for method: " + method);
+        }
+
+        final Optional<ConsumerRebalanceListener> listener = getConsumerRebalanceListener(consumerBean, kafkaConsumer);
+
+        if (hasPatterns) {
+            try {
+                final Pattern compiledPattern = compileTopicPattern(topicNames, patterns);
+                listener.ifPresentOrElse(
+                    l -> kafkaConsumer.subscribe(compiledPattern, l),
+                    () -> kafkaConsumer.subscribe(compiledPattern));
+                LOG.info("Kafka listener [{}] subscribed to topics: {} and topic patterns: {}", logMethod, topicNames, patterns);
+            } catch (PatternSyntaxException e) {
+                throw new MessagingSystemException("Invalid topic pattern [" + e.getPattern() + "] for method [" + method + "]: " + e.getMessage(), e);
+            }
+            return;
+        }
+
+        listener.ifPresentOrElse(
+            l -> kafkaConsumer.subscribe(topicNames, l),
+            () -> kafkaConsumer.subscribe(topicNames));
+        LOG.info("Kafka listener [{}] subscribed to topics: {}", logMethod, topicNames);
+    }
+
+    @SuppressWarnings("unused")
+    private static void setupConsumerSubscription(
+        ExecutableMethod<?, ?> method,
+        List<AnnotationValue<Topic>> topicAnnotations,
+        Object consumerBean,
+        Consumer<?, ?> kafkaConsumer
+    ) {
+        java.util.stream.Stream<String> directTopics = topicAnnotations.stream()
+            .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues()))
+            .filter(StringUtils::isNotEmpty);
+        final List<String> topicNames = directTopics.collect(java.util.stream.Collectors.collectingAndThen(
+            java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+            List::copyOf
+        ));
         final List<String> patterns = topicAnnotations.stream()
             .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues("patterns")))
             .collect(java.util.stream.Collectors.collectingAndThen(
@@ -720,16 +776,20 @@ class KafkaConsumerProcessor
         return argument.equals(lastArgumentValue);
     }
 
-    private void configureDeserializers(final List<ExecutableMethod<?, ?>> methods, final DefaultKafkaConsumerConfiguration<?, ?> config) {
+    private void configureDeserializers(
+        final List<ExecutableMethod<?, ?>> methods,
+        final DefaultKafkaConsumerConfiguration<?, ?> config,
+        @Nullable NonBlockingRetryTopics nonBlockingRetryTopics
+    ) {
         if (methods.size() == 1) {
             configureDeserializers(methods.get(0), config);
             return;
         }
         if (!config.getConfig().containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG) && config.getKeyDeserializer().isEmpty()) {
-            config.setKeyDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, true), "key"));
+            config.setKeyDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, true, nonBlockingRetryTopics), "key"));
         }
         if (!config.getConfig().containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG) && config.getValueDeserializer().isEmpty()) {
-            config.setValueDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, false), "value"));
+            config.setValueDeserializer((Deserializer) new TopicAwareDeserializer(buildDeserializerRouter(methods, false, nonBlockingRetryTopics), "value"));
         }
         debugDeserializationConfiguration(methods.get(0), config);
     }
@@ -743,14 +803,22 @@ class KafkaConsumerProcessor
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private TopicRouter<Deserializer<Object>> buildDeserializerRouter(List<ExecutableMethod<?, ?>> methods, boolean key) {
+    private TopicRouter<Deserializer<Object>> buildDeserializerRouter(
+        List<ExecutableMethod<?, ?>> methods,
+        boolean key,
+        @Nullable NonBlockingRetryTopics nonBlockingRetryTopics
+    ) {
         TopicRouter<Deserializer<Object>> router = new TopicRouter<>();
         for (ExecutableMethod<?, ?> method : methods) {
             final boolean batch = method.isTrue(KafkaListener.class, "batch");
             final Argument<?> bodyArgument = findBodyArgument(batch, method);
             final Deserializer<Object> deserializer = key ? resolveKeyDeserializer(bodyArgument, method) : resolveValueDeserializer(bodyArgument);
             for (AnnotationValue<Topic> topicAnnotation : method.getDeclaredAnnotationValuesByType(Topic.class)) {
-                router.register(topicAnnotation.stringValues(), topicAnnotation.stringValues("patterns"), deserializer, logMethod(method));
+                String[] topics = topicAnnotation.stringValues();
+                if (nonBlockingRetryTopics != null && topics.length > 0) {
+                    topics = nonBlockingRetryTopics.expandTopics(topics).toArray(String[]::new);
+                }
+                router.register(topics, topicAnnotation.stringValues("patterns"), deserializer, logMethod(method));
             }
         }
         return router;

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/NonBlockingRetryTopics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/NonBlockingRetryTopics.java
@@ -109,7 +109,10 @@ final class NonBlockingRetryTopics {
         Map<String, TopicBinding> bindings = new LinkedHashMap<>();
         for (String directTopic : directTopics) {
             TopicBinding originalBinding = new TopicBinding(directTopic, 0);
-            bindings.put(directTopic, originalBinding);
+            TopicBinding previousOriginal = bindings.putIfAbsent(directTopic, originalBinding);
+            if (previousOriginal != null && previousOriginal.attempt() > 0) {
+                throw new MessagingSystemException("Topic [" + directTopic + "] is both an original topic and a retry topic");
+            }
             for (int i = 0; i < suffixes.size(); i++) {
                 String retryTopic = directTopic + suffixes.get(i);
                 TopicBinding previous = bindings.putIfAbsent(retryTopic, new TopicBinding(directTopic, i + 1));

--- a/kafka/src/main/java/io/micronaut/configuration/kafka/processor/NonBlockingRetryTopics.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/processor/NonBlockingRetryTopics.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.kafka.processor;
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy;
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.messaging.exceptions.MessagingSystemException;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Non-blocking retry topic metadata resolved from a listener definition.
+ *
+ * @author Micronaut Framework Team
+ * @since 6.0.0
+ */
+@Internal
+final class NonBlockingRetryTopics {
+
+    private final List<String> suffixes;
+    private final List<Duration> delays;
+    private final Map<String, TopicBinding> bindings;
+
+    private NonBlockingRetryTopics(List<String> suffixes, List<Duration> delays, Map<String, TopicBinding> bindings) {
+        this.suffixes = suffixes;
+        this.delays = delays;
+        this.bindings = bindings;
+    }
+
+    @Nullable
+    static NonBlockingRetryTopics create(
+        AnnotationValue<KafkaListener> kafkaListener,
+        List<AnnotationValue<Topic>> topicAnnotations,
+        boolean batch
+    ) {
+        Optional<AnnotationValue<ErrorStrategy>> errorStrategyAnnotation = kafkaListener.getAnnotation("errorStrategy", ErrorStrategy.class);
+        if (errorStrategyAnnotation.isEmpty()) {
+            return null;
+        }
+        AnnotationValue<ErrorStrategy> errorStrategy = errorStrategyAnnotation.get();
+        ErrorStrategyValue errorStrategyValue = errorStrategy.getRequiredValue(ErrorStrategyValue.class);
+        if (!errorStrategyValue.isRetryTopic()) {
+            return null;
+        }
+        if (batch) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' is not supported for batch Kafka listeners");
+        }
+        List<String> directTopics = topicAnnotations.stream()
+            .flatMap(annotationValue -> Arrays.stream(annotationValue.stringValues()))
+            .filter(StringUtils::isNotEmpty)
+            .collect(java.util.stream.Collectors.collectingAndThen(
+                java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+                List::copyOf
+            ));
+        if (directTopics.isEmpty()) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' requires direct topic names and does not support topic patterns");
+        }
+        boolean hasPatterns = topicAnnotations.stream().anyMatch(annotationValue -> annotationValue.stringValues("patterns").length > 0);
+        if (hasPatterns) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' does not support @Topic patterns");
+        }
+        List<String> suffixes = Arrays.stream(errorStrategy.stringValues("retryTopicSuffixes"))
+            .filter(StringUtils::isNotEmpty)
+            .toList();
+        if (suffixes.isEmpty()) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' requires at least one retry topic suffix");
+        }
+        List<String> delayStrings = Arrays.stream(errorStrategy.stringValues("retryTopicDelays"))
+            .filter(StringUtils::isNotEmpty)
+            .toList();
+        if (delayStrings.size() != suffixes.size()) {
+            throw new MessagingSystemException("Error strategy 'RETRY_TOPIC_ON_ERROR' requires the same number of retry topic suffixes and retry topic delays");
+        }
+        List<Duration> delays = new ArrayList<>(delayStrings.size());
+        for (String delayString : delayStrings) {
+            Duration delay = ConversionService.SHARED.convert(delayString, Duration.class)
+                .filter(duration -> !duration.isZero() && !duration.isNegative())
+                .orElseThrow(() -> new MessagingSystemException("Invalid retry topic delay [" + delayString + "] for error strategy 'RETRY_TOPIC_ON_ERROR'"));
+            delays.add(delay);
+        }
+        Map<String, TopicBinding> bindings = new LinkedHashMap<>();
+        for (String directTopic : directTopics) {
+            TopicBinding originalBinding = new TopicBinding(directTopic, 0);
+            bindings.put(directTopic, originalBinding);
+            for (int i = 0; i < suffixes.size(); i++) {
+                String retryTopic = directTopic + suffixes.get(i);
+                TopicBinding previous = bindings.putIfAbsent(retryTopic, new TopicBinding(directTopic, i + 1));
+                if (previous != null && !previous.originalTopic().equals(directTopic)) {
+                    throw new MessagingSystemException("Retry topic [" + retryTopic + "] maps to multiple original topics");
+                }
+            }
+        }
+        return new NonBlockingRetryTopics(List.copyOf(suffixes), List.copyOf(delays), Map.copyOf(bindings));
+    }
+
+    List<String> expandTopics(String[] topics) {
+        List<String> expandedTopics = new ArrayList<>(topics.length * (suffixes.size() + 1));
+        for (String topic : topics) {
+            expandedTopics.add(topic);
+            for (String suffix : suffixes) {
+                expandedTopics.add(topic + suffix);
+            }
+        }
+        return List.copyOf(expandedTopics);
+    }
+
+    List<String> additionalRetryTopics() {
+        return bindings.entrySet().stream()
+            .filter(entry -> entry.getValue().attempt() > 0)
+            .map(Map.Entry::getKey)
+            .toList();
+    }
+
+    boolean isRetryTopic(String topic) {
+        TopicBinding binding = bindings.get(topic);
+        return binding != null && binding.attempt() > 0;
+    }
+
+    @Nullable
+    RetryDispatch nextRetry(String topic) {
+        TopicBinding binding = bindings.get(topic);
+        if (binding == null) {
+            return null;
+        }
+        int nextRetryIndex = binding.attempt();
+        if (nextRetryIndex >= suffixes.size()) {
+            return null;
+        }
+        return new RetryDispatch(
+            binding.originalTopic(),
+            binding.originalTopic() + suffixes.get(nextRetryIndex),
+            delays.get(nextRetryIndex),
+            nextRetryIndex + 1
+        );
+    }
+
+    @Nullable
+    TopicBinding binding(String topic) {
+        return bindings.get(topic);
+    }
+
+    boolean applies() {
+        return CollectionUtils.isNotEmpty(bindings);
+    }
+
+    record TopicBinding(String originalTopic, int attempt) {
+    }
+
+    record RetryDispatch(String originalTopic, String retryTopic, Duration delay, int attempt) {
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaRetryTopicErrorStrategySpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/errors/KafkaRetryTopicErrorStrategySpec.groovy
@@ -1,0 +1,144 @@
+package io.micronaut.configuration.kafka.errors
+
+import io.micronaut.configuration.kafka.AbstractEmbeddedServerSpec
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.OffsetReset
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import spock.lang.Shared
+
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_TOPIC_ON_ERROR
+import static io.micronaut.configuration.kafka.annotation.OffsetStrategy.SYNC
+
+class KafkaRetryTopicErrorStrategySpec extends AbstractEmbeddedServerSpec {
+
+    @Shared final String mainTopic = "errors-retry-topic-${UUID.randomUUID()}"
+    @Shared final String retryTopic = "${mainTopic}-retry-100ms"
+    @Shared final String dlqTopic = "${mainTopic}-dlq"
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+            'spec.retry.topic.main': mainTopic,
+            'spec.retry.topic.dlq' : dlqTopic
+        ]
+    }
+
+    @Override
+    void afterKafkaStarted() {
+        createTopic(mainTopic, 1, 1)
+        createTopic(retryTopic, 1, 1)
+        createTopic(dlqTopic, 1, 1)
+    }
+
+    void "failed records are retried on a retry topic without blocking later original records"() {
+        when:
+        RetryTopicClient client = context.getBean(RetryTopicClient)
+        client.sendMessage('One')
+        client.sendMessage('Two')
+
+        RetryTopicConsumer consumer = context.getBean(RetryTopicConsumer)
+        RetryTopicDlqConsumer dlqConsumer = context.getBean(RetryTopicDlqConsumer)
+
+        then:
+        conditions.eventually {
+            consumer.successful == ["${mainTopic}:Two", "${retryTopic}:One"]
+            consumer.retryAttempts == ['1']
+            dlqConsumer.received.isEmpty()
+        }
+        and:
+        consumer.retrySuccessTime - consumer.firstFailureTime >= 100
+    }
+
+    void "records are routed to the dead letter topic after retry topics are exhausted"() {
+        when:
+        RetryTopicClient client = context.getBean(RetryTopicClient)
+        client.sendMessage("AlwaysFail")
+
+        RetryTopicConsumer consumer = context.getBean(RetryTopicConsumer)
+        RetryTopicDlqConsumer dlqConsumer = context.getBean(RetryTopicDlqConsumer)
+
+        then:
+        conditions.eventually {
+            consumer.failedMessages.count("AlwaysFail") >= 2
+            dlqConsumer.received == ["AlwaysFail"]
+            dlqConsumer.originalTopics == [mainTopic]
+        }
+    }
+
+    @Requires(property = 'spec.retry.topic.main')
+    @KafkaClient
+    static interface RetryTopicClient {
+        @Topic('${spec.retry.topic.main}')
+        void sendMessage(String message)
+    }
+
+    @Requires(property = 'spec.retry.topic.main')
+    @KafkaListener(
+        groupId = 'retry-topic-consumer',
+        offsetReset = OffsetReset.EARLIEST,
+        offsetStrategy = SYNC,
+        errorStrategy = @ErrorStrategy(
+            value = RETRY_TOPIC_ON_ERROR,
+            retryTopicSuffixes = '-retry-100ms',
+            retryTopicDelays = '100ms',
+            dlq = '${spec.retry.topic.dlq}'
+        )
+    )
+    static class RetryTopicConsumer {
+        @Value('${spec.retry.topic.main}')
+        String mainTopic
+
+        final AtomicInteger failures = new AtomicInteger()
+        final List<String> successful = new CopyOnWriteArrayList<>()
+        final List<String> retryAttempts = new CopyOnWriteArrayList<>()
+        final List<String> failedMessages = new CopyOnWriteArrayList<>()
+        volatile long firstFailureTime
+        volatile long retrySuccessTime
+
+        @Topic('${spec.retry.topic.main}')
+        void receive(ConsumerRecord<String, String> record) {
+            failedMessages << record.value()
+            if (record.value() == 'AlwaysFail') {
+                if (firstFailureTime == 0) {
+                    firstFailureTime = System.currentTimeMillis()
+                }
+                throw new IllegalStateException('always boom')
+            }
+            if (record.topic() == mainTopic && record.value() == 'One' && failures.incrementAndGet() == 1) {
+                firstFailureTime = System.currentTimeMillis()
+                throw new IllegalStateException('boom')
+            }
+            successful << "${record.topic()}:${record.value()}"
+            if (record.topic() != mainTopic) {
+                retrySuccessTime = System.currentTimeMillis()
+                retryAttempts << new String(record.headers().lastHeader('micronaut-kafka-retry-attempt').value())
+            }
+        }
+    }
+
+    @Requires(property = 'spec.retry.topic.main')
+    @KafkaListener(
+        groupId = 'retry-topic-dlq-consumer',
+        offsetReset = OffsetReset.EARLIEST,
+        offsetStrategy = SYNC
+    )
+    static class RetryTopicDlqConsumer {
+        final List<String> received = new CopyOnWriteArrayList<>()
+        final List<String> originalTopics = new CopyOnWriteArrayList<>()
+
+        @Topic('${spec.retry.topic.dlq}')
+        void receive(String message, ConsumerRecord<String, String> record) {
+            received << message
+            originalTopics << new String(record.headers().lastHeader('micronaut-kafka-original-topic').value())
+        }
+    }
+}

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/processor/ConsumerStateSingleSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.configuration.kafka.bind.ConsumerRecordBinderRegistry
 import io.micronaut.configuration.kafka.annotation.ErrorStrategy
 import io.micronaut.configuration.kafka.annotation.KafkaListener
 import io.micronaut.configuration.kafka.annotation.OffsetStrategy
+import io.micronaut.configuration.kafka.annotation.Topic
 import io.micronaut.configuration.kafka.exceptions.KafkaListenerException
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.core.type.Argument
@@ -32,6 +33,7 @@ import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.NON
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.LOG_AND_RESUME_AT_NEXT_RECORD
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RESUME_AT_NEXT_RECORD
 import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_ON_ERROR
+import static io.micronaut.configuration.kafka.annotation.ErrorStrategyValue.RETRY_TOPIC_ON_ERROR
 
 class ConsumerStateSingleSpec extends Specification {
 
@@ -131,21 +133,127 @@ class ConsumerStateSingleSpec extends Specification {
         ex.message.contains('dlq')
     }
 
-    void "consumer info requires a retry strategy to stop on exhausted retry"() {
+    void "resolveWithErrorStrategy publishes the failed record to the retry topic and resumes"() {
+        given:
+        Producer<?, ?> kafkaProducer = Mock(Producer)
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock(KafkaConsumerProcessor) {
+            getProducer('group', String, String) >> kafkaProducer
+        }
+        Consumer<?, ?> kafkaConsumer = Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+        }
+        ConsumerStateSingle consumerState = newRetryTopicConsumerState(kafkaConsumerProcessor, kafkaConsumer)
+        ConsumerRecord<?, ?> consumerRecord = new ConsumerRecord<>('source-topic', 2, 7L, 'key', 'value')
+        ConsumerRecords<?, ?> consumerRecords = new ConsumerRecords<>([
+            (new TopicPartition(consumerRecord.topic(), consumerRecord.partition())): [consumerRecord]
+        ])
+        RuntimeException error = new RuntimeException('boom')
+
+        when:
+        boolean shouldRetry = invokePrivateMethod(
+            consumerState,
+            'resolveWithErrorStrategy',
+            [ConsumerRecords, ConsumerRecord, Throwable] as Class[],
+            [consumerRecords, consumerRecord, error] as Object[]
+        ) as boolean
+
+        then:
+        !shouldRetry
+        1 * kafkaProducer.send({
+            ProducerRecord<?, ?> record ->
+                record.topic() == 'source-topic-retry-100ms' &&
+                    record.key() == 'key' &&
+                    record.value() == 'value' &&
+                    headerValue(record, 'micronaut-kafka-exception-class') == RuntimeException.name &&
+                    headerValue(record, 'micronaut-kafka-original-topic') == 'source-topic' &&
+                    headerValue(record, 'micronaut-kafka-original-partition') == '2' &&
+                    headerValue(record, 'micronaut-kafka-original-offset') == '7' &&
+                    headerValue(record, 'micronaut-kafka-retry-attempt') == '1' &&
+                    Long.parseLong(headerValue(record, 'micronaut-kafka-retry-due-timestamp')) >= System.currentTimeMillis()
+        }) >> CompletableFuture.completedFuture(null)
+        0 * kafkaConsumer.seek(_, _)
+        0 * kafkaConsumerProcessor.handleException(_, _)
+    }
+
+    void "consumer info requires retry topic suffixes and delays for retry topic strategy"() {
         when:
         new ConsumerInfo(
             'client',
             'group',
             OffsetStrategy.DISABLED,
-            kafkaListenerAnnotation(RESUME_AT_NEXT_RECORD, null, null, true),
+            kafkaListenerAnnotation(RETRY_TOPIC_ON_ERROR, null),
             new Properties(),
-            executableMethod()
+            executableMethod(),
+            topicAnnotations('source-topic')
         )
 
         then:
         def ex = thrown(MessagingSystemException)
-        ex.message.contains('stopOnExhaustedRetry')
-        ex.message.contains('retry error strategy')
+        ex.message.contains('RETRY_TOPIC_ON_ERROR')
+    }
+
+    void "retry topic record is deferred until its due timestamp"() {
+        given:
+        TopicPartition topicPartition = new TopicPartition('source-topic-retry-100ms', 2)
+        ConsumerRecord<?, ?> consumerRecord = new ConsumerRecord<>('source-topic-retry-100ms', 2, 7L, 'key', 'value')
+        consumerRecord.headers().add('micronaut-kafka-retry-due-timestamp', Long.toString(System.currentTimeMillis() + 60_000).getBytes(StandardCharsets.UTF_8))
+        ConsumerRecords<?, ?> consumerRecords = new ConsumerRecords<>([(topicPartition): [consumerRecord]])
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock(KafkaConsumerProcessor) {
+            getBinderRegistry() >> Stub(ConsumerRecordBinderRegistry)
+            scheduleTask(_, _) >> { Duration retryDelay, Runnable task -> }
+        }
+        Consumer<?, ?> kafkaConsumer = Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+        }
+        ConsumerStateSingle consumerState = newRetryTopicConsumerState(kafkaConsumerProcessor, kafkaConsumer)
+
+        when:
+        consumerState.processRecords(consumerRecords, [:])
+
+        then:
+        1 * kafkaConsumer.seek(topicPartition, 7L)
+        0 * kafkaConsumerProcessor.handleException(_, _)
+    }
+
+    void "exhausted retry topic record is published to dlq with original headers preserved"() {
+        given:
+        Producer<?, ?> kafkaProducer = Mock(Producer)
+        KafkaConsumerProcessor kafkaConsumerProcessor = Mock(KafkaConsumerProcessor) {
+            getProducer(_, _, _) >> kafkaProducer
+        }
+        Consumer<?, ?> kafkaConsumer = Mock(Consumer) {
+            subscription() >> Collections.emptySet()
+        }
+        ConsumerStateSingle consumerState = newRetryTopicConsumerState(kafkaConsumerProcessor, kafkaConsumer)
+        ConsumerRecord<?, ?> consumerRecord = new ConsumerRecord<>('source-topic-retry-100ms', 2, 8L, 'key', 'value')
+        consumerRecord.headers().add('micronaut-kafka-original-topic', 'source-topic'.getBytes(StandardCharsets.UTF_8))
+        consumerRecord.headers().add('micronaut-kafka-original-partition', '2'.getBytes(StandardCharsets.UTF_8))
+        consumerRecord.headers().add('micronaut-kafka-original-offset', '7'.getBytes(StandardCharsets.UTF_8))
+        consumerRecord.headers().add('micronaut-kafka-retry-attempt', '1'.getBytes(StandardCharsets.UTF_8))
+        ConsumerRecords<?, ?> consumerRecords = new ConsumerRecords<>([
+            (new TopicPartition(consumerRecord.topic(), consumerRecord.partition())): [consumerRecord]
+        ])
+        RuntimeException error = new RuntimeException('boom again')
+
+        when:
+        boolean shouldRetry = invokePrivateMethod(
+            consumerState,
+            'resolveWithErrorStrategy',
+            [ConsumerRecords, ConsumerRecord, Throwable] as Class[],
+            [consumerRecords, consumerRecord, error] as Object[]
+        ) as boolean
+
+        then:
+        !shouldRetry
+        1 * kafkaProducer.send({
+            ProducerRecord<?, ?> record ->
+                record.topic() == 'errors-dlq' &&
+                    headerValue(record, 'micronaut-kafka-original-topic') == 'source-topic' &&
+                    headerValue(record, 'micronaut-kafka-original-partition') == '2' &&
+                    headerValue(record, 'micronaut-kafka-original-offset') == '7' &&
+                    headerValue(record, 'micronaut-kafka-exception-message') == 'boom again'
+        }) >> CompletableFuture.completedFuture(null)
+        1 * kafkaConsumerProcessor.handleException(_, _)
     }
 
     void "poll-time deserialization failures expose a synthetic consumer record to the exception handler"() {
@@ -397,6 +505,19 @@ class ConsumerStateSingleSpec extends Specification {
         new ConsumerStateSingle(kafkaConsumerProcessor, consumerInfo, kafkaConsumer, new Object())
     }
 
+    private ConsumerStateSingle newRetryTopicConsumerState(KafkaConsumerProcessor kafkaConsumerProcessor, Consumer<?, ?> kafkaConsumer) {
+        ConsumerInfo consumerInfo = new ConsumerInfo(
+            'client',
+            'group',
+            OffsetStrategy.DISABLED,
+            kafkaListenerAnnotation(RETRY_TOPIC_ON_ERROR, 'errors-dlq', null, ['-retry-100ms'], ['100ms']),
+            new Properties(),
+            executableMethod(),
+            topicAnnotations('source-topic')
+        )
+        new ConsumerStateSingle(kafkaConsumerProcessor, consumerInfo, kafkaConsumer, new Object())
+    }
+
     private static Object invokePrivateMethod(Object target, String name, Class[] parameterTypes, Object[] arguments) {
         def method = target.class.getDeclaredMethod(name, parameterTypes)
         method.accessible = true
@@ -407,7 +528,8 @@ class ConsumerStateSingleSpec extends Specification {
         def errorStrategy = LOG_AND_RESUME_AT_NEXT_RECORD,
         String dlq = 'errors-dlq',
         Integer retryCount = null,
-        boolean stopOnExhaustedRetry = false
+        List<String> retryTopicSuffixes = [],
+        List<String> retryTopicDelays = []
     ) {
         def errorStrategyAnnotation = AnnotationValue.builder(ErrorStrategy)
             .member('value', errorStrategy)
@@ -417,12 +539,21 @@ class ConsumerStateSingleSpec extends Specification {
         if (retryCount != null) {
             errorStrategyAnnotation.member('retryCount', retryCount)
         }
-        if (stopOnExhaustedRetry) {
-            errorStrategyAnnotation.member('stopOnExhaustedRetry', true)
+        if (!retryTopicSuffixes.isEmpty()) {
+            errorStrategyAnnotation.member('retryTopicSuffixes', retryTopicSuffixes as String[])
+        }
+        if (!retryTopicDelays.isEmpty()) {
+            errorStrategyAnnotation.member('retryTopicDelays', retryTopicDelays as String[])
         }
         AnnotationValue.builder(KafkaListener)
             .member('errorStrategy', errorStrategyAnnotation.build())
             .build()
+    }
+
+    private static List<AnnotationValue<Topic>> topicAnnotations(String... topics) {
+        [AnnotationValue.builder(Topic)
+            .member('value', topics)
+            .build()]
     }
 
     private ExecutableMethod<?, ?> executableMethod() {

--- a/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
+++ b/src/main/docs/guide/kafkaListener/kafkaErrors.adoc
@@ -21,9 +21,13 @@ You can choose one of the error strategies:
 
 - `LOG_AND_RESUME_AT_NEXT_RECORD` - This strategy will publish the failed record to a dead letter topic, invoke the exception handler, and resume at the next offset. You must configure the target topic with `dlq`.
 
+- `RETRY_TOPIC_ON_ERROR` - This strategy will publish the failed record to derived retry topics and resume at the next offset on the original topic. Configure the retry topics with `retryTopicSuffixes` and `retryTopicDelays`. When retry topics are exhausted, Micronaut optionally publishes the record to `dlq`.
+
 - `NONE` - This error strategy will skip over all records from the current offset in the current poll when the consumer encounters an error. This option is deprecated and kept for consistent behaviour with previous versions of Micronaut Kafka that do not support error strategy.
 
 NOTE: For batch listeners, `LOG_AND_RESUME_AT_NEXT_RECORD` is supported. The other error strategies apply only to non-batch message processing.
+
+NOTE: `RETRY_TOPIC_ON_ERROR` requires direct topic names, not `@Topic` patterns. Retry topics must already exist in Kafka.
 
 NOTE: When using retry error strategies in combination with reactive consumer methods, it is necessary to add the `@Blocking` annotation to the reactive consumer method.
 
@@ -68,6 +72,30 @@ When a ann:configuration.kafka.annotation.KafkaListener[] does not implement ann
 If you wish to apply the same conditional retry strategy for all of your ann:configuration.kafka.annotation.KafkaListener[] you can define a bean that implements `ConditionalRetryBehaviourHandler` and use Micronaut's link:https://docs.micronaut.io/latest/guide/#replaces[Bean Replacement] feature to replace the default bean: `@Replaces(DefaultConditionalRetryBehaviourHandler.class)`.
 
 NOTE: Conditional retry behaviour only applies to `RETRY_CONDITIONALLY_ON_ERROR` and `RETRY_CONDITIONALLY_EXPONENTIALLY_ON_ERROR` error strategies.
+
+==== Non-blocking retry topics
+
+`RETRY_TOPIC_ON_ERROR` implements non-blocking retries by republishing the failed record to derived retry topics. Each retry topic suffix in `retryTopicSuffixes` must have a matching delay in `retryTopicDelays`.
+
+.A client that publishes to the source topic
+snippet::io.micronaut.kafka.docs.consumer.errors.RetryTopicProductClient[tags = client, indent = 0]
+
+.A listener that processes the source topic and derived retry topics
+snippet::io.micronaut.kafka.docs.consumer.errors.RetryTopicProductListener[tags = listener, indent = 0]
+
+.A listener for the dead letter topic
+snippet::io.micronaut.kafka.docs.consumer.errors.RetryTopicProductDltListener[tags = dlt, indent = 0]
+
+In this example, Micronaut derives `products-retry-5s` and `products-retry-30s` from the source topic `products`. The same listener processes the initial delivery and the retry topics, and `micronaut-kafka-retry-attempt` is populated only when the record is being retried.
+
+When Micronaut publishes a failed record to a retry topic, it preserves the record key, value, and headers, updates the failure metadata headers, and adds:
+
+- `micronaut-kafka-retry-attempt`
+- `micronaut-kafka-retry-due-timestamp`
+
+When a record arrives from a retry topic before its due timestamp, Micronaut pauses that retry partition until the configured delay expires and then processes the record.
+
+When all retry topics are exhausted, Micronaut publishes the record to the configured dead letter topic, preserving the original topic metadata in the dead letter headers.
 
 === Exception handlers
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = 'spec.name', value = 'RetryTopicProductListenerTest')
+// tag::client[]
+@KafkaClient('product-client')
+interface RetryTopicProductClient {
+
+    @Topic('products')
+    void sendProduct(String product)
+}
+// end::client[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.MessageHeaders
+
+@Requires(property = 'spec.name', value = 'RetryTopicProductListenerTest')
+// tag::dlt[]
+@KafkaListener('product-retry-dlt-group')
+class RetryTopicProductDltListener {
+
+    @Topic('products-dlt')
+    void receive(String product, MessageHeaders headers) {
+        String originalTopic = headers.get('micronaut-kafka-original-topic', String).orElse('unknown')
+        System.out.printf('Routing %s from %s to the dead letter topic%n', product, originalTopic)
+    }
+}
+// end::dlt[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.MessageHeaders
+
+@Requires(property = 'spec.name', value = 'RetryTopicProductListenerTest')
+// tag::listener[]
+@KafkaListener(
+    value = 'product-retry-group',
+    errorStrategy = @ErrorStrategy(
+        value = ErrorStrategyValue.RETRY_TOPIC_ON_ERROR,
+        retryTopicSuffixes = ['-retry-5s', '-retry-30s'],
+        retryTopicDelays = ['5s', '30s'],
+        dlq = 'products-dlt'
+    )
+)
+class RetryTopicProductListener {
+
+    @Topic('products')
+    void receive(String product, MessageHeaders headers) {
+        String retryAttempt = headers.get('micronaut-kafka-retry-attempt', String).orElse('initial')
+        String sourceTopic = headers.get('micronaut-kafka-original-topic', String).orElse('products')
+        System.out.printf('Processing %s from %s (attempt=%s)%n', product, sourceTopic, retryAttempt)
+    }
+}
+// end::listener[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.kt
@@ -1,0 +1,15 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::client[]
+@KafkaClient("product-client")
+interface RetryTopicProductClient {
+
+    @Topic("products")
+    fun sendProduct(product: String)
+}
+// end::client[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.kt
@@ -1,0 +1,19 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.MessageHeaders
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::dlt[]
+@KafkaListener("product-retry-dlt-group")
+class RetryTopicProductDltListener {
+
+    @Topic("products-dlt")
+    fun receive(product: String, headers: MessageHeaders) {
+        val originalTopic = headers.get("micronaut-kafka-original-topic", String::class.java).orElse("unknown")
+        println("Routing $product from $originalTopic to the dead letter topic")
+    }
+}
+// end::dlt[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.kt
@@ -1,0 +1,30 @@
+package io.micronaut.kafka.docs.consumer.errors
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue
+import io.micronaut.configuration.kafka.annotation.KafkaListener
+import io.micronaut.configuration.kafka.annotation.Topic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.messaging.MessageHeaders
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::listener[]
+@KafkaListener(
+    value = "product-retry-group",
+    errorStrategy = ErrorStrategy(
+        value = ErrorStrategyValue.RETRY_TOPIC_ON_ERROR,
+        retryTopicSuffixes = ["-retry-5s", "-retry-30s"],
+        retryTopicDelays = ["5s", "30s"],
+        dlq = "products-dlt"
+    )
+)
+class RetryTopicProductListener {
+
+    @Topic("products")
+    fun receive(product: String, headers: MessageHeaders) {
+        val retryAttempt = headers.get("micronaut-kafka-retry-attempt", String::class.java).orElse("initial")
+        val sourceTopic = headers.get("micronaut-kafka-original-topic", String::class.java).orElse("products")
+        println("Processing $product from $sourceTopic (attempt=$retryAttempt)")
+    }
+}
+// end::listener[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductClient.java
@@ -1,0 +1,15 @@
+package io.micronaut.kafka.docs.consumer.errors;
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Requires;
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::client[]
+@KafkaClient("product-client")
+public interface RetryTopicProductClient {
+
+    @Topic("products")
+    void sendProduct(String product);
+}
+// end::client[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductDltListener.java
@@ -1,0 +1,19 @@
+package io.micronaut.kafka.docs.consumer.errors;
+
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.messaging.MessageHeaders;
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::dlt[]
+@KafkaListener("product-retry-dlt-group")
+public class RetryTopicProductDltListener {
+
+    @Topic("products-dlt")
+    void receive(String product, MessageHeaders headers) {
+        String originalTopic = headers.get("micronaut-kafka-original-topic", String.class).orElse("unknown");
+        System.out.printf("Routing %s from %s to the dead letter topic%n", product, originalTopic);
+    }
+}
+// end::dlt[]

--- a/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.java
+++ b/test-suite/src/test/java/io/micronaut/kafka/docs/consumer/errors/RetryTopicProductListener.java
@@ -1,0 +1,30 @@
+package io.micronaut.kafka.docs.consumer.errors;
+
+import io.micronaut.configuration.kafka.annotation.ErrorStrategy;
+import io.micronaut.configuration.kafka.annotation.ErrorStrategyValue;
+import io.micronaut.configuration.kafka.annotation.KafkaListener;
+import io.micronaut.configuration.kafka.annotation.Topic;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.messaging.MessageHeaders;
+
+@Requires(property = "spec.name", value = "RetryTopicProductListenerTest")
+// tag::listener[]
+@KafkaListener(
+    value = "product-retry-group",
+    errorStrategy = @ErrorStrategy(
+        value = ErrorStrategyValue.RETRY_TOPIC_ON_ERROR,
+        retryTopicSuffixes = {"-retry-5s", "-retry-30s"},
+        retryTopicDelays = {"5s", "30s"},
+        dlq = "products-dlt"
+    )
+)
+public class RetryTopicProductListener {
+
+    @Topic("products")
+    void receive(String product, MessageHeaders headers) {
+        String retryAttempt = headers.get("micronaut-kafka-retry-attempt", String.class).orElse("initial");
+        String sourceTopic = headers.get("micronaut-kafka-original-topic", String.class).orElse("products");
+        System.out.printf("Processing %s from %s (attempt=%s)%n", product, sourceTopic, retryAttempt);
+    }
+}
+// end::listener[]


### PR DESCRIPTION
## Summary
- add non-blocking retry topic support through `RETRY_TOPIC_ON_ERROR`
- publish exhausted retry-topic records to the configured DLQ and cover the behavior with focused tests
- expand the guide with snippet-backed Java, Groovy, and Kotlin retry-topic examples

## Verification
- `./gradlew :micronaut-kafka:test --tests '*ConsumerStateSingleSpec' --tests '*KafkaRetryTopicErrorStrategySpec' -q`
- `./gradlew :micronaut-kafka:test --tests '*KafkaErrorStrategySpec' --tests '*ConsumerStateBatchSpec' --tests '*ConsumerCreationStrategyStateSpec' --tests '*ConsumerCreationStrategySupportSpec' --tests '*KafkaRetryTopicErrorStrategySpec' --tests '*ConsumerStateSingleSpec' -q`
- `./gradlew publishGuide docs -q`

Resolves #425
