### PR TITLE
Fix kafka tests failing on Micronaut Core 5.2

### DIFF
--- a/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractTestContainersSpec.groovy
+++ b/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/AbstractTestContainersSpec.groovy
@@ -38,6 +38,11 @@ abstract class AbstractTestContainersSpec extends AbstractEmbeddedServerSpec {
     }
 
     void stopContext() {
+        if (!context?.isRunning()) {
+            // Already shut down (e.g. by a SHUTDOWN_APPLICATION uncaught exception handler), which closed the streams
+            // and cleared the factory; resolving beans from a stopped context throws since Micronaut 5.2
+            return
+        }
         def kafkaStreamsFactory = context.getBean(KafkaStreamsFactory)
         try {
           embeddedServer.stop()

--- a/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientSpec.groovy
+++ b/kafka/src/test/groovy/io/micronaut/configuration/kafka/annotation/KafkaClientSpec.groovy
@@ -63,7 +63,7 @@ class KafkaClientSpec extends AbstractKafkaSpec {
         MyClient client = ctx.getBean(MyClient)
 
         when:
-        client.sendSentence("test", "hello-world").get(1, SECONDS)
+        client.sendSentence("test", "hello-world").get(10, SECONDS)
 
         then:
         ExecutionException e = thrown()


### PR DESCRIPTION
Test-only fixes for the micronaut-kafka failures found while testing against Micronaut Core 5.2 (micronaut-projects/micronaut-core#13110).

## Changes

- **kafka-streams `AbstractTestContainersSpec.stopContext`**: skip the cleanup when the context is no longer running. `UncaughtExceptionsSpec`'s SHUTDOWN_APPLICATION test shuts the application down. `cleanupSpec` then called `context.getBean(KafkaStreamsFactory)` on the stopped context, which throws `IllegalStateException: Cannot resolve beans until the context is running` since micronaut-projects/micronaut-core#12948 and failed the spec with `executionError`. There is nothing left to clean up anyway: closing the context closes `KafkaStreamsFactory`, which shuts the streams down and clears its map.
- **`KafkaClientSpec` "test future send message when Kafka is not available"**: wait up to 10 seconds instead of 1. With no broker, the producer fails in about 1 second; run on its own the test takes 1.07 to 1.20s. So under load (a full `check`) the `get(1, SECONDS)` timed out first and the test failed with `TimeoutException`. This happened on core 5.1.7 as well as 5.2.

No other test base in the project resolves beans during cleanup.

## Verification

| | core 5.1.7 (catalog) | core 5.2.0 | core 5.2.x + micronaut-projects/micronaut-core#13111 |
|---|---|---|---|
| `UncaughtExceptionsSpec` before | 3/3 | `executionError` | – |
| `UncaughtExceptionsSpec` after | 3/3 | 3/3 | 3/3 |
| `KafkaClientSpec` after | 4/4 | – | 4/4 (in a full `check`) |
| full `check` after | – | – | 376 tests, 1 failed: Groovy docs `MyTest`, see below |

## Not in this PR: core bump

The catalog stays on `micronaut = "5.1.7"`. On the released core 5.2.0, six metrics specs still fail (`KafkaListenerSpec` "test simple consumer", `KafkaConsumerMetricsSpec`, `KafkaProducerMetricsSpec`, `KafkaStreamsMetricsSpec` ×2, `KafkaStreamsMetricsDisabledSpec`). The `/metrics` endpoint of the released micronaut-micrometer 6.0.2 returns 404 there. That is a core regression from micronaut-projects/micronaut-core#12960, and micronaut-projects/micronaut-core#13111 fixes it; with that fix all six pass. The core update can go through Renovate once a core release includes #13111.

## Known intermittent failure, not addressed here

Groovy docs `MyTest` "test kafka running" sometimes times out (`SpockTimeoutError`), on core 5.1.7 as well as 5.2. A longer wait does not help: the ungated no-op Kafka stream in the docs suites shares the listeners' consumer group, and whichever joins second gets `InconsistentGroupProtocolException`. It is fixed separately in #1398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
