### PR TITLE
Require lz4-java 1.11.2 to fix the vulnerability audit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ awaitility = '4.3.0'
 opentracing-kafka-client = '0.1.15'
 opentracing-mock = '0.33.0'
 zipkin-brave-kafka-clients = '6.3.1'
+lz4-java = '1.11.2'
 
 micronaut-cache = "6.1.0"
 micronaut-micrometer = "6.0.1"
@@ -21,6 +22,7 @@ micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'mi
 
 managed-kafka-clients = { module = 'org.apache.kafka:kafka-clients', version.ref = 'managed-kafka' }
 managed-kafka-streams = { module = 'org.apache.kafka:kafka-streams', version.ref = 'managed-kafka' }
+lz4-java = { module = 'at.yawk.lz4:lz4-java', version.ref = 'lz4-java' }
 
 opentracing-kafka-client = { module = 'io.opentracing.contrib:opentracing-kafka-client', version.ref = 'opentracing-kafka-client' }
 opentracing-mock = { module = 'io.opentracing:opentracing-mock', version.ref = 'opentracing-mock' }

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -21,6 +21,10 @@ dependencies {
         api("com.fasterxml.jackson.core:jackson-core:2.22.1") {
             because("Require a non-vulnerable jackson-core version instead of the transitive 2.19.1 from :kafka-clients")
         }
+        // "org.apache.kafka:kafka-clients 4.3.1 requests lz4-java 1.10.2, which is affected by GHSA-xx22-p4ch-683r"
+        api(libs.lz4.java) {
+            because("Require a non-vulnerable lz4-java version instead of the transitive 1.10.2 from :kafka-clients")
+        }
     }
     api("com.fasterxml.jackson.core:jackson-core")
 


### PR DESCRIPTION
Fixes the failing `audit (25)` check on `6.2.x`. It fails on the common-files PR #1392, and it would fail every other PR on the branch too, including the core 5.2 bump #1399. Part of the core 5.2 rollout: micronaut-projects/micronaut-core#13110.

```
- at.yawk.lz4:lz4-java:1.10.2 (GHSA-xx22-p4ch-683r; fixed: 1.11.1)
```

`kafka-clients` 4.3.1 brings in lz4-java 1.10.2. It is the latest Kafka release, so a Kafka upgrade can't fix this. This PR:

- adds a (non-managed) catalog entry `lz4-java = 1.11.2`, the version Apache Kafka trunk already uses
- requires it with an `api` constraint in `micronaut-kafka`, next to the existing jackson-core constraint

`kafka-streams` gets it through `micronaut-kafka`. No `osv-scanner.toml` exception is needed.

Verified locally:
- `dependencyInsight` resolves `at.yawk.lz4:lz4-java:1.10.2 -> 1.11.2` on `runtimeClasspath` for `micronaut-kafka` and `micronaut-kafka-streams`.
- `.github/scripts/vulnerability-audit.sh` prints "No known vulnerabilities found.", both on this branch and with #1399's core 5.2 bump applied on top.
- `:micronaut-kafka:check`: 296/297 passed. `:micronaut-kafka-streams:check`: 40/40 passed. The one failure was `KafkaShutdownHandlingSpec` "wakeup does not commit messages that have not been processed", an offset commit poll that timed out on a loaded machine. It passes when rerun alone.

Note: the audit reports the existing `GHSA-5jmj-h7xm-6q6v` ignore in `osv-scanner.toml` as unused. This PR leaves it as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
